### PR TITLE
OAuth client-metadata + PAR/token loop, TID, and signed commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,28 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | --- | --- | --- |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
 | AppView | `Actor`, `Feed`, `Graph`, `Notification` | Profiles, search (`q`), follows/blocks/mutes |
-| Repo writes | `Repo` | `createRecord` / `putRecord` send `record` as JSON |
+| Repo writes | `Repo` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; `uploadBlob` parse |
 | Server | `Server` | describe server, app passwords, invites |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | `resolveHandle`, `did:plc`, `did:web` (including `%3A` ports), `did:key` |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | Current `getLatestCommit`, `getRepo` (CAR), `listBlobs`, `listRepos` |
 | CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1 |
-| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff inversion |
+| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff inversion, p256/k256 commit sign+verify |
+| TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON, `to_ocaml` codegen, JSON validate |
-| Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode |
-| OAuth / DPoP | `Oauth` | PKCE S256, DPoP ES256, PAR/token request shapes |
+| Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
+| OAuth / DPoP | `Oauth` | PKCE S256, DPoP ES256 + nonce, client metadata, AS/resource metadata, redirect callback, PAR/token loop (injectable HTTP) |
+| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
 
 ## Remaining gaps
 
 These are product-level, not missing protocol cores:
 
-- OAuth **browser redirect / client-metadata hosting / live token loop** against a PDS (PKCE + DPoP + PAR encoding and ES256 proofs, including low-S, are implemented)
+- Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
 
-PLC k256 verify and MST firehose-diff operation inversion are implemented in this slice (stacked on #70).
+PLC k256 verify, MST firehose-diff inversion, signed-commit verify, and OAuth client-metadata / PAR+token loop are implemented in this stack (#70 / #71 / this slice).
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -67,6 +69,16 @@ let ident = Identity.resolve "jay.bsky.team"
 
 (* MST layer for a repo key — official vector *)
 let () = assert (Mst.layer_for_key "blue" = 1)
+
+(* TID used as record keys and commit revs *)
+let () = assert (Tid.is_valid "3jzfcijpj2z2a")
+
+(* OAuth client metadata + authorize URL (no hosted client required) *)
+let meta =
+  Oauth.public_metadata
+    ~client_id:"https://client.example/client-metadata.json"
+    ~redirect_uris:[ "https://client.example/cb" ] ()
+let _ = Oauth.validate_metadata meta
 
 (* firehose: one subscribeRepos frame from the public relay *)
 let _header, msg = Firehose.subscribe_one ()

--- a/src/dune
+++ b/src/dune
@@ -63,6 +63,7 @@
   Server
   Session
   Sync
+  Tid
   User
   Varint
   Websocket))

--- a/src/label.ml
+++ b/src/label.ml
@@ -10,6 +10,8 @@ module Label = struct
     val_ : string;
     neg : bool option;
     cts : string option;
+    exp : string option;
+    ver : int option;
   }
 
   let parse_label json : label =
@@ -21,6 +23,21 @@ module Label = struct
       val_ = (match json |> member "val" with `String s -> s | _ -> "");
       neg = (match json |> member "neg" with `Bool b -> Some b | _ -> None);
       cts = (match json |> member "cts" with `String s -> Some s | _ -> None);
+      exp = (match json |> member "exp" with `String s -> Some s | _ -> None);
+      ver = (match json |> member "ver" with `Int n -> Some n | _ -> None);
+    }
+
+  type query_labels = { cursor : string option; labels : label list }
+
+  let parse_query_labels json : query_labels =
+    let open Yojson.Safe.Util in
+    {
+      cursor =
+        (match json |> member "cursor" with `String s -> Some s | _ -> None);
+      labels =
+        (match json |> member "labels" with
+        | `List items -> List.map parse_label items
+        | _ -> []);
     }
 
   let parse_label_values json : string list option =

--- a/src/mst.ml
+++ b/src/mst.ml
@@ -272,11 +272,11 @@ module Mst = struct
     in
     encode_repo_commit ~version ~did ~data ~rev ?prev ~sig_:(r ^ s) ()
 
-  let sign_k256 ~(priv : K256.priv) ?(version = 3) ~did ~data ~rev ?prev () :
-      string =
+  let sign_k256 ~(priv : K256.K256.priv) ?(version = 3) ~did ~data ~rev ?prev ()
+      : string =
     let unsigned = unsigned_repo_commit ~version ~did ~data ~rev ?prev () in
     let digest = Hash.sha256 unsigned in
-    let r, s = K256.sign ~key:priv digest in
+    let r, s = K256.K256.sign ~key:priv digest in
     encode_repo_commit ~version ~did ~data ~rev ?prev ~sig_:(r ^ s) ()
 
   let verify_commit_sig ~(keys : string list) (c : repo_commit) : sig_status =
@@ -294,7 +294,7 @@ module Mst = struct
           in
           let parsed =
             List.filter_map
-              (fun k -> try Some (Did_key.of_string k) with _ -> None)
+              (fun k -> try Some (Did_key.Did_key.of_string k) with _ -> None)
               keys
           in
           let rec try_keys = function
@@ -302,8 +302,9 @@ module Mst = struct
                 let other =
                   List.find_map
                     (fun k ->
-                      match k.Did_key.curve with
-                      | Did_key.Other n -> Some (Printf.sprintf "0x%x" n)
+                      match k.Did_key.Did_key.curve with
+                      | Did_key.Did_key.Other n ->
+                          Some (Printf.sprintf "0x%x" n)
                       | _ -> None)
                     parsed
                 in
@@ -311,9 +312,9 @@ module Mst = struct
                 | Some curve -> `Unsupported_curve curve
                 | None -> `Invalid)
             | k :: rest -> (
-                match k.Did_key.curve with
-                | Did_key.P256 -> (
-                    match Did_key.p256_pub k with
+                match k.Did_key.Did_key.curve with
+                | Did_key.Did_key.P256 -> (
+                    match Did_key.Did_key.p256_pub k with
                     | Some pub ->
                         if
                           Did_plc.Did_plc.is_low_s s
@@ -322,15 +323,16 @@ module Mst = struct
                         then `Valid
                         else try_keys rest
                     | None -> try_keys rest)
-                | Did_key.K256 -> (
-                    match Did_key.k256_pub k with
+                | Did_key.Did_key.K256 -> (
+                    match Did_key.Did_key.k256_pub k with
                     | Some pub ->
                         if
-                          K256.is_low_s s && K256.verify ~key:pub (r, s) digest
+                          K256.K256.is_low_s s
+                          && K256.K256.verify ~key:pub (r, s) digest
                         then `Valid
                         else try_keys rest
                     | None -> try_keys rest)
-                | Did_key.Other _ -> try_keys rest)
+                | Did_key.Did_key.Other _ -> try_keys rest)
           in
           try_keys parsed
 

--- a/src/mst.ml
+++ b/src/mst.ml
@@ -2,6 +2,8 @@ open Cid
 open Dag_cbor
 open Hash
 
+let ensure_rng = lazy (Mirage_crypto_rng_unix.use_default ())
+
 (** Merkle Search Tree used by AT Protocol repositories (fanout 4). *)
 module Mst = struct
   type entry = {
@@ -250,6 +252,87 @@ module Mst = struct
       @ match sig_ with Some b -> [ ("sig", Dag_cbor.Bytes b) ] | None -> []
     in
     Dag_cbor.encode (Dag_cbor.Map fields)
+
+  let unsigned_repo_commit ?(version = 3) ~did ~data ~rev ?prev () : string =
+    encode_repo_commit ~version ~did ~data ~rev ?prev ()
+
+  type sig_status =
+    [ `Valid | `Invalid | `Unsupported_curve of string | `Missing ]
+
+  let sign_p256 ~(priv : Mirage_crypto_ec.P256.Dsa.priv) ?(version = 3) ~did
+      ~data ~rev ?prev () : string =
+    Lazy.force ensure_rng;
+    let unsigned = unsigned_repo_commit ~version ~did ~data ~rev ?prev () in
+    let digest = Hash.sha256 unsigned in
+    let r, s = Mirage_crypto_ec.P256.Dsa.sign ~key:priv digest in
+    let s =
+      if String.compare s Did_plc.Did_plc.p256_n_half > 0 then
+        Did_plc.Did_plc.sub_be Did_plc.Did_plc.p256_n s
+      else s
+    in
+    encode_repo_commit ~version ~did ~data ~rev ?prev ~sig_:(r ^ s) ()
+
+  let sign_k256 ~(priv : K256.priv) ?(version = 3) ~did ~data ~rev ?prev () :
+      string =
+    let unsigned = unsigned_repo_commit ~version ~did ~data ~rev ?prev () in
+    let digest = Hash.sha256 unsigned in
+    let r, s = K256.sign ~key:priv digest in
+    encode_repo_commit ~version ~did ~data ~rev ?prev ~sig_:(r ^ s) ()
+
+  let verify_commit_sig ~(keys : string list) (c : repo_commit) : sig_status =
+    match c.sig_ with
+    | None -> `Missing
+    | Some raw ->
+        if String.length raw <> 64 then `Invalid
+        else
+          let r = String.sub raw 0 32 in
+          let s = String.sub raw 32 32 in
+          let digest =
+            Hash.sha256
+              (unsigned_repo_commit ~version:c.version ~did:c.did ~data:c.data
+                 ~rev:c.rev ?prev:c.prev ())
+          in
+          let parsed =
+            List.filter_map
+              (fun k -> try Some (Did_key.of_string k) with _ -> None)
+              keys
+          in
+          let rec try_keys = function
+            | [] -> (
+                let other =
+                  List.find_map
+                    (fun k ->
+                      match k.Did_key.curve with
+                      | Did_key.Other n -> Some (Printf.sprintf "0x%x" n)
+                      | _ -> None)
+                    parsed
+                in
+                match other with
+                | Some curve -> `Unsupported_curve curve
+                | None -> `Invalid)
+            | k :: rest -> (
+                match k.Did_key.curve with
+                | Did_key.P256 -> (
+                    match Did_key.p256_pub k with
+                    | Some pub ->
+                        if
+                          Did_plc.Did_plc.is_low_s s
+                          && Mirage_crypto_ec.P256.Dsa.verify ~key:pub (r, s)
+                               digest
+                        then `Valid
+                        else try_keys rest
+                    | None -> try_keys rest)
+                | Did_key.K256 -> (
+                    match Did_key.k256_pub k with
+                    | Some pub ->
+                        if
+                          K256.is_low_s s && K256.verify ~key:pub (r, s) digest
+                        then `Valid
+                        else try_keys rest
+                    | None -> try_keys rest)
+                | Did_key.Other _ -> try_keys rest)
+          in
+          try_keys parsed
 
   type record_op = {
     action : string;

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -95,8 +95,8 @@ module Oauth = struct
     r ^ low_s s
 
   let dpop_proof ~(priv : Mirage_crypto_ec.P256.Dsa.priv)
-      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~htm ~htu ?ath ?jti ?iat ?nonce () :
-      string =
+      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~htm ~htu ?ath ?jti ?iat ?nonce ()
+      : string =
     let jti =
       match jti with
       | Some j -> j
@@ -197,9 +197,7 @@ module Oauth = struct
       ("state", state);
       ("scope", scope);
     ]
-    @ (match login_hint with
-      | Some h -> [ ("login_hint", h) ]
-      | None -> [])
+    @ (match login_hint with Some h -> [ ("login_hint", h) ] | None -> [])
     @
     match client_assertion with
     | Some assertion ->
@@ -279,19 +277,17 @@ module Oauth = struct
                  Some (Uri.pct_decode k, Uri.pct_decode (String.concat "=" rest)))
 
   let assoc_opt key pairs =
-    match List.assoc_opt key pairs with
-    | Some "" -> None
-    | other -> other
+    match List.assoc_opt key pairs with Some "" -> None | other -> other
 
   let parse_redirect (uri : string) : callback =
     let q =
       match String.index_opt uri '?' with
       | None -> ""
-      | Some i ->
+      | Some i -> (
           let rest = String.sub uri (i + 1) (String.length uri - i - 1) in
           match String.index_opt rest '#' with
           | None -> rest
-          | Some h -> String.sub rest 0 h
+          | Some h -> String.sub rest 0 h)
     in
     let pairs = parse_query_pairs q in
     match assoc_opt "error" pairs with
@@ -474,8 +470,7 @@ module Oauth = struct
     | _ -> false
 
   let is_localhost_client_id (client_id : string) : bool =
-    client_id = "http://localhost"
-    || starts_with client_id "http://localhost?"
+    client_id = "http://localhost" || starts_with client_id "http://localhost?"
 
   let validate_metadata (m : client_metadata) : unit =
     if m.client_id = "" then failwith "Oauth: client_id is required";
@@ -492,7 +487,8 @@ module Oauth = struct
     if m.token_endpoint_auth_signing_alg = Some "none" then
       failwith "Oauth: token_endpoint_auth_signing_alg must not be none";
     (match (m.jwks, m.jwks_uri) with
-    | Some _, Some _ -> failwith "Oauth: jwks and jwks_uri are mutually exclusive"
+    | Some _, Some _ ->
+        failwith "Oauth: jwks and jwks_uri are mutually exclusive"
     | _ -> ());
     (match m.jwks with
     | Some j when jwk_has_private_d j ->
@@ -502,8 +498,7 @@ module Oauth = struct
     | "private_key_jwt" -> (
         match (m.jwks, m.jwks_uri) with
         | None, None ->
-            failwith
-              "Oauth: confidential clients must supply jwks or jwks_uri"
+            failwith "Oauth: confidential clients must supply jwks or jwks_uri"
         | _ -> ())
     | "none" | "" -> ()
     | other ->
@@ -576,7 +571,8 @@ module Oauth = struct
     let open Yojson.Safe.Util in
     {
       issuer = json |> member "issuer" |> to_string;
-      authorization_endpoint = json |> member "authorization_endpoint" |> to_string;
+      authorization_endpoint =
+        json |> member "authorization_endpoint" |> to_string;
       token_endpoint = json |> member "token_endpoint" |> to_string;
       pushed_authorization_request_endpoint =
         json |> member "pushed_authorization_request_endpoint" |> to_string;
@@ -596,7 +592,9 @@ module Oauth = struct
         | `Bool b -> b
         | _ -> false);
       authorization_response_iss_parameter_supported =
-        (match json |> member "authorization_response_iss_parameter_supported" with
+        (match
+           json |> member "authorization_response_iss_parameter_supported"
+         with
         | `Bool b -> b
         | _ -> false);
       client_id_metadata_document_supported =
@@ -607,8 +605,7 @@ module Oauth = struct
 
   let require_mem label xs value =
     if not (List.mem value xs) then
-      failwith
-        (Printf.sprintf "Oauth: %s must include %s" label value)
+      failwith (Printf.sprintf "Oauth: %s must include %s" label value)
 
   let validate_as_metadata (m : as_metadata) : unit =
     if not (starts_with m.issuer "https://") then
@@ -628,14 +625,16 @@ module Oauth = struct
     require_mem "token_endpoint_auth_signing_alg_values_supported"
       m.token_endpoint_auth_signing_alg_values_supported "ES256";
     if List.mem "none" m.token_endpoint_auth_signing_alg_values_supported then
-      failwith "Oauth: token_endpoint_auth_signing_alg_values_supported has none";
+      failwith
+        "Oauth: token_endpoint_auth_signing_alg_values_supported has none";
     require_mem "scopes_supported" m.scopes_supported "atproto";
     require_mem "dpop_signing_alg_values_supported"
       m.dpop_signing_alg_values_supported "ES256";
     if not m.require_pushed_authorization_requests then
       failwith "Oauth: require_pushed_authorization_requests must be true";
     if not m.authorization_response_iss_parameter_supported then
-      failwith "Oauth: authorization_response_iss_parameter_supported must be true";
+      failwith
+        "Oauth: authorization_response_iss_parameter_supported must be true";
     if not m.client_id_metadata_document_supported then
       failwith "Oauth: client_id_metadata_document_supported must be true";
     if m.pushed_authorization_request_endpoint = "" then
@@ -685,8 +684,8 @@ module Oauth = struct
     }
 
   let client_assertion ~(priv : Mirage_crypto_ec.P256.Dsa.priv)
-      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~client_id ~issuer ?kid ?jti ?iat
-      ?exp () : string =
+      ~pub:(_pub : Mirage_crypto_ec.P256.Dsa.pub) ~client_id ~issuer ?kid ?jti
+      ?iat ?exp () : string =
     let jti =
       match jti with
       | Some j -> j
@@ -720,8 +719,8 @@ module Oauth = struct
     let sig_ = Base64url.encode (sign_es256 ~priv input) in
     input ^ "." ^ sig_
 
-  let jwks_of_pub ?(kid = "oauth-client")
-      (pub : Mirage_crypto_ec.P256.Dsa.pub) : Yojson.Safe.t =
+  let jwks_of_pub ?(kid = "oauth-client") (pub : Mirage_crypto_ec.P256.Dsa.pub)
+      : Yojson.Safe.t =
     match p256_jwk pub with
     | `Assoc fields ->
         `Assoc
@@ -752,8 +751,7 @@ module Oauth = struct
   let header_value headers name =
     let lower = String.lowercase_ascii name in
     List.find_map
-      (fun (k, v) ->
-        if String.lowercase_ascii k = lower then Some v else None)
+      (fun (k, v) -> if String.lowercase_ascii k = lower then Some v else None)
       headers
 
   let use_dpop_nonce status body =
@@ -790,10 +788,10 @@ module Oauth = struct
   let ensure_ok label resp =
     if resp.status < 200 || resp.status >= 300 then
       match Error.Error.of_body resp.body with
-      | Some e -> failwith (Printf.sprintf "Oauth %s: %s" label (Error.Error.to_string e))
-      | None ->
+      | Some e ->
           failwith
-            (Printf.sprintf "Oauth %s: HTTP %d" label resp.status)
+            (Printf.sprintf "Oauth %s: %s" label (Error.Error.to_string e))
+      | None -> failwith (Printf.sprintf "Oauth %s: HTTP %d" label resp.status)
     else decode_json_body label resp.body
 
   let push_authorization ~(http : http_post) ~priv ~pub ~par_url ~form ?nonce ()
@@ -819,9 +817,7 @@ module Oauth = struct
   let resource_request_headers ~priv ~pub ~htm ~htu ~access_token ?ath ?nonce ()
       =
     let ath =
-      match ath with
-      | Some a -> a
-      | None -> ath_of_access_token access_token
+      match ath with Some a -> a | None -> ath_of_access_token access_token
     in
     let proof = dpop_proof ~priv ~pub ~htm ~htu ~ath ?nonce () in
     [ authorization_dpop access_token; dpop_header proof ]

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -3,9 +3,10 @@ open Base64url
 
 let ensure_rng = lazy (Mirage_crypto_rng_unix.use_default ())
 
-(** AT Protocol OAuth core: PKCE (S256), DPoP (ES256), PAR/token request shapes.
-    Browser redirects, client-metadata hosting, and a live token loop are
-    product-level and left to the application. *)
+(** AT Protocol OAuth core: PKCE (S256), DPoP (ES256 + nonce), client metadata,
+    PAR/token request+response, redirect callback, and an injectable HTTP loop.
+    Hosting a public client-metadata URL and completing a live browser login
+    remain application-level. *)
 module Oauth = struct
   type pkce = { verifier : string; challenge : string; method_ : string }
 
@@ -18,6 +19,7 @@ module Oauth = struct
     htu : string;
     iat : int64;
     ath : string option;
+    nonce : string option;
   }
 
   let pkce_unreserved =
@@ -93,7 +95,7 @@ module Oauth = struct
     r ^ low_s s
 
   let dpop_proof ~(priv : Mirage_crypto_ec.P256.Dsa.priv)
-      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~htm ~htu ?ath ?jti ?iat () :
+      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~htm ~htu ?ath ?jti ?iat ?nonce () :
       string =
     let jti =
       match jti with
@@ -122,7 +124,8 @@ module Oauth = struct
         ("htu", `String htu);
         ("iat", `Intlit (Int64.to_string iat));
       ]
-      @ match ath with Some a -> [ ("ath", `String a) ] | None -> []
+      @ (match ath with Some a -> [ ("ath", `String a) ] | None -> [])
+      @ match nonce with Some n -> [ ("nonce", `String n) ] | None -> []
     in
     let payload = `Assoc payload_fields in
     let input = b64url_json header ^ "." ^ b64url_json payload in
@@ -153,6 +156,8 @@ module Oauth = struct
         | _ -> 0L);
       ath =
         (match payload |> member "ath" with `String s -> Some s | _ -> None);
+      nonce =
+        (match payload |> member "nonce" with `String s -> Some s | _ -> None);
     }
 
   let verify_dpop ~(pub : Mirage_crypto_ec.P256.Dsa.pub) (jwt : string) : bool =
@@ -178,8 +183,11 @@ module Oauth = struct
   let token_url ?(host = "bsky.social") () =
     Printf.sprintf "https://%s/oauth/token" host
 
+  let jwt_bearer_assertion_type =
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
   let pushed_authorization_body ~client_id ~redirect_uri ~code_challenge ~state
-      ?(scope = "atproto transition:generic") () =
+      ?(scope = "atproto transition:generic") ?login_hint ?client_assertion () =
     [
       ("response_type", "code");
       ("client_id", client_id);
@@ -189,8 +197,20 @@ module Oauth = struct
       ("state", state);
       ("scope", scope);
     ]
+    @ (match login_hint with
+      | Some h -> [ ("login_hint", h) ]
+      | None -> [])
+    @
+    match client_assertion with
+    | Some assertion ->
+        [
+          ("client_assertion_type", jwt_bearer_assertion_type);
+          ("client_assertion", assertion);
+        ]
+    | None -> []
 
-  let token_body ~client_id ~redirect_uri ~code ~code_verifier =
+  let token_body ~client_id ~redirect_uri ~code ~code_verifier ?client_assertion
+      () =
     [
       ("grant_type", "authorization_code");
       ("client_id", client_id);
@@ -198,17 +218,611 @@ module Oauth = struct
       ("code", code);
       ("code_verifier", code_verifier);
     ]
+    @
+    match client_assertion with
+    | Some assertion ->
+        [
+          ("client_assertion_type", jwt_bearer_assertion_type);
+          ("client_assertion", assertion);
+        ]
+    | None -> []
 
-  let refresh_body ~client_id ~refresh_token =
+  let refresh_body ~client_id ~refresh_token ?client_assertion () =
     [
       ("grant_type", "refresh_token");
       ("client_id", client_id);
       ("refresh_token", refresh_token);
     ]
+    @
+    match client_assertion with
+    | Some assertion ->
+        [
+          ("client_assertion_type", jwt_bearer_assertion_type);
+          ("client_assertion", assertion);
+        ]
+    | None -> []
 
   let form_encode (pairs : (string * string) list) : string =
     let kv (k, v) = Uri.pct_encode k ^ "=" ^ Uri.pct_encode v in
     String.concat "&" (List.map kv pairs)
 
   let dpop_header proof = ("DPoP", proof)
+  let authorization_dpop access_token = ("Authorization", "DPoP " ^ access_token)
+
+  let query_append url pairs =
+    let encoded = form_encode pairs in
+    if encoded = "" then url
+    else if String.contains url '?' then url ^ "&" ^ encoded
+    else url ^ "?" ^ encoded
+
+  let authorize_redirect_url ~authorization_endpoint ~client_id ~request_uri =
+    query_append authorization_endpoint
+      [ ("client_id", client_id); ("request_uri", request_uri) ]
+
+  type callback =
+    | Authorized of { code : string; state : string; iss : string option }
+    | Denied of {
+        error : string;
+        description : string option;
+        state : string option;
+      }
+
+  let parse_query_pairs (query : string) : (string * string) list =
+    if query = "" then []
+    else
+      String.split_on_char '&' query
+      |> List.filter_map (fun part ->
+             match String.split_on_char '=' part with
+             | [] | [ "" ] -> None
+             | [ k ] -> Some (Uri.pct_decode k, "")
+             | k :: rest ->
+                 Some (Uri.pct_decode k, Uri.pct_decode (String.concat "=" rest)))
+
+  let assoc_opt key pairs =
+    match List.assoc_opt key pairs with
+    | Some "" -> None
+    | other -> other
+
+  let parse_redirect (uri : string) : callback =
+    let q =
+      match String.index_opt uri '?' with
+      | None -> ""
+      | Some i ->
+          let rest = String.sub uri (i + 1) (String.length uri - i - 1) in
+          match String.index_opt rest '#' with
+          | None -> rest
+          | Some h -> String.sub rest 0 h
+    in
+    let pairs = parse_query_pairs q in
+    match assoc_opt "error" pairs with
+    | Some err ->
+        Denied
+          {
+            error = err;
+            description = assoc_opt "error_description" pairs;
+            state = assoc_opt "state" pairs;
+          }
+    | None -> (
+        match (assoc_opt "code" pairs, assoc_opt "state" pairs) with
+        | Some code, Some state ->
+            Authorized { code; state; iss = assoc_opt "iss" pairs }
+        | _ ->
+            failwith
+              "Oauth.parse_redirect: expected code+state or error query params")
+
+  let expect_state ~expected = function
+    | Authorized { state; _ } | Denied { state = Some state; _ } ->
+        if state = expected then ()
+        else failwith "Oauth: redirect state does not match the PAR request"
+    | Denied { state = None; _ } ->
+        failwith "Oauth: denied redirect is missing state"
+
+  let expect_issuer ~expected = function
+    | Authorized { iss = Some iss; _ } ->
+        if iss = expected then ()
+        else
+          failwith
+            (Printf.sprintf "Oauth: redirect iss %s != authorization server %s"
+               iss expected)
+    | Authorized { iss = None; _ } ->
+        failwith "Oauth: redirect is missing iss (required by atproto OAuth)"
+    | Denied _ -> ()
+
+  type client_metadata = {
+    client_id : string;
+    application_type : string;
+    grant_types : string list;
+    response_types : string list;
+    redirect_uris : string list;
+    scope : string;
+    token_endpoint_auth_method : string;
+    token_endpoint_auth_signing_alg : string option;
+    dpop_bound_access_tokens : bool;
+    jwks : Yojson.Safe.t option;
+    jwks_uri : string option;
+    client_name : string option;
+    client_uri : string option;
+  }
+
+  let string_list json field =
+    match Yojson.Safe.Util.member field json with
+    | `List items ->
+        List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> []
+
+  let json_string_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
+  let starts_with s prefix =
+    let n = String.length prefix in
+    String.length s >= n && String.sub s 0 n = prefix
+
+  let contains_scope ~scope needle =
+    List.mem needle (String.split_on_char ' ' scope)
+
+  let public_metadata ~client_id ~redirect_uris
+      ?(scope = "atproto transition:generic") ?(application_type = "web")
+      ?client_name ?client_uri () : client_metadata =
+    {
+      client_id;
+      application_type;
+      grant_types = [ "authorization_code"; "refresh_token" ];
+      response_types = [ "code" ];
+      redirect_uris;
+      scope;
+      token_endpoint_auth_method = "none";
+      token_endpoint_auth_signing_alg = None;
+      dpop_bound_access_tokens = true;
+      jwks = None;
+      jwks_uri = None;
+      client_name;
+      client_uri;
+    }
+
+  let confidential_metadata ~client_id ~redirect_uris ~jwks
+      ?(scope = "atproto transition:generic") ?(application_type = "web")
+      ?client_name ?client_uri () : client_metadata =
+    {
+      (public_metadata ~client_id ~redirect_uris ~scope ~application_type
+         ?client_name ?client_uri ())
+      with
+      token_endpoint_auth_method = "private_key_jwt";
+      token_endpoint_auth_signing_alg = Some "ES256";
+      jwks = Some jwks;
+    }
+
+  let metadata_to_json (m : client_metadata) : Yojson.Safe.t =
+    let str_list xs = `List (List.map (fun s -> `String s) xs) in
+    let fields =
+      [
+        ("client_id", `String m.client_id);
+        ("application_type", `String m.application_type);
+        ("grant_types", str_list m.grant_types);
+        ("response_types", str_list m.response_types);
+        ("redirect_uris", str_list m.redirect_uris);
+        ("scope", `String m.scope);
+        ("token_endpoint_auth_method", `String m.token_endpoint_auth_method);
+        ("dpop_bound_access_tokens", `Bool m.dpop_bound_access_tokens);
+      ]
+      @ (match m.token_endpoint_auth_signing_alg with
+        | Some alg -> [ ("token_endpoint_auth_signing_alg", `String alg) ]
+        | None -> [])
+      @ (match m.jwks with Some j -> [ ("jwks", j) ] | None -> [])
+      @ (match m.jwks_uri with
+        | Some u -> [ ("jwks_uri", `String u) ]
+        | None -> [])
+      @ (match m.client_name with
+        | Some n -> [ ("client_name", `String n) ]
+        | None -> [])
+      @
+      match m.client_uri with
+      | Some u -> [ ("client_uri", `String u) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let metadata_of_json json : client_metadata =
+    let open Yojson.Safe.Util in
+    {
+      client_id = json |> member "client_id" |> to_string;
+      application_type =
+        (match json |> member "application_type" with
+        | `String s -> s
+        | _ -> "web");
+      grant_types = string_list json "grant_types";
+      response_types = string_list json "response_types";
+      redirect_uris = string_list json "redirect_uris";
+      scope = (match json |> member "scope" with `String s -> s | _ -> "");
+      token_endpoint_auth_method =
+        (match json |> member "token_endpoint_auth_method" with
+        | `String s -> s
+        | _ -> "none");
+      token_endpoint_auth_signing_alg =
+        json_string_opt json "token_endpoint_auth_signing_alg";
+      dpop_bound_access_tokens =
+        (match json |> member "dpop_bound_access_tokens" with
+        | `Bool b -> b
+        | _ -> false);
+      jwks =
+        (match json |> member "jwks" with
+        | `Null | `Assoc [] -> None
+        | j -> Some j);
+      jwks_uri = json_string_opt json "jwks_uri";
+      client_name = json_string_opt json "client_name";
+      client_uri = json_string_opt json "client_uri";
+    }
+
+  let jwk_has_private_d json =
+    match json with
+    | `Assoc fields ->
+        List.exists
+          (function
+            | "d", `String _ -> true
+            | "keys", `List keys ->
+                List.exists
+                  (function
+                    | `Assoc k ->
+                        List.exists
+                          (function "d", `String _ -> true | _ -> false)
+                          k
+                    | _ -> false)
+                  keys
+            | _ -> false)
+          fields
+    | _ -> false
+
+  let is_localhost_client_id (client_id : string) : bool =
+    client_id = "http://localhost"
+    || starts_with client_id "http://localhost?"
+
+  let validate_metadata (m : client_metadata) : unit =
+    if m.client_id = "" then failwith "Oauth: client_id is required";
+    if not m.dpop_bound_access_tokens then
+      failwith "Oauth: dpop_bound_access_tokens must be true";
+    if not (List.mem "authorization_code" m.grant_types) then
+      failwith "Oauth: grant_types must include authorization_code";
+    if not (List.mem "code" m.response_types) then
+      failwith "Oauth: response_types must include code";
+    if not (contains_scope ~scope:m.scope "atproto") then
+      failwith "Oauth: scope must include atproto";
+    if m.redirect_uris = [] then
+      failwith "Oauth: redirect_uris must contain at least one URI";
+    if m.token_endpoint_auth_signing_alg = Some "none" then
+      failwith "Oauth: token_endpoint_auth_signing_alg must not be none";
+    (match (m.jwks, m.jwks_uri) with
+    | Some _, Some _ -> failwith "Oauth: jwks and jwks_uri are mutually exclusive"
+    | _ -> ());
+    (match m.jwks with
+    | Some j when jwk_has_private_d j ->
+        failwith "Oauth: client JWKS must not contain private key material (d)"
+    | _ -> ());
+    match m.token_endpoint_auth_method with
+    | "private_key_jwt" -> (
+        match (m.jwks, m.jwks_uri) with
+        | None, None ->
+            failwith
+              "Oauth: confidential clients must supply jwks or jwks_uri"
+        | _ -> ())
+    | "none" | "" -> ()
+    | other ->
+        failwith ("Oauth: unsupported token_endpoint_auth_method " ^ other)
+
+  let localhost_metadata (client_id : string) : client_metadata =
+    if not (is_localhost_client_id client_id) then
+      failwith "Oauth: not a localhost development client_id";
+    let query =
+      match String.index_opt client_id '?' with
+      | None -> ""
+      | Some i -> String.sub client_id (i + 1) (String.length client_id - i - 1)
+    in
+    let pairs = parse_query_pairs query in
+    let redirects =
+      List.filter_map
+        (fun (k, v) -> if k = "redirect_uri" && v <> "" then Some v else None)
+        pairs
+    in
+    let redirects =
+      if redirects = [] then [ "http://127.0.0.1/"; "http://[::1]/" ]
+      else redirects
+    in
+    let scope =
+      match assoc_opt "scope" pairs with Some s -> s | None -> "atproto"
+    in
+    public_metadata ~client_id ~redirect_uris:redirects ~scope
+      ~application_type:"native" ~client_name:"Development client" ()
+
+  type as_metadata = {
+    issuer : string;
+    authorization_endpoint : string;
+    token_endpoint : string;
+    pushed_authorization_request_endpoint : string;
+    response_types_supported : string list;
+    grant_types_supported : string list;
+    code_challenge_methods_supported : string list;
+    token_endpoint_auth_methods_supported : string list;
+    token_endpoint_auth_signing_alg_values_supported : string list;
+    scopes_supported : string list;
+    dpop_signing_alg_values_supported : string list;
+    require_pushed_authorization_requests : bool;
+    authorization_response_iss_parameter_supported : bool;
+    client_id_metadata_document_supported : bool;
+  }
+
+  type resource_metadata = {
+    resource : string option;
+    authorization_servers : string list;
+  }
+
+  let protected_resource_url ?(host = "bsky.social") () =
+    Printf.sprintf "https://%s/.well-known/oauth-protected-resource" host
+
+  let authorization_server_url ?(issuer = "https://bsky.social") () =
+    let issuer =
+      if issuer <> "" && issuer.[String.length issuer - 1] = '/' then
+        String.sub issuer 0 (String.length issuer - 1)
+      else issuer
+    in
+    issuer ^ "/.well-known/oauth-authorization-server"
+
+  let parse_resource_metadata json : resource_metadata =
+    {
+      resource = json_string_opt json "resource";
+      authorization_servers = string_list json "authorization_servers";
+    }
+
+  let parse_as_metadata json : as_metadata =
+    let open Yojson.Safe.Util in
+    {
+      issuer = json |> member "issuer" |> to_string;
+      authorization_endpoint = json |> member "authorization_endpoint" |> to_string;
+      token_endpoint = json |> member "token_endpoint" |> to_string;
+      pushed_authorization_request_endpoint =
+        json |> member "pushed_authorization_request_endpoint" |> to_string;
+      response_types_supported = string_list json "response_types_supported";
+      grant_types_supported = string_list json "grant_types_supported";
+      code_challenge_methods_supported =
+        string_list json "code_challenge_methods_supported";
+      token_endpoint_auth_methods_supported =
+        string_list json "token_endpoint_auth_methods_supported";
+      token_endpoint_auth_signing_alg_values_supported =
+        string_list json "token_endpoint_auth_signing_alg_values_supported";
+      scopes_supported = string_list json "scopes_supported";
+      dpop_signing_alg_values_supported =
+        string_list json "dpop_signing_alg_values_supported";
+      require_pushed_authorization_requests =
+        (match json |> member "require_pushed_authorization_requests" with
+        | `Bool b -> b
+        | _ -> false);
+      authorization_response_iss_parameter_supported =
+        (match json |> member "authorization_response_iss_parameter_supported" with
+        | `Bool b -> b
+        | _ -> false);
+      client_id_metadata_document_supported =
+        (match json |> member "client_id_metadata_document_supported" with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let require_mem label xs value =
+    if not (List.mem value xs) then
+      failwith
+        (Printf.sprintf "Oauth: %s must include %s" label value)
+
+  let validate_as_metadata (m : as_metadata) : unit =
+    if not (starts_with m.issuer "https://") then
+      failwith "Oauth: issuer must be an https origin";
+    if String.contains_from m.issuer (String.length "https://") '/' then
+      failwith "Oauth: issuer must not include a path";
+    require_mem "response_types_supported" m.response_types_supported "code";
+    require_mem "grant_types_supported" m.grant_types_supported
+      "authorization_code";
+    require_mem "grant_types_supported" m.grant_types_supported "refresh_token";
+    require_mem "code_challenge_methods_supported"
+      m.code_challenge_methods_supported "S256";
+    require_mem "token_endpoint_auth_methods_supported"
+      m.token_endpoint_auth_methods_supported "none";
+    require_mem "token_endpoint_auth_methods_supported"
+      m.token_endpoint_auth_methods_supported "private_key_jwt";
+    require_mem "token_endpoint_auth_signing_alg_values_supported"
+      m.token_endpoint_auth_signing_alg_values_supported "ES256";
+    if List.mem "none" m.token_endpoint_auth_signing_alg_values_supported then
+      failwith "Oauth: token_endpoint_auth_signing_alg_values_supported has none";
+    require_mem "scopes_supported" m.scopes_supported "atproto";
+    require_mem "dpop_signing_alg_values_supported"
+      m.dpop_signing_alg_values_supported "ES256";
+    if not m.require_pushed_authorization_requests then
+      failwith "Oauth: require_pushed_authorization_requests must be true";
+    if not m.authorization_response_iss_parameter_supported then
+      failwith "Oauth: authorization_response_iss_parameter_supported must be true";
+    if not m.client_id_metadata_document_supported then
+      failwith "Oauth: client_id_metadata_document_supported must be true";
+    if m.pushed_authorization_request_endpoint = "" then
+      failwith "Oauth: pushed_authorization_request_endpoint is required"
+
+  type par_response = { request_uri : string; expires_in : int option }
+
+  type token = {
+    access_token : string;
+    token_type : string;
+    expires_in : int option;
+    refresh_token : string option;
+    scope : string;
+    sub : string;
+  }
+
+  let parse_par_response json : par_response =
+    let open Yojson.Safe.Util in
+    {
+      request_uri = json |> member "request_uri" |> to_string;
+      expires_in =
+        (match json |> member "expires_in" with `Int n -> Some n | _ -> None);
+    }
+
+  let parse_token_response json : token =
+    let open Yojson.Safe.Util in
+    let token_type =
+      match json |> member "token_type" with `String s -> s | _ -> ""
+    in
+    let scope = match json |> member "scope" with `String s -> s | _ -> "" in
+    let sub = match json |> member "sub" with `String s -> s | _ -> "" in
+    if String.lowercase_ascii token_type <> "dpop" then
+      failwith "Oauth: token_type must be DPoP";
+    if scope = "" then failwith "Oauth: token response is missing scope";
+    if not (contains_scope ~scope "atproto") then
+      failwith "Oauth: granted scope must include atproto";
+    if not (starts_with sub "did:") then
+      failwith "Oauth: token response sub must be an atproto DID";
+    {
+      access_token = json |> member "access_token" |> to_string;
+      token_type;
+      expires_in =
+        (match json |> member "expires_in" with `Int n -> Some n | _ -> None);
+      refresh_token = json_string_opt json "refresh_token";
+      scope;
+      sub;
+    }
+
+  let client_assertion ~(priv : Mirage_crypto_ec.P256.Dsa.priv)
+      ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~client_id ~issuer ?kid ?jti ?iat
+      ?exp () : string =
+    let jti =
+      match jti with
+      | Some j -> j
+      | None ->
+          Base64url.encode
+            (Hash.sha256 (string_of_float (Unix.gettimeofday ())))
+    in
+    let iat =
+      match iat with
+      | Some n -> n
+      | None -> Int64.of_float (Unix.gettimeofday ())
+    in
+    let exp = match exp with Some n -> n | None -> Int64.add iat 300L in
+    let header_fields =
+      [ ("typ", `String "JWT"); ("alg", `String "ES256") ]
+      @ match kid with Some k -> [ ("kid", `String k) ] | None -> []
+    in
+    let header = `Assoc header_fields in
+    let payload =
+      `Assoc
+        [
+          ("iss", `String client_id);
+          ("sub", `String client_id);
+          ("aud", `String issuer);
+          ("jti", `String jti);
+          ("iat", `Intlit (Int64.to_string iat));
+          ("exp", `Intlit (Int64.to_string exp));
+        ]
+    in
+    let input = b64url_json header ^ "." ^ b64url_json payload in
+    let sig_ = Base64url.encode (sign_es256 ~priv input) in
+    input ^ "." ^ sig_
+
+  let jwks_of_pub ?(kid = "oauth-client")
+      (pub : Mirage_crypto_ec.P256.Dsa.pub) : Yojson.Safe.t =
+    match p256_jwk pub with
+    | `Assoc fields ->
+        `Assoc
+          [
+            ( "keys",
+              `List
+                [
+                  `Assoc
+                    (fields
+                    @ [
+                        ("kid", `String kid);
+                        ("use", `String "sig");
+                        ("alg", `String "ES256");
+                      ]);
+                ] );
+          ]
+    | other -> other
+
+  type http_response = {
+    status : int;
+    headers : (string * string) list;
+    body : string;
+  }
+
+  type http_post =
+    url:string -> headers:(string * string) list -> body:string -> http_response
+
+  let header_value headers name =
+    let lower = String.lowercase_ascii name in
+    List.find_map
+      (fun (k, v) ->
+        if String.lowercase_ascii k = lower then Some v else None)
+      headers
+
+  let use_dpop_nonce status body =
+    status = 400
+    &&
+    match Error.Error.of_body body with
+    | Some e -> e.Error.Error.error = "use_dpop_nonce"
+    | None -> false
+
+  let post_with_dpop ~(http : http_post) ~priv ~pub ~url ~htm ~body ?ath ?nonce
+      () : http_response * string option =
+    let rec attempt nonce tries =
+      let proof = dpop_proof ~priv ~pub ~htm ~htu:url ?ath ?nonce () in
+      let headers =
+        [
+          ("Content-Type", "application/x-www-form-urlencoded");
+          dpop_header proof;
+        ]
+      in
+      let resp = http ~url ~headers ~body in
+      let next_nonce = header_value resp.headers "DPoP-Nonce" in
+      if use_dpop_nonce resp.status resp.body && tries > 0 then
+        match next_nonce with
+        | Some n -> attempt (Some n) (tries - 1)
+        | None -> (resp, nonce)
+      else (resp, match next_nonce with Some n -> Some n | None -> nonce)
+    in
+    attempt nonce 1
+
+  let decode_json_body label body =
+    try Yojson.Safe.from_string body
+    with _ -> failwith (Printf.sprintf "Oauth: %s returned non-JSON" label)
+
+  let ensure_ok label resp =
+    if resp.status < 200 || resp.status >= 300 then
+      match Error.Error.of_body resp.body with
+      | Some e -> failwith (Printf.sprintf "Oauth %s: %s" label (Error.Error.to_string e))
+      | None ->
+          failwith
+            (Printf.sprintf "Oauth %s: HTTP %d" label resp.status)
+    else decode_json_body label resp.body
+
+  let push_authorization ~(http : http_post) ~priv ~pub ~par_url ~form ?nonce ()
+      : par_response * string option =
+    let body = form_encode form in
+    let resp, nonce =
+      post_with_dpop ~http ~priv ~pub ~url:par_url ~htm:"POST" ~body ?nonce ()
+    in
+    (parse_par_response (ensure_ok "PAR" resp), nonce)
+
+  let exchange_code ~(http : http_post) ~priv ~pub ~token_url ~form ?nonce () :
+      token * string option =
+    let body = form_encode form in
+    let resp, nonce =
+      post_with_dpop ~http ~priv ~pub ~url:token_url ~htm:"POST" ~body ?nonce ()
+    in
+    (parse_token_response (ensure_ok "token" resp), nonce)
+
+  let refresh ~(http : http_post) ~priv ~pub ~token_url ~form ?nonce () :
+      token * string option =
+    exchange_code ~http ~priv ~pub ~token_url ~form ?nonce ()
+
+  let resource_request_headers ~priv ~pub ~htm ~htu ~access_token ?ath ?nonce ()
+      =
+    let ath =
+      match ath with
+      | Some a -> a
+      | None -> ath_of_access_token access_token
+    in
+    let proof = dpop_proof ~priv ~pub ~htm ~htu ~ath ?nonce () in
+    [ authorization_dpop access_token; dpop_header proof ]
 end

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -280,18 +280,13 @@ module Repo = struct
 
   let parse_blob_ref json : blob_ref =
     let open Yojson.Safe.Util in
-    let blob =
-      match json |> member "blob" with `Null -> json | b -> b
-    in
+    let blob = match json |> member "blob" with `Null -> json | b -> b in
     let cid =
       match blob |> member "ref" with
       | `Assoc _ as ref_ -> (
-          match ref_ |> member "$link" with
-          | `String s -> s
-          | _ -> "")
+          match ref_ |> member "$link" with `String s -> s | _ -> "")
       | `String s -> s
-      | _ -> (
-          match blob |> member "cid" with `String s -> s | _ -> "")
+      | _ -> ( match blob |> member "cid" with `String s -> s | _ -> "")
     in
     {
       cid;
@@ -305,8 +300,8 @@ module Repo = struct
     App.create_endpoint_url (App.create_base_url s)
       (create_repo_endpoint "uploadBlob")
 
-  let upload_blob (s : Session.session) ?(content_type = "application/octet-stream")
-      (bytes : string) : blob_ref =
+  let upload_blob (s : Session.session)
+      ?(content_type = "application/octet-stream") (bytes : string) : blob_ref =
     let bearer_token = Session.bearer_token_from_session s in
     let headers =
       Cohttp_client.create_headers_from_pairs

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -204,4 +204,117 @@ module Repo = struct
         (Cohttp_client.post_data_with_headers delete_record_url data headers)
     in
     deleted_record
+
+  type write_op =
+    | Create of {
+        collection : string;
+        rkey : string option;
+        value : Yojson.Safe.t;
+      }
+    | Update of { collection : string; rkey : string; value : Yojson.Safe.t }
+    | Delete of { collection : string; rkey : string }
+
+  let write_op_to_json = function
+    | Create { collection; rkey; value } ->
+        `Assoc
+          ([
+             ("$type", `String "com.atproto.repo.applyWrites#create");
+             ("collection", `String collection);
+             ("value", value);
+           ]
+          @ match rkey with Some r -> [ ("rkey", `String r) ] | None -> [])
+    | Update { collection; rkey; value } ->
+        `Assoc
+          [
+            ("$type", `String "com.atproto.repo.applyWrites#update");
+            ("collection", `String collection);
+            ("rkey", `String rkey);
+            ("value", value);
+          ]
+    | Delete { collection; rkey } ->
+        `Assoc
+          [
+            ("$type", `String "com.atproto.repo.applyWrites#delete");
+            ("collection", `String collection);
+            ("rkey", `String rkey);
+          ]
+
+  let apply_writes_body ~repo ~writes ?(validate = true) ?swap_commit () :
+      Yojson.Safe.t =
+    let fields =
+      [
+        ("repo", `String repo);
+        ("validate", `Bool validate);
+        ("writes", `List (List.map write_op_to_json writes));
+      ]
+      @
+      match swap_commit with
+      | Some cid -> [ ("swapCommit", `String cid) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let apply_writes (s : Session.session) ~repo ~writes ?validate ?swap_commit ()
+      : string =
+    let bearer_token = Session.bearer_token_from_session s in
+    let application_json = Cohttp_client.application_json_setting_tuple in
+    let headers =
+      Cohttp_client.create_headers_from_pairs [ application_json; bearer_token ]
+    in
+    let base_url = App.create_base_url s in
+    let url =
+      App.create_endpoint_url base_url (create_repo_endpoint "applyWrites")
+    in
+    let data =
+      Yojson.Safe.to_string
+        (apply_writes_body ~repo ~writes ?validate ?swap_commit ())
+    in
+    Lwt_main.run (Cohttp_client.post_data_with_headers url data headers)
+
+  type blob_ref = {
+    cid : string;
+    mime_type : string;
+    size : int;
+    original : Yojson.Safe.t;
+  }
+
+  let parse_blob_ref json : blob_ref =
+    let open Yojson.Safe.Util in
+    let blob =
+      match json |> member "blob" with `Null -> json | b -> b
+    in
+    let cid =
+      match blob |> member "ref" with
+      | `Assoc _ as ref_ -> (
+          match ref_ |> member "$link" with
+          | `String s -> s
+          | _ -> "")
+      | `String s -> s
+      | _ -> (
+          match blob |> member "cid" with `String s -> s | _ -> "")
+    in
+    {
+      cid;
+      mime_type =
+        (match blob |> member "mimeType" with `String s -> s | _ -> "");
+      size = (match blob |> member "size" with `Int n -> n | _ -> 0);
+      original = blob;
+    }
+
+  let upload_blob_url (s : Session.session) : string =
+    App.create_endpoint_url (App.create_base_url s)
+      (create_repo_endpoint "uploadBlob")
+
+  let upload_blob (s : Session.session) ?(content_type = "application/octet-stream")
+      (bytes : string) : blob_ref =
+    let bearer_token = Session.bearer_token_from_session s in
+    let headers =
+      Cohttp_client.create_headers_from_pairs
+        [ ("Content-Type", content_type); bearer_token ]
+    in
+    let url = upload_blob_url s in
+    let body =
+      Lwt_main.run (Cohttp_client.post_data_with_headers url bytes headers)
+    in
+    parse_blob_ref (Yojson.Safe.from_string body)
 end

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -1,0 +1,79 @@
+(** Timestamp Identifiers (TIDs) — https://atproto.com/specs/tid *)
+module Tid = struct
+  let alphabet = "234567abcdefghijklmnopqrstuvwxyz"
+  let first_ok = "234567abcdefghij"
+  let zero = "2222222222222"
+
+  exception Invalid of string
+
+  let fail msg = raise (Invalid msg)
+
+  let index_of alphabet c =
+    let rec loop i =
+      if i >= String.length alphabet then None
+      else if alphabet.[i] = c then Some i
+      else loop (i + 1)
+    in
+    loop 0
+
+  let is_valid (s : string) : bool =
+    String.length s = 13
+    &&
+    match index_of first_ok s.[0] with
+    | None -> false
+    | Some _ ->
+        let rec loop i =
+          if i >= 13 then true
+          else
+            match index_of alphabet s.[i] with
+            | None -> false
+            | Some _ -> loop (i + 1)
+        in
+        loop 1
+
+  let of_int64 (v : int64) : string =
+    let v = Int64.logand v 0x7FFF_FFFF_FFFF_FFFFL in
+    let buf = Bytes.create 13 in
+    let rec loop i n =
+      if i < 0 then ()
+      else (
+        Bytes.set buf i alphabet.[Int64.to_int (Int64.logand n 0x1FL)];
+        loop (i - 1) (Int64.shift_right_logical n 5))
+    in
+    loop 12 v;
+    Bytes.to_string buf
+
+  let to_int64 (s : string) : int64 =
+    if String.length s <> 13 then fail "TID must be 13 characters";
+    let rec loop i acc =
+      if i >= 13 then acc
+      else
+        match index_of alphabet s.[i] with
+        | None -> fail ("TID has invalid character " ^ String.make 1 s.[i])
+        | Some n ->
+            loop (i + 1)
+              (Int64.logor (Int64.shift_left acc 5) (Int64.of_int n))
+    in
+    let v = loop 0 0L in
+    if Int64.logand v 0x8000_0000_0000_0000L <> 0L then
+      fail "TID top bit must be 0";
+    v
+
+  let of_string (s : string) : string =
+    if not (is_valid s) then fail ("invalid TID " ^ s);
+    s
+
+  let timestamp_us (s : string) : int64 =
+    Int64.shift_right_logical (to_int64 s) 10
+
+  let clock_id (s : string) : int = Int64.to_int (Int64.logand (to_int64 s) 0x3FFL)
+
+  let create ?(clock_id = 0) (timestamp_us : int64) : string =
+    let ts = Int64.logand timestamp_us 0x1F_FFFF_FFFF_FFFFL in
+    let clk = Int64.logand (Int64.of_int clock_id) 0x3FFL in
+    of_int64 (Int64.logor (Int64.shift_left ts 10) clk)
+
+  let now ?(clock_id = Random.int 1024) () : string =
+    let us = Int64.of_float (Unix.gettimeofday () *. 1_000_000.) in
+    create ~clock_id us
+end

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -51,8 +51,7 @@ module Tid = struct
         match index_of alphabet s.[i] with
         | None -> fail ("TID has invalid character " ^ String.make 1 s.[i])
         | Some n ->
-            loop (i + 1)
-              (Int64.logor (Int64.shift_left acc 5) (Int64.of_int n))
+            loop (i + 1) (Int64.logor (Int64.shift_left acc 5) (Int64.of_int n))
     in
     let v = loop 0 0L in
     if Int64.logand v 0x8000_0000_0000_0000L <> 0L then
@@ -66,7 +65,8 @@ module Tid = struct
   let timestamp_us (s : string) : int64 =
     Int64.shift_right_logical (to_int64 s) 10
 
-  let clock_id (s : string) : int = Int64.to_int (Int64.logand (to_int64 s) 0x3FFL)
+  let clock_id (s : string) : int =
+    Int64.to_int (Int64.logand (to_int64 s) 0x3FFL)
 
   let create ?(clock_id = 0) (timestamp_us : int64) : string =
     let ts = Int64.logand timestamp_us 0x1F_FFFF_FFFF_FFFFL in

--- a/test/dune
+++ b/test/dune
@@ -29,11 +29,12 @@
   test_server
   test_session
   test_sync
+  test_tid
   test_user
   test_blob
   test_blocks
   test_download_image)
- (libraries
+ (libraries)
   async
   core
   uri
@@ -86,6 +87,7 @@
   test_server
   test_session
   test_sync
+  test_tid
   test_user
   test_blob
   test_blocks

--- a/test/dune
+++ b/test/dune
@@ -34,7 +34,7 @@
   test_blob
   test_blocks
   test_download_image)
- (libraries)
+ (libraries
   async
   core
   uri

--- a/test/test_firehose.ml
+++ b/test/test_firehose.ml
@@ -34,6 +34,58 @@ let test_decode_identity_frame _ =
       OUnit2.assert_equal (Some "alice.test") ev.handle
   | _ -> OUnit2.assert_failure "expected #identity frame"
 
+let test_decode_sync_account_info _ =
+  let cid = Cid.of_digest (String.make 32 '\x09') in
+  let empty_car = Car.encode { Car.roots = [ cid ]; blocks = [] } in
+  let sync_header = Firehose.encode_header { op = 1; t = Some "#sync" } in
+  let sync_body =
+    Dag_cbor.encode
+      (Dag_cbor.Map
+         [
+           ("seq", Dag_cbor.Int 3);
+           ("did", Dag_cbor.Text "did:plc:7iza6de2dwap2sbkpav7c6c6");
+           ("blocks", Dag_cbor.Bytes empty_car);
+           ("rev", Dag_cbor.Text "3jzfcijpj2z2a");
+           ("time", Dag_cbor.Text "2024-01-01T00:00:00.000Z");
+         ])
+  in
+  (match Firehose.decode_frame (sync_header ^ sync_body) with
+  | _, `Sync ev ->
+      OUnit2.assert_equal ~printer:Int64.to_string 3L ev.seq;
+      OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a" ev.rev
+  | _ -> OUnit2.assert_failure "expected #sync frame");
+  let acct_header = Firehose.encode_header { op = 1; t = Some "#account" } in
+  let acct_body =
+    Dag_cbor.encode
+      (Dag_cbor.Map
+         [
+           ("seq", Dag_cbor.Int 4);
+           ("did", Dag_cbor.Text "did:plc:7iza6de2dwap2sbkpav7c6c6");
+           ("time", Dag_cbor.Text "2024-01-01T00:00:00.000Z");
+           ("active", Dag_cbor.Bool false);
+           ("status", Dag_cbor.Text "takendown");
+         ])
+  in
+  (match Firehose.decode_frame (acct_header ^ acct_body) with
+  | _, `Account ev ->
+      OUnit2.assert_equal false ev.active;
+      OUnit2.assert_equal (Some "takendown") ev.status
+  | _ -> OUnit2.assert_failure "expected #account frame");
+  let info_header = Firehose.encode_header { op = 1; t = Some "#info" } in
+  let info_body =
+    Dag_cbor.encode
+      (Dag_cbor.Map
+         [
+           ("name", Dag_cbor.Text "OutdatedCursor");
+           ("message", Dag_cbor.Text "cursor is too old");
+         ])
+  in
+  match Firehose.decode_frame (info_header ^ info_body) with
+  | _, `Info ev ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "OutdatedCursor" ev.name;
+      OUnit2.assert_equal (Some "cursor is too old") ev.message
+  | _ -> OUnit2.assert_failure "expected #info frame"
+
 let test_decode_error_frame _ =
   let header = Firehose.encode_header { op = -1; t = None } in
   let body =
@@ -322,6 +374,7 @@ let suite =
   >::: [
          "test_subscribe_url" >:: test_subscribe_url;
          "test_decode_identity_frame" >:: test_decode_identity_frame;
+         "test_decode_sync_account_info" >:: test_decode_sync_account_info;
          "test_decode_error_frame" >:: test_decode_error_frame;
          "test_decode_commit_ops" >:: test_decode_commit_ops;
          "test_decode_update_and_delete_ops"

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -16,5 +16,38 @@ let test_query_labels _ =
   Printf.printf "Query Labels: %s\n" labels;
   OUnit2.assert_bool "Query Labels is not empty" (labels <> "")
 
-let suite = "suite" >::: [ "test_query_labels" >:: test_query_labels ]
+let test_parse_query_labels _ =
+  let json =
+    `Assoc
+      [
+        ("cursor", `String "c1");
+        ( "labels",
+          `List
+            [
+              `Assoc
+                [
+                  ("src", `String "did:plc:labeler");
+                  ("uri", `String "at://did:plc:alice/app.bsky.feed.post/1");
+                  ("val", `String "!warn");
+                  ("neg", `Bool false);
+                  ("cts", `String "2024-01-01T00:00:00.000Z");
+                  ("ver", `Int 1);
+                ];
+            ] );
+      ]
+  in
+  let q = Label.parse_query_labels json in
+  OUnit2.assert_equal (Some "c1") q.cursor;
+  OUnit2.assert_equal 1 (List.length q.labels);
+  let label = List.hd q.labels in
+  OUnit2.assert_equal ~printer:(fun x -> x) "!warn" label.val_;
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:plc:labeler" label.src;
+  OUnit2.assert_equal (Some 1) label.ver
+
+let suite =
+  "suite"
+  >::: [
+         "test_query_labels" >:: test_query_labels;
+         "test_parse_query_labels" >:: test_parse_query_labels;
+       ]
 let () = run_test_tt_main suite

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -50,4 +50,5 @@ let suite =
          "test_query_labels" >:: test_query_labels;
          "test_parse_query_labels" >:: test_parse_query_labels;
        ]
+
 let () = run_test_tt_main suite

--- a/test/test_mst.ml
+++ b/test/test_mst.ml
@@ -1,6 +1,9 @@
 open OUnit2
 open Atproto.Cid
 open Atproto.Mst
+open Atproto.Did_key
+open Atproto.Hash
+open Atproto.K256
 
 let official_heights =
   [
@@ -263,6 +266,92 @@ let test_invert_create_mismatch _ =
        false
      with Mst.Verify_error _ -> true)
 
+let rfc6979_p256_priv =
+  Hash.hex_decode
+    "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"
+
+let p256_pair () =
+  match Mirage_crypto_ec.P256.Dsa.priv_of_octets rfc6979_p256_priv with
+  | Error _ -> failwith "could not load RFC 6979 P-256 private key"
+  | Ok priv -> (priv, Mirage_crypto_ec.P256.Dsa.pub_of_priv priv)
+
+let p256_did_key pub =
+  Did_key.to_string
+    (Did_key.of_p256_octets
+       (Mirage_crypto_ec.P256.Dsa.pub_to_octets ~compress:true pub))
+
+let test_sign_verify_commit_p256 _ =
+  let priv, pub = p256_pair () in
+  let data = Cid.create ~codec:Cid.Raw "mst-root" in
+  let signed =
+    Mst.sign_p256 ~priv ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
+      ~rev:"3jzfcijpj2z2a" ()
+  in
+  let commit = Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed) in
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a" commit.rev;
+  match Mst.verify_commit_sig ~keys:[ p256_did_key pub ] commit with
+  | `Valid -> ()
+  | other ->
+      OUnit2.assert_failure
+        (match other with
+        | `Invalid -> "p256 commit sig invalid"
+        | `Missing -> "p256 commit sig missing"
+        | `Unsupported_curve c -> "unsupported " ^ c
+        | `Valid -> "valid")
+
+let test_sign_verify_commit_k256 _ =
+  match K256.priv_of_octets (Hash.hex_decode (String.make 63 '0' ^ "3")) with
+  | Error _ -> OUnit2.assert_failure "k256 priv rejected"
+  | Ok priv -> (
+      let pub = K256.pub_of_priv priv in
+      let data = Cid.create ~codec:Cid.Raw "mst-root-k" in
+      let signed =
+        Mst.sign_k256 ~priv ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
+          ~rev:"3jzfcijpj2z2a" ()
+      in
+      let commit =
+        Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed)
+      in
+      let key =
+        Did_key.to_string
+          (Did_key.of_k256_octets (K256.pub_to_octets ~compress:true pub))
+      in
+      match Mst.verify_commit_sig ~keys:[ key ] commit with
+      | `Valid -> ()
+      | _ -> OUnit2.assert_failure "k256 commit sig invalid")
+
+let test_commit_sig_wrong_key_and_missing _ =
+  let priv, pub = p256_pair () in
+  let data = Cid.create ~codec:Cid.Raw "mst-root" in
+  let unsigned =
+    Mst.unsigned_repo_commit ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
+      ~rev:"3jzfcijpj2z2a" ()
+  in
+  let unsigned_c =
+    Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode unsigned)
+  in
+  (match Mst.verify_commit_sig ~keys:[ p256_did_key pub ] unsigned_c with
+  | `Missing -> ()
+  | _ -> OUnit2.assert_failure "unsigned commit should be Missing");
+  let signed =
+    Mst.sign_p256 ~priv ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
+      ~rev:"3jzfcijpj2z2a" ()
+  in
+  let commit = Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed) in
+  match
+    K256.priv_of_octets (String.make 31 '\x00' ^ "\x01")
+  with
+  | Error _ -> OUnit2.assert_failure "k256 priv=1 rejected"
+  | Ok kpriv -> (
+      let kpub = K256.pub_of_priv kpriv in
+      let wrong =
+        Did_key.to_string
+          (Did_key.of_k256_octets (K256.pub_to_octets ~compress:true kpub))
+      in
+      match Mst.verify_commit_sig ~keys:[ wrong ] commit with
+      | `Invalid -> ()
+      | _ -> OUnit2.assert_failure "wrong-key commit should be Invalid")
+
 let test_cid_mismatch _ =
   let v = Cid.create ~codec:Cid.Raw "x" in
   let node =
@@ -293,6 +382,10 @@ let suite =
          "test_insert_replace_returns_prev" >:: test_insert_replace_returns_prev;
          "test_invert_create_update_delete" >:: test_invert_create_update_delete;
          "test_invert_create_mismatch" >:: test_invert_create_mismatch;
+         "test_sign_verify_commit_p256" >:: test_sign_verify_commit_p256;
+         "test_sign_verify_commit_k256" >:: test_sign_verify_commit_k256;
+         "test_commit_sig_wrong_key_and_missing"
+         >:: test_commit_sig_wrong_key_and_missing;
          "test_cid_mismatch" >:: test_cid_mismatch;
        ]
 

--- a/test/test_mst.ml
+++ b/test/test_mst.ml
@@ -287,7 +287,9 @@ let test_sign_verify_commit_p256 _ =
     Mst.sign_p256 ~priv ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
       ~rev:"3jzfcijpj2z2a" ()
   in
-  let commit = Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed) in
+  let commit =
+    Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed)
+  in
   OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a" commit.rev;
   match Mst.verify_commit_sig ~keys:[ p256_did_key pub ] commit with
   | `Valid -> ()
@@ -337,10 +339,10 @@ let test_commit_sig_wrong_key_and_missing _ =
     Mst.sign_p256 ~priv ~did:"did:plc:7iza6de2dwap2sbkpav7c6c6" ~data
       ~rev:"3jzfcijpj2z2a" ()
   in
-  let commit = Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed) in
-  match
-    K256.priv_of_octets (String.make 31 '\x00' ^ "\x01")
-  with
+  let commit =
+    Mst.parse_repo_commit (Atproto.Dag_cbor.Dag_cbor.decode signed)
+  in
+  match K256.priv_of_octets (String.make 31 '\x00' ^ "\x01") with
   | Error _ -> OUnit2.assert_failure "k256 priv=1 rejected"
   | Ok kpriv -> (
       let kpub = K256.pub_of_priv kpriv in

--- a/test/test_oauth.ml
+++ b/test/test_oauth.ml
@@ -76,6 +76,37 @@ let test_dpop_ath _ =
   OUnit2.assert_equal (Some ath) claims.ath;
   OUnit2.assert_bool "ath proof verifies" (Oauth.verify_dpop ~pub proof)
 
+let client_id = "https://client.example/client-metadata.json"
+let redirect_uri = "https://client.example/cb"
+
+let sample_as_json =
+  `Assoc
+    [
+      ("issuer", `String "https://bsky.social");
+      ("authorization_endpoint", `String "https://bsky.social/oauth/authorize");
+      ("token_endpoint", `String "https://bsky.social/oauth/token");
+      ( "pushed_authorization_request_endpoint",
+        `String "https://bsky.social/oauth/par" );
+      ("response_types_supported", `List [ `String "code" ]);
+      ( "grant_types_supported",
+        `List [ `String "authorization_code"; `String "refresh_token" ] );
+      ("code_challenge_methods_supported", `List [ `String "S256" ]);
+      ( "token_endpoint_auth_methods_supported",
+        `List [ `String "none"; `String "private_key_jwt" ] );
+      ("token_endpoint_auth_signing_alg_values_supported", `List [ `String "ES256" ]);
+      ( "scopes_supported",
+        `List
+          [
+            `String "atproto";
+            `String "transition:generic";
+            `String "transition:chat.bsky";
+          ] );
+      ("dpop_signing_alg_values_supported", `List [ `String "ES256" ]);
+      ("require_pushed_authorization_requests", `Bool true);
+      ("authorization_response_iss_parameter_supported", `Bool true);
+      ("client_id_metadata_document_supported", `Bool true);
+    ]
+
 let test_par_and_token_shapes _ =
   let pkce = Oauth.pkce_s256 ~verifier:rfc7636_verifier () in
   let par =
@@ -90,7 +121,7 @@ let test_par_and_token_shapes _ =
   let token =
     Oauth.token_body ~client_id:"https://client.example/client-metadata.json"
       ~redirect_uri:"https://client.example/cb" ~code:"authz-code"
-      ~code_verifier:pkce.verifier
+      ~code_verifier:pkce.verifier ()
   in
   OUnit2.assert_equal (Some "authorization_code")
     (List.assoc_opt "grant_type" token);
@@ -99,6 +130,339 @@ let test_par_and_token_shapes _ =
     "https://bsky.social/oauth/par" (Oauth.par_url ());
   let encoded = Oauth.form_encode par in
   OUnit2.assert_bool "form body includes challenge" (String.length encoded > 20)
+
+let test_client_metadata_public _ =
+  let meta =
+    Oauth.public_metadata ~client_id ~redirect_uris:[ redirect_uri ]
+      ~client_name:"Example" ()
+  in
+  Oauth.validate_metadata meta;
+  let again = Oauth.metadata_of_json (Oauth.metadata_to_json meta) in
+  OUnit2.assert_equal ~printer:(fun x -> x) client_id again.client_id;
+  OUnit2.assert_equal ~printer:(fun x -> x) "none"
+    again.token_endpoint_auth_method;
+  OUnit2.assert_bool "dpop bound" again.dpop_bound_access_tokens;
+  OUnit2.assert_bool "atproto"
+    (Oauth.contains_scope ~scope:again.scope "atproto")
+
+let test_client_metadata_confidential _ =
+  let priv, pub = p256_pair () in
+  let jwks = Oauth.jwks_of_pub pub in
+  let meta =
+    Oauth.confidential_metadata ~client_id ~redirect_uris:[ redirect_uri ] ~jwks
+      ()
+  in
+  Oauth.validate_metadata meta;
+  OUnit2.assert_equal ~printer:(fun x -> x) "private_key_jwt"
+    meta.token_endpoint_auth_method;
+  ignore priv
+
+let test_client_metadata_rejects_private_jwk _ =
+  let bad =
+    Oauth.confidential_metadata ~client_id ~redirect_uris:[ redirect_uri ]
+      ~jwks:
+        (`Assoc
+          [
+            ( "keys",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("kty", `String "EC");
+                      ("crv", `String "P-256");
+                      ("x", `String "aa");
+                      ("y", `String "bb");
+                      ("d", `String "secret");
+                    ];
+                ] );
+          ])
+      ()
+  in
+  OUnit2.assert_bool "private d accepted"
+    (try
+       Oauth.validate_metadata bad;
+       false
+     with Failure _ -> true)
+
+let test_localhost_client_metadata _ =
+  let id =
+    "http://localhost?redirect_uri=http://127.0.0.1:8080/cb&scope=atproto%20transition:generic"
+  in
+  let meta = Oauth.localhost_metadata id in
+  Oauth.validate_metadata meta;
+  OUnit2.assert_equal ~printer:(fun x -> x) "native" meta.application_type;
+  OUnit2.assert_equal [ "http://127.0.0.1:8080/cb" ] meta.redirect_uris;
+  OUnit2.assert_equal ~printer:(fun x -> x) "atproto transition:generic"
+    meta.scope
+
+let test_as_and_resource_metadata _ =
+  let as_ = Oauth.parse_as_metadata sample_as_json in
+  Oauth.validate_as_metadata as_;
+  OUnit2.assert_equal ~printer:(fun x -> x) "https://bsky.social" as_.issuer;
+  let resource =
+    Oauth.parse_resource_metadata
+      (`Assoc
+        [
+          ("resource", `String "https://morel.us-east.host.bsky.network");
+          ("authorization_servers", `List [ `String "https://bsky.social" ]);
+        ])
+  in
+  OUnit2.assert_equal [ "https://bsky.social" ] resource.authorization_servers;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://bsky.social/.well-known/oauth-protected-resource"
+    (Oauth.protected_resource_url ());
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://bsky.social/.well-known/oauth-authorization-server"
+    (Oauth.authorization_server_url ())
+
+let test_as_metadata_rejects_missing_par _ =
+  let bad =
+    match sample_as_json with
+    | `Assoc fields ->
+        `Assoc
+          (List.map
+             (fun (k, v) ->
+               if k = "require_pushed_authorization_requests" then (k, `Bool false)
+               else (k, v))
+             fields)
+    | _ -> sample_as_json
+  in
+  OUnit2.assert_bool "missing PAR accepted"
+    (try
+       Oauth.validate_as_metadata (Oauth.parse_as_metadata bad);
+       false
+     with Failure _ -> true)
+
+let test_redirect_and_authorize_url _ =
+  match
+    Oauth.parse_redirect
+      "https://client.example/cb?code=splendid&state=abc&iss=https%3A%2F%2Fbsky.social"
+  with
+  | Oauth.Authorized { code; state; iss } ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "splendid" code;
+      OUnit2.assert_equal ~printer:(fun x -> x) "abc" state;
+      OUnit2.assert_equal (Some "https://bsky.social") iss;
+      Oauth.expect_state ~expected:"abc"
+        (Oauth.Authorized { code; state; iss });
+      Oauth.expect_issuer ~expected:"https://bsky.social"
+        (Oauth.Authorized { code; state; iss });
+      let url =
+        Oauth.authorize_redirect_url
+          ~authorization_endpoint:"https://bsky.social/oauth/authorize"
+          ~client_id ~request_uri:"urn:ietf:params:oauth:request_uri:abc"
+      in
+      OUnit2.assert_bool url (String.contains url '?');
+      OUnit2.assert_bool url
+        (let needle = "request_uri=" in
+         let rec find i =
+           i + String.length needle <= String.length url
+           && (String.sub url i (String.length needle) = needle
+              || find (i + 1))
+         in
+         find 0)
+  | Oauth.Denied _ -> OUnit2.assert_failure "expected authorized redirect"
+
+let test_redirect_denied _ =
+  match
+    Oauth.parse_redirect
+      "https://client.example/cb?error=access_denied&error_description=nope&state=abc"
+  with
+  | Oauth.Denied { error; description; state } ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "access_denied" error;
+      OUnit2.assert_equal (Some "nope") description;
+      OUnit2.assert_equal (Some "abc") state
+  | Oauth.Authorized _ -> OUnit2.assert_failure "expected denied redirect"
+
+let test_redirect_state_mismatch _ =
+  OUnit2.assert_bool "state mismatch accepted"
+    (try
+       Oauth.expect_state ~expected:"nope"
+         (Oauth.Authorized
+            { code = "x"; state = "abc"; iss = Some "https://bsky.social" });
+       false
+     with Failure _ -> true)
+
+let test_token_response_guards _ =
+  let good =
+    Oauth.parse_token_response
+      (`Assoc
+        [
+          ("access_token", `String "tok");
+          ("token_type", `String "DPoP");
+          ("expires_in", `Int 300);
+          ("refresh_token", `String "rt");
+          ("scope", `String "atproto transition:generic");
+          ("sub", `String "did:plc:7iza6de2dwap2sbkpav7c6c6");
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "tok" good.access_token;
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "did:plc:7iza6de2dwap2sbkpav7c6c6" good.sub;
+  let rejects json =
+    try
+      ignore (Oauth.parse_token_response json);
+      false
+    with Failure _ -> true
+  in
+  OUnit2.assert_bool "bearer accepted"
+    (rejects
+       (`Assoc
+         [
+           ("access_token", `String "tok");
+           ("token_type", `String "Bearer");
+           ("scope", `String "atproto");
+           ("sub", `String "did:plc:7iza6de2dwap2sbkpav7c6c6");
+         ]));
+  OUnit2.assert_bool "missing atproto accepted"
+    (rejects
+       (`Assoc
+         [
+           ("access_token", `String "tok");
+           ("token_type", `String "DPoP");
+           ("scope", `String "transition:generic");
+           ("sub", `String "did:plc:7iza6de2dwap2sbkpav7c6c6");
+         ]));
+  OUnit2.assert_bool "missing sub accepted"
+    (rejects
+       (`Assoc
+         [
+           ("access_token", `String "tok");
+           ("token_type", `String "DPoP");
+           ("scope", `String "atproto");
+         ]))
+
+let test_client_assertion _ =
+  let priv, pub = p256_pair () in
+  let jwt =
+    Oauth.client_assertion ~priv ~pub ~client_id ~issuer:"https://bsky.social"
+      ~kid:"oauth-client" ~jti:"assert-jti" ~iat:1_700_000_000L ()
+  in
+  let h, p, _ = Oauth.split_jwt jwt in
+  let header = Yojson.Safe.from_string (Atproto.Base64url.Base64url.decode h) in
+  let payload = Yojson.Safe.from_string (Atproto.Base64url.Base64url.decode p) in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal ~printer:(fun x -> x) "ES256"
+    (header |> member "alg" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x) client_id
+    (payload |> member "iss" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x) "https://bsky.social"
+    (payload |> member "aud" |> to_string);
+  OUnit2.assert_bool "assertion verifies" (Oauth.verify_dpop ~pub jwt)
+
+let test_dpop_nonce_claim _ =
+  let priv, pub = p256_pair () in
+  let proof =
+    Oauth.dpop_proof ~priv ~pub ~htm:"POST"
+      ~htu:"https://bsky.social/oauth/par" ~nonce:"server-nonce" ~jti:"n1"
+      ~iat:1L ()
+  in
+  let claims = Oauth.parse_dpop proof in
+  OUnit2.assert_equal (Some "server-nonce") claims.nonce;
+  OUnit2.assert_bool "nonce proof verifies" (Oauth.verify_dpop ~pub proof)
+
+let test_par_token_loop_retries_nonce _ =
+  let priv, pub = p256_pair () in
+  let par_hits = ref 0 in
+  let seen_nonce = ref None in
+  let http ~url ~headers ~body:_ =
+    let dpop = List.assoc "DPoP" headers in
+    let claims = Oauth.parse_dpop dpop in
+    if url = "https://bsky.social/oauth/par" then (
+      incr par_hits;
+      if !par_hits = 1 then
+        {
+          Oauth.status = 400;
+          headers = [ ("DPoP-Nonce", "server-nonce-1") ];
+          body =
+            {|{"error":"use_dpop_nonce","error_description":"retry with nonce"}|};
+        }
+      else (
+        seen_nonce := claims.nonce;
+        {
+          Oauth.status = 201;
+          headers = [ ("DPoP-Nonce", "server-nonce-2") ];
+          body =
+            {|{"request_uri":"urn:ietf:params:oauth:request_uri:abc","expires_in":90}|};
+        }))
+    else if url = "https://bsky.social/oauth/token" then
+      {
+        Oauth.status = 200;
+        headers = [];
+        body =
+          {|{"access_token":"tok","token_type":"DPoP","expires_in":300,"refresh_token":"rt","scope":"atproto transition:generic","sub":"did:plc:7iza6de2dwap2sbkpav7c6c6"}|};
+      }
+    else failwith ("unexpected url " ^ url)
+  in
+  let pkce = Oauth.pkce_s256 ~verifier:rfc7636_verifier () in
+  let par_form =
+    Oauth.pushed_authorization_body ~client_id ~redirect_uri
+      ~code_challenge:pkce.challenge ~state:"abc" ()
+  in
+  let par, nonce =
+    Oauth.push_authorization ~http ~priv ~pub
+      ~par_url:"https://bsky.social/oauth/par" ~form:par_form ()
+  in
+  OUnit2.assert_equal 2 !par_hits;
+  OUnit2.assert_equal (Some "server-nonce-1") !seen_nonce;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "urn:ietf:params:oauth:request_uri:abc" par.request_uri;
+  OUnit2.assert_equal (Some 90) par.expires_in;
+  OUnit2.assert_equal (Some "server-nonce-2") nonce;
+  let token_form =
+    Oauth.token_body ~client_id ~redirect_uri ~code:"authz-code"
+      ~code_verifier:pkce.verifier ()
+  in
+  let token, _ =
+    Oauth.exchange_code ~http ~priv ~pub
+      ~token_url:"https://bsky.social/oauth/token" ~form:token_form ()
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "did:plc:7iza6de2dwap2sbkpav7c6c6" token.sub;
+  let headers =
+    Oauth.resource_request_headers ~priv ~pub ~htm:"GET"
+      ~htu:"https://pds.example/xrpc/com.atproto.repo.getRecord"
+      ~access_token:token.access_token ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "DPoP tok"
+    (List.assoc "Authorization" headers)
+
+let test_live_as_metadata _ =
+  let old =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
+  in
+  ignore (Unix.alarm 20);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm old)
+    (fun () ->
+      try
+        let url = Oauth.authorization_server_url () in
+        let headers =
+          Atproto.Cohttp_client.Cohttp_client.create_headers_from_pairs
+            [
+              Atproto.Cohttp_client.Cohttp_client
+              .application_json_setting_tuple;
+            ]
+        in
+        let body =
+          Lwt_main.run
+            (Atproto.Cohttp_client.Cohttp_client.get_request_with_headers url
+               headers)
+        in
+        let meta = Oauth.parse_as_metadata (Yojson.Safe.from_string body) in
+        Oauth.validate_as_metadata meta;
+        OUnit2.assert_equal ~printer:(fun x -> x) "https://bsky.social"
+          meta.issuer
+      with exn ->
+        skip_if true
+          ("oauth authorization-server metadata skipped: "
+         ^ Printexc.to_string exn))
 
 let suite =
   "oauth"
@@ -109,6 +473,24 @@ let suite =
          "test_dpop_sign_and_verify" >:: test_dpop_sign_and_verify;
          "test_dpop_ath" >:: test_dpop_ath;
          "test_par_and_token_shapes" >:: test_par_and_token_shapes;
+         "test_client_metadata_public" >:: test_client_metadata_public;
+         "test_client_metadata_confidential"
+         >:: test_client_metadata_confidential;
+         "test_client_metadata_rejects_private_jwk"
+         >:: test_client_metadata_rejects_private_jwk;
+         "test_localhost_client_metadata" >:: test_localhost_client_metadata;
+         "test_as_and_resource_metadata" >:: test_as_and_resource_metadata;
+         "test_as_metadata_rejects_missing_par"
+         >:: test_as_metadata_rejects_missing_par;
+         "test_redirect_and_authorize_url" >:: test_redirect_and_authorize_url;
+         "test_redirect_denied" >:: test_redirect_denied;
+         "test_redirect_state_mismatch" >:: test_redirect_state_mismatch;
+         "test_token_response_guards" >:: test_token_response_guards;
+         "test_client_assertion" >:: test_client_assertion;
+         "test_dpop_nonce_claim" >:: test_dpop_nonce_claim;
+         "test_par_token_loop_retries_nonce"
+         >:: test_par_token_loop_retries_nonce;
+         "test_live_as_metadata" >:: test_live_as_metadata;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_oauth.ml
+++ b/test/test_oauth.ml
@@ -93,7 +93,8 @@ let sample_as_json =
       ("code_challenge_methods_supported", `List [ `String "S256" ]);
       ( "token_endpoint_auth_methods_supported",
         `List [ `String "none"; `String "private_key_jwt" ] );
-      ("token_endpoint_auth_signing_alg_values_supported", `List [ `String "ES256" ]);
+      ( "token_endpoint_auth_signing_alg_values_supported",
+        `List [ `String "ES256" ] );
       ( "scopes_supported",
         `List
           [
@@ -139,8 +140,9 @@ let test_client_metadata_public _ =
   Oauth.validate_metadata meta;
   let again = Oauth.metadata_of_json (Oauth.metadata_to_json meta) in
   OUnit2.assert_equal ~printer:(fun x -> x) client_id again.client_id;
-  OUnit2.assert_equal ~printer:(fun x -> x) "none"
-    again.token_endpoint_auth_method;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "none" again.token_endpoint_auth_method;
   OUnit2.assert_bool "dpop bound" again.dpop_bound_access_tokens;
   OUnit2.assert_bool "atproto"
     (Oauth.contains_scope ~scope:again.scope "atproto")
@@ -153,8 +155,9 @@ let test_client_metadata_confidential _ =
       ()
   in
   Oauth.validate_metadata meta;
-  OUnit2.assert_equal ~printer:(fun x -> x) "private_key_jwt"
-    meta.token_endpoint_auth_method;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "private_key_jwt" meta.token_endpoint_auth_method;
   ignore priv
 
 let test_client_metadata_rejects_private_jwk _ =
@@ -192,8 +195,9 @@ let test_localhost_client_metadata _ =
   Oauth.validate_metadata meta;
   OUnit2.assert_equal ~printer:(fun x -> x) "native" meta.application_type;
   OUnit2.assert_equal [ "http://127.0.0.1:8080/cb" ] meta.redirect_uris;
-  OUnit2.assert_equal ~printer:(fun x -> x) "atproto transition:generic"
-    meta.scope
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "atproto transition:generic" meta.scope
 
 let test_as_and_resource_metadata _ =
   let as_ = Oauth.parse_as_metadata sample_as_json in
@@ -224,7 +228,8 @@ let test_as_metadata_rejects_missing_par _ =
         `Assoc
           (List.map
              (fun (k, v) ->
-               if k = "require_pushed_authorization_requests" then (k, `Bool false)
+               if k = "require_pushed_authorization_requests" then
+                 (k, `Bool false)
                else (k, v))
              fields)
     | _ -> sample_as_json
@@ -244,8 +249,7 @@ let test_redirect_and_authorize_url _ =
       OUnit2.assert_equal ~printer:(fun x -> x) "splendid" code;
       OUnit2.assert_equal ~printer:(fun x -> x) "abc" state;
       OUnit2.assert_equal (Some "https://bsky.social") iss;
-      Oauth.expect_state ~expected:"abc"
-        (Oauth.Authorized { code; state; iss });
+      Oauth.expect_state ~expected:"abc" (Oauth.Authorized { code; state; iss });
       Oauth.expect_issuer ~expected:"https://bsky.social"
         (Oauth.Authorized { code; state; iss });
       let url =
@@ -258,8 +262,7 @@ let test_redirect_and_authorize_url _ =
         (let needle = "request_uri=" in
          let rec find i =
            i + String.length needle <= String.length url
-           && (String.sub url i (String.length needle) = needle
-              || find (i + 1))
+           && (String.sub url i (String.length needle) = needle || find (i + 1))
          in
          find 0)
   | Oauth.Denied _ -> OUnit2.assert_failure "expected authorized redirect"
@@ -298,7 +301,8 @@ let test_token_response_guards _ =
         ])
   in
   OUnit2.assert_equal ~printer:(fun x -> x) "tok" good.access_token;
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "did:plc:7iza6de2dwap2sbkpav7c6c6" good.sub;
   let rejects json =
     try
@@ -341,22 +345,29 @@ let test_client_assertion _ =
   in
   let h, p, _ = Oauth.split_jwt jwt in
   let header = Yojson.Safe.from_string (Atproto.Base64url.Base64url.decode h) in
-  let payload = Yojson.Safe.from_string (Atproto.Base64url.Base64url.decode p) in
+  let payload =
+    Yojson.Safe.from_string (Atproto.Base64url.Base64url.decode p)
+  in
   let open Yojson.Safe.Util in
-  OUnit2.assert_equal ~printer:(fun x -> x) "ES256"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "ES256"
     (header |> member "alg" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x) client_id
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    client_id
     (payload |> member "iss" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x) "https://bsky.social"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://bsky.social"
     (payload |> member "aud" |> to_string);
   OUnit2.assert_bool "assertion verifies" (Oauth.verify_dpop ~pub jwt)
 
 let test_dpop_nonce_claim _ =
   let priv, pub = p256_pair () in
   let proof =
-    Oauth.dpop_proof ~priv ~pub ~htm:"POST"
-      ~htu:"https://bsky.social/oauth/par" ~nonce:"server-nonce" ~jti:"n1"
-      ~iat:1L ()
+    Oauth.dpop_proof ~priv ~pub ~htm:"POST" ~htu:"https://bsky.social/oauth/par"
+      ~nonce:"server-nonce" ~jti:"n1" ~iat:1L ()
   in
   let claims = Oauth.parse_dpop proof in
   OUnit2.assert_equal (Some "server-nonce") claims.nonce;
@@ -419,7 +430,8 @@ let test_par_token_loop_retries_nonce _ =
     Oauth.exchange_code ~http ~priv ~pub
       ~token_url:"https://bsky.social/oauth/token" ~form:token_form ()
   in
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "did:plc:7iza6de2dwap2sbkpav7c6c6" token.sub;
   let headers =
     Oauth.resource_request_headers ~priv ~pub ~htm:"GET"
@@ -446,8 +458,7 @@ let test_live_as_metadata _ =
         let headers =
           Atproto.Cohttp_client.Cohttp_client.create_headers_from_pairs
             [
-              Atproto.Cohttp_client.Cohttp_client
-              .application_json_setting_tuple;
+              Atproto.Cohttp_client.Cohttp_client.application_json_setting_tuple;
             ]
         in
         let body =
@@ -457,8 +468,9 @@ let test_live_as_metadata _ =
         in
         let meta = Oauth.parse_as_metadata (Yojson.Safe.from_string body) in
         Oauth.validate_as_metadata meta;
-        OUnit2.assert_equal ~printer:(fun x -> x) "https://bsky.social"
-          meta.issuer
+        OUnit2.assert_equal
+          ~printer:(fun x -> x)
+          "https://bsky.social" meta.issuer
       with exn ->
         skip_if true
           ("oauth authorization-server metadata skipped: "

--- a/test/test_repo.ml
+++ b/test/test_repo.ml
@@ -2,6 +2,7 @@ open OUnit2
 open Atproto.Session
 open Atproto.Auth
 open Atproto.Repo
+open Atproto.Tid
 
 let create_test_session _ =
   let username, password = Auth.username_and_password_from_env in
@@ -24,5 +25,82 @@ let test_create_record _ =
   let created_record = Repo.create_record test_session "david-engelmann.bsky.social"
 *)
 
-let suite = "suite" >::: [ "test_describe_repo" >:: test_describe_repo ]
+let test_apply_writes_body _ =
+  let rkey = Tid.create ~clock_id:1 1_700_000_000_000_000L in
+  let body =
+    Repo.apply_writes_body ~repo:"did:plc:7iza6de2dwap2sbkpav7c6c6"
+      ~swap_commit:"bafyreihdummy"
+      ~writes:
+        [
+          Repo.Create
+            {
+              collection = "app.bsky.feed.post";
+              rkey = Some rkey;
+              value = `Assoc [ ("text", `String "hi"); ("$type", `String "app.bsky.feed.post") ];
+            };
+          Repo.Update
+            {
+              collection = "app.bsky.actor.profile";
+              rkey = "self";
+              value = `Assoc [ ("displayName", `String "Ada") ];
+            };
+          Repo.Delete { collection = "app.bsky.feed.like"; rkey = "3jzfcijpj2z2a" };
+        ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "did:plc:7iza6de2dwap2sbkpav7c6c6"
+    (body |> member "repo" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x) "bafyreihdummy"
+    (body |> member "swapCommit" |> to_string);
+  let writes = body |> member "writes" |> to_list in
+  OUnit2.assert_equal 3 (List.length writes);
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "com.atproto.repo.applyWrites#create"
+    (List.nth writes 0 |> member "$type" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "com.atproto.repo.applyWrites#update"
+    (List.nth writes 1 |> member "$type" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x)
+    "com.atproto.repo.applyWrites#delete"
+    (List.nth writes 2 |> member "$type" |> to_string);
+  OUnit2.assert_equal ~printer:(fun x -> x) rkey
+    (List.nth writes 0 |> member "rkey" |> to_string)
+
+let test_parse_blob_ref _ =
+  let json =
+    `Assoc
+      [
+        ( "blob",
+          `Assoc
+            [
+              ("$type", `String "blob");
+              ( "ref",
+                `Assoc
+                  [
+                    ( "$link",
+                      `String
+                        "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+                    );
+                  ] );
+              ("mimeType", `String "image/png");
+              ("size", `Int 1234);
+            ] );
+      ]
+  in
+  let blob = Repo.parse_blob_ref json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "image/png" blob.mime_type;
+  OUnit2.assert_equal ~printer:string_of_int 1234 blob.size;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku" blob.cid
+
+let suite =
+  "suite"
+  >::: [
+         "test_describe_repo" >:: test_describe_repo;
+         "test_apply_writes_body" >:: test_apply_writes_body;
+         "test_parse_blob_ref" >:: test_parse_blob_ref;
+       ]
 let () = run_test_tt_main suite

--- a/test/test_repo.ml
+++ b/test/test_repo.ml
@@ -36,7 +36,12 @@ let test_apply_writes_body _ =
             {
               collection = "app.bsky.feed.post";
               rkey = Some rkey;
-              value = `Assoc [ ("text", `String "hi"); ("$type", `String "app.bsky.feed.post") ];
+              value =
+                `Assoc
+                  [
+                    ("text", `String "hi");
+                    ("$type", `String "app.bsky.feed.post");
+                  ];
             };
           Repo.Update
             {
@@ -44,28 +49,37 @@ let test_apply_writes_body _ =
               rkey = "self";
               value = `Assoc [ ("displayName", `String "Ada") ];
             };
-          Repo.Delete { collection = "app.bsky.feed.like"; rkey = "3jzfcijpj2z2a" };
+          Repo.Delete
+            { collection = "app.bsky.feed.like"; rkey = "3jzfcijpj2z2a" };
         ]
       ()
   in
   let open Yojson.Safe.Util in
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "did:plc:7iza6de2dwap2sbkpav7c6c6"
     (body |> member "repo" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x) "bafyreihdummy"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bafyreihdummy"
     (body |> member "swapCommit" |> to_string);
   let writes = body |> member "writes" |> to_list in
   OUnit2.assert_equal 3 (List.length writes);
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "com.atproto.repo.applyWrites#create"
     (List.nth writes 0 |> member "$type" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "com.atproto.repo.applyWrites#update"
     (List.nth writes 1 |> member "$type" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x)
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
     "com.atproto.repo.applyWrites#delete"
     (List.nth writes 2 |> member "$type" |> to_string);
-  OUnit2.assert_equal ~printer:(fun x -> x) rkey
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    rkey
     (List.nth writes 0 |> member "rkey" |> to_string)
 
 let test_parse_blob_ref _ =
@@ -103,4 +117,5 @@ let suite =
          "test_apply_writes_body" >:: test_apply_writes_body;
          "test_parse_blob_ref" >:: test_parse_blob_ref;
        ]
+
 let () = run_test_tt_main suite

--- a/test/test_tid.ml
+++ b/test/test_tid.ml
@@ -7,7 +7,9 @@ let test_zero _ =
 
 let test_official_example _ =
   OUnit2.assert_bool "3jzfcijpj2z2a" (Tid.is_valid "3jzfcijpj2z2a");
-  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "3jzfcijpj2z2a"
     (Tid.of_string "3jzfcijpj2z2a")
 
 let test_roundtrip _ =

--- a/test/test_tid.ml
+++ b/test/test_tid.ml
@@ -1,0 +1,74 @@
+open OUnit2
+open Atproto.Tid
+
+let test_zero _ =
+  OUnit2.assert_equal ~printer:(fun x -> x) Tid.zero (Tid.of_int64 0L);
+  OUnit2.assert_equal ~printer:Int64.to_string 0L (Tid.to_int64 Tid.zero)
+
+let test_official_example _ =
+  OUnit2.assert_bool "3jzfcijpj2z2a" (Tid.is_valid "3jzfcijpj2z2a");
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a"
+    (Tid.of_string "3jzfcijpj2z2a")
+
+let test_roundtrip _ =
+  let samples = [ 0L; 1L; 1024L; 1_700_000_000_000_000L; Int64.max_int ] in
+  List.iter
+    (fun n ->
+      let encoded = Tid.of_int64 n in
+      OUnit2.assert_equal 13 (String.length encoded);
+      OUnit2.assert_bool encoded (Tid.is_valid encoded);
+      let decoded = Tid.to_int64 encoded in
+      let expected = Int64.logand n 0x7FFF_FFFF_FFFF_FFFFL in
+      OUnit2.assert_equal ~printer:Int64.to_string expected decoded)
+    samples
+
+let test_timestamp_and_clock _ =
+  let tid = Tid.create ~clock_id:42 1_700_000_000_000_123L in
+  OUnit2.assert_equal ~printer:Int64.to_string 1_700_000_000_000_123L
+    (Tid.timestamp_us tid);
+  OUnit2.assert_equal ~printer:string_of_int 42 (Tid.clock_id tid)
+
+let test_sorts_with_time _ =
+  let older = Tid.create ~clock_id:0 1000L in
+  let newer = Tid.create ~clock_id:0 2000L in
+  OUnit2.assert_bool "string order matches time" (older < newer)
+
+let test_rejects_bad_syntax _ =
+  let bad =
+    [
+      "";
+      "short";
+      "22222222222221";
+      "l234567abcdef";
+      "k234567abcdef";
+      "3jzfcijpj2z2A";
+    ]
+  in
+  List.iter
+    (fun s ->
+      OUnit2.assert_bool ("accepted " ^ s) (not (Tid.is_valid s));
+      OUnit2.assert_bool ("of_string " ^ s)
+        (try
+           ignore (Tid.of_string s);
+           false
+         with Tid.Invalid _ -> true))
+    bad
+
+let test_now_is_valid _ =
+  Random.init 7;
+  let tid = Tid.now ~clock_id:1 () in
+  OUnit2.assert_bool tid (Tid.is_valid tid)
+
+let suite =
+  "tid"
+  >::: [
+         "test_zero" >:: test_zero;
+         "test_official_example" >:: test_official_example;
+         "test_roundtrip" >:: test_roundtrip;
+         "test_timestamp_and_clock" >:: test_timestamp_and_clock;
+         "test_sorts_with_time" >:: test_sorts_with_time;
+         "test_rejects_bad_syntax" >:: test_rejects_bad_syntax;
+         "test_now_is_valid" >:: test_now_is_valid;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks on #71.

This slice adds leftover protocol cores so the library is closer to complete (no hosted public client, no invented Bluesky credentials):

- **OAuth client-metadata** — public and confidential (`private_key_jwt` + JWKS) documents, localhost virtual metadata, `dpop_bound_access_tokens`, validate (including reject private `d` in JWKS)
- **AS / protected-resource metadata** — parse + atproto-profile checks (`require_pushed_authorization_requests`, `S256`, `ES256`, `atproto` scope, `iss` on redirect)
- **Redirect + authorize URL** — parse `code`/`state`/`iss` or `error`, enforce state/issuer, build `authorization_endpoint?client_id=&request_uri=`
- **PAR + token loop** — DPoP `nonce` claim, `use_dpop_nonce` retry, injectable HTTP `push_authorization` / `exchange_code` / `refresh`, token parse (`token_type=DPoP`, `sub` DID, granted `atproto` scope), `Authorization: DPoP` resource headers, ES256 client assertion
- **TID** — official base32-sortable syntax (`3jzfcijpj2z2a`, zero = `2222222222222`), timestamp/clock-id, sort order
- **Signed repo commits** — p256/k256 sign + verify over unsigned DAG-CBOR (`sig` omitted), high-S / missing / wrong-key paths
- **Repo / label leftovers** — `applyWrites` create/update/delete bodies, `uploadBlob` parse, `queryLabels` parse (`ver`/`exp`)
- **Firehose tests** — `#sync` / `#account` / `#info` decode

`dune build` and `dune runtest` pass locally. Auth suites still skip without real `ATP_AUTH`. Live AS metadata fetch against `bsky.social` ran successfully in this environment. GitHub Action majors stay at checkout@v4, setup-ocaml@v3, cache@v4, upload-artifact@v4.

Hosting a public client-metadata URL and completing a live browser login remain application-level.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efa2a522-a247-4ceb-a0f7-891e7b89880b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efa2a522-a247-4ceb-a0f7-891e7b89880b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

