### PR TITLE
Syntax, XRPC headers, signed labels, and remaining sync/identity APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,32 +31,34 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 
 | Area | Module | Notes |
 | --- | --- | --- |
+| Syntax | `Syntax` | Handle, DID, NSID, record key, datetime, language, at-identifier |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
 | AppView | `Actor`, `Feed`, `Graph`, `Notification` | Profiles, search (`q`), follows/blocks/mutes |
-| Repo writes | `Repo` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; `uploadBlob` parse |
-| Server | `Server` | describe server, app passwords, invites |
-| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | `resolveHandle`, `did:plc`, `did:web` (including `%3A` ports), `did:key` |
-| PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
-| Sync | `Sync` | Current `getLatestCommit`, `getRepo` (CAR), `listBlobs`, `listRepos` |
+| Repo writes | `Repo` | `createRecord` / `putRecord` / `applyWrites` / `uploadBlob` / `listMissingBlobs` / `importRepo` |
+| Server | `Server` | describe server, app passwords, invites, `getServiceAuth`, account status |
+| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | `resolveHandle` / `resolveIdentity`, `did:plc`, `did:web`, `did:key` |
+| PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 + k256 ECDSA (low-S, IEEE P1363) |
+| Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), `listBlobs`, `listRepos`, `getRepoStatus`, `listHosts`, `listReposByCollection` |
 | CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1 |
-| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff inversion, p256/k256 commit sign+verify |
-| TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
+| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff invert |
 | AT URI | `At_uri` | `at://` parse / serialize |
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON, `to_ocaml` codegen, JSON validate |
-| Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
-| OAuth / DPoP | `Oauth` | PKCE S256, DPoP ES256 + nonce, client metadata, AS/resource metadata, redirect callback, PAR/token loop (injectable HTTP) |
-| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) |
-| Errors | `Error` | XRPC `{error, message}` including rate limits |
+| Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode + commit verify |
+| Labels | `Label` | `queryLabels` parse, signed labels (p256/k256), `subscribeLabels` frames |
+| XRPC | `Xrpc`, `Error` | `atproto-proxy`, accept/content-labelers, rate-limit headers, service-auth JWT |
+| OAuth / DPoP | `Oauth` | PKCE S256, DPoP ES256, PAR/token request shapes |
+| TID | `Tid` | Timestamp identifiers |
+| Signed commits | `Mst` | Repo commit sign/verify (p256/k256) |
 
 ## Remaining gaps
 
-These are product-level, not missing protocol cores:
+The protocol core is complete. Leftovers are product / application-level:
 
-- Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
-
-PLC k256 verify, MST firehose-diff inversion, signed-commit verify, and OAuth client-metadata / PAR+token loop are implemented in this stack (#70 / #71 / this slice).
-
-Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
+- OAuth **browser redirect / client-metadata hosting / live token loop** against a PDS (PKCE + DPoP + PAR encoding and ES256 proofs are implemented)
+- Hosting a public client-metadata URL or completing a live browser login
+- AppView product surfaces beyond the existing profile / feed / graph / notification helpers
+- Admin / ozone moderation dashboards (createReport + labeler proxy headers are implemented)
+- Live `getServiceAuth` against a real PDS (JWT parse and request shape are implemented; skipped without `ATP_AUTH`)
 
 ## Sample usage
 
@@ -67,18 +69,13 @@ let commit = Sync.get_latest_commit did
 let doc = Did_plc.resolve did
 let ident = Identity.resolve "jay.bsky.team"
 
+(* syntax — official spec vectors *)
+let () = assert (Syntax.is_valid_nsid "com.atproto.sync.getRecord")
+let () = assert (Syntax.is_valid_handle "jay.bsky.team")
+let () = assert (Syntax.is_valid_datetime "1985-04-12T23:20:50.123Z")
+
 (* MST layer for a repo key — official vector *)
 let () = assert (Mst.layer_for_key "blue" = 1)
-
-(* TID used as record keys and commit revs *)
-let () = assert (Tid.is_valid "3jzfcijpj2z2a")
-
-(* OAuth client metadata + authorize URL (no hosted client required) *)
-let meta =
-  Oauth.public_metadata
-    ~client_id:"https://client.example/client-metadata.json"
-    ~redirect_uris:[ "https://client.example/cb" ] ()
-let _ = Oauth.validate_metadata meta
 
 (* firehose: one subscribeRepos frame from the public relay *)
 let _header, msg = Firehose.subscribe_one ()

--- a/src/dune
+++ b/src/dune
@@ -63,7 +63,9 @@
   Server
   Session
   Sync
+  Syntax
   Tid
   User
   Varint
-  Websocket))
+  Websocket
+  Xrpc))

--- a/src/identity.ml
+++ b/src/identity.ml
@@ -132,8 +132,7 @@ module Identity = struct
     let open Yojson.Safe.Util in
     {
       did = json |> member "did" |> to_string;
-      handle =
-        (match json |> member "handle" with `String s -> s | _ -> "");
+      handle = (match json |> member "handle" with `String s -> s | _ -> "");
       did_doc =
         (match json |> member "didDoc" with
         | `Null -> None
@@ -186,8 +185,7 @@ module Identity = struct
       @ (match verification_methods with
         | Some v -> [ ("verificationMethods", v) ]
         | None -> [])
-      @
-      match services with Some s -> [ ("services", s) ] | None -> []
+      @ match services with Some s -> [ ("services", s) ] | None -> []
     in
     `Assoc fields
 

--- a/src/identity.ml
+++ b/src/identity.ml
@@ -121,4 +121,81 @@ module Identity = struct
           pds = Did_plc.Did_plc.pds_endpoint doc;
         }
       else { did; handle = Some actor; pds = None }
+
+  type identity_info = {
+    did : string;
+    handle : string;
+    did_doc : Yojson.Safe.t option;
+  }
+
+  let parse_identity_info json : identity_info =
+    let open Yojson.Safe.Util in
+    {
+      did = json |> member "did" |> to_string;
+      handle =
+        (match json |> member "handle" with `String s -> s | _ -> "");
+      did_doc =
+        (match json |> member "didDoc" with
+        | `Null -> None
+        | `Assoc _ as doc -> Some doc
+        | _ -> None);
+    }
+
+  let resolve_identity ?host ?session (identifier : string) : identity_info =
+    get_json ?host ?session
+      (create_identity_endpoint "resolveIdentity")
+      [ ("identifier", identifier) ]
+    |> parse_identity_info
+
+  let update_handle_body (handle : string) : Yojson.Safe.t =
+    `Assoc [ ("handle", `String handle) ]
+
+  type recommended_did_credentials = {
+    rotation_keys : string list;
+    also_known_as : string list;
+    verification_methods : Yojson.Safe.t;
+    services : Yojson.Safe.t;
+  }
+
+  let parse_recommended_did_credentials json : recommended_did_credentials =
+    let open Yojson.Safe.Util in
+    let strings field =
+      match json |> member field with
+      | `List items ->
+          List.filter_map (function `String s -> Some s | _ -> None) items
+      | _ -> []
+    in
+    {
+      rotation_keys = strings "rotationKeys";
+      also_known_as = strings "alsoKnownAs";
+      verification_methods = json |> member "verificationMethods";
+      services = json |> member "services";
+    }
+
+  let sign_plc_operation_body ?token ?rotation_keys ?also_known_as
+      ?verification_methods ?services () : Yojson.Safe.t =
+    let str_list xs = `List (List.map (fun s -> `String s) xs) in
+    let fields =
+      (match token with Some t -> [ ("token", `String t) ] | None -> [])
+      @ (match rotation_keys with
+        | Some ks -> [ ("rotationKeys", str_list ks) ]
+        | None -> [])
+      @ (match also_known_as with
+        | Some aka -> [ ("alsoKnownAs", str_list aka) ]
+        | None -> [])
+      @ (match verification_methods with
+        | Some v -> [ ("verificationMethods", v) ]
+        | None -> [])
+      @
+      match services with Some s -> [ ("services", s) ] | None -> []
+    in
+    `Assoc fields
+
+  let submit_plc_operation_body (operation : Yojson.Safe.t) : Yojson.Safe.t =
+    `Assoc [ ("operation", operation) ]
+
+  let handle_txt_name = Syntax.Syntax.handle_txt_name
+  let parse_txt_did = Syntax.Syntax.parse_txt_did
+  let handle_well_known_url = Syntax.Syntax.handle_well_known_url
+  let parse_well_known_did = Syntax.Syntax.parse_well_known_did
 end

--- a/src/label.ml
+++ b/src/label.ml
@@ -191,7 +191,8 @@ module Label = struct
     | Some sig_ ->
         let unsigned = Dag_cbor.decode (encode_unsigned l) in
         let fields = Dag_cbor.get_map unsigned in
-        Dag_cbor.encode (Dag_cbor.Map (fields @ [ ("sig", Dag_cbor.Bytes sig_) ]))
+        Dag_cbor.encode
+          (Dag_cbor.Map (fields @ [ ("sig", Dag_cbor.Bytes sig_) ]))
 
   type sig_status =
     [ `Valid | `Invalid | `Unsupported_curve of string | `Missing ]
@@ -236,8 +237,9 @@ module Label = struct
                       | _ -> None)
                     parsed
                 in
-                match other with Some c -> `Unsupported_curve c | None -> `Invalid
-                )
+                match other with
+                | Some c -> `Unsupported_curve c
+                | None -> `Invalid)
             | k :: rest -> (
                 match k.Did_key.curve with
                 | Did_key.P256 -> (
@@ -266,9 +268,7 @@ module Label = struct
   let json_of_label (l : label) : Yojson.Safe.t =
     let fields =
       [
-        ("src", `String l.src);
-        ("uri", `String l.uri);
-        ("val", `String l.val_);
+        ("src", `String l.src); ("uri", `String l.uri); ("val", `String l.val_);
       ]
       @ (match l.ver with Some n -> [ ("ver", `Int n) ] | None -> [])
       @ (match l.cid with Some c -> [ ("cid", `String c) ] | None -> [])
@@ -286,7 +286,6 @@ module Label = struct
   (* ---- subscribeLabels ------------------------------------------------- *)
 
   type header = { op : int; t : string option }
-
   type labels_msg = { seq : int64; labels : label list }
   type info = { name : string; message : string option }
 

--- a/src/label.ml
+++ b/src/label.ml
@@ -1,6 +1,12 @@
 open Session
 open Cohttp_client
 open App
+open Dag_cbor
+open Base64url
+open Hash
+open Did_key
+
+let ensure_rng = lazy (Mirage_crypto_rng_unix.use_default ())
 
 module Label = struct
   type label = {
@@ -12,7 +18,17 @@ module Label = struct
     cts : string option;
     exp : string option;
     ver : int option;
+    sig_ : string option;
   }
+
+  let bytes_of_json json =
+    match json with
+    | `Assoc fields -> (
+        match List.assoc_opt "$bytes" fields with
+        | Some (`String s) -> Some (Base64url.decode s)
+        | _ -> None)
+    | `String s -> Some (Base64url.decode s)
+    | _ -> None
 
   let parse_label json : label =
     let open Yojson.Safe.Util in
@@ -25,6 +41,39 @@ module Label = struct
       cts = (match json |> member "cts" with `String s -> Some s | _ -> None);
       exp = (match json |> member "exp" with `String s -> Some s | _ -> None);
       ver = (match json |> member "ver" with `Int n -> Some n | _ -> None);
+      sig_ = bytes_of_json (json |> member "sig");
+    }
+
+  let parse_label_cbor (v : Dag_cbor.value) : label =
+    let fields = Dag_cbor.get_map v in
+    {
+      src = Dag_cbor.as_text (Dag_cbor.require "src" fields);
+      uri = Dag_cbor.as_text (Dag_cbor.require "uri" fields);
+      cid =
+        (match Dag_cbor.find "cid" fields with
+        | Some (Dag_cbor.Text s) -> Some s
+        | _ -> None);
+      val_ = Dag_cbor.as_text (Dag_cbor.require "val" fields);
+      neg =
+        (match Dag_cbor.find "neg" fields with
+        | Some b -> Some (Dag_cbor.as_bool b)
+        | None -> None);
+      cts =
+        (match Dag_cbor.find "cts" fields with
+        | Some t -> Some (Dag_cbor.as_text t)
+        | None -> None);
+      exp =
+        (match Dag_cbor.find "exp" fields with
+        | Some t -> Some (Dag_cbor.as_text t)
+        | None -> None);
+      ver =
+        (match Dag_cbor.find "ver" fields with
+        | Some n -> Some (Dag_cbor.as_int n)
+        | None -> None);
+      sig_ =
+        (match Dag_cbor.find "sig" fields with
+        | Some (Dag_cbor.Bytes b) -> Some b
+        | _ -> None);
     }
 
   type query_labels = { cursor : string option; labels : label list }
@@ -61,6 +110,20 @@ module Label = struct
   let create_label_endpoint (query_name : string) : string =
     "com.atproto.label" ^ "." ^ query_name
 
+  let query_labels_body ?(uri_patterns = []) ?sources ?limit ?cursor () :
+      (string * string) list =
+    let pairs =
+      List.map (fun p -> ("uriPatterns", p)) uri_patterns
+      @ (match sources with
+        | Some srcs -> List.map (fun s -> ("sources", s)) srcs
+        | None -> [])
+      @ (match limit with
+        | Some n -> [ ("limit", string_of_int n) ]
+        | None -> [])
+      @ match cursor with Some c -> [ ("cursor", c) ] | None -> []
+    in
+    pairs
+
   (* List of AT URI patterns to match (boolean 'OR'). Each may
    * be a prefix (ending with '*'; will match inclusive of the string leading to
    * '*'), or a full URI *)
@@ -81,4 +144,243 @@ module Label = struct
            headers)
     in
     labels
+
+  let query_labels_parsed (s : Session.session) ~uri_patterns ?sources ?limit
+      ?cursor () : query_labels =
+    let bearer_token = Session.bearer_token_from_session s in
+    let application_json = Cohttp_client.application_json_setting_tuple in
+    let headers =
+      Cohttp_client.create_headers_from_pairs [ application_json; bearer_token ]
+    in
+    let base_url = App.create_base_url s in
+    let url =
+      App.create_endpoint_url base_url (create_label_endpoint "queryLabels")
+    in
+    let body =
+      Cohttp_client.create_body_from_pairs
+        (query_labels_body ~uri_patterns ?sources ?limit ?cursor ())
+    in
+    let resp =
+      Lwt_main.run
+        (Cohttp_client.get_request_with_body_and_headers url body headers)
+    in
+    parse_query_labels (Yojson.Safe.from_string resp)
+
+  (* ---- signed labels (com.atproto.label.defs#label) -------------------- *)
+
+  let encode_unsigned (l : label) : string =
+    let fields =
+      [
+        ("src", Dag_cbor.Text l.src);
+        ("uri", Dag_cbor.Text l.uri);
+        ("val", Dag_cbor.Text l.val_);
+        ("ver", Dag_cbor.Int (Option.value ~default:1 l.ver));
+      ]
+      @ (match l.cid with Some c -> [ ("cid", Dag_cbor.Text c) ] | None -> [])
+      @ (match l.neg with
+        | Some true -> [ ("neg", Dag_cbor.Bool true) ]
+        | _ -> [])
+      @ (match l.cts with Some t -> [ ("cts", Dag_cbor.Text t) ] | None -> [])
+      @ match l.exp with Some t -> [ ("exp", Dag_cbor.Text t) ] | None -> []
+    in
+    Dag_cbor.encode (Dag_cbor.Map fields)
+
+  let encode_signed (l : label) : string =
+    match l.sig_ with
+    | None -> encode_unsigned l
+    | Some sig_ ->
+        let unsigned = Dag_cbor.decode (encode_unsigned l) in
+        let fields = Dag_cbor.get_map unsigned in
+        Dag_cbor.encode (Dag_cbor.Map (fields @ [ ("sig", Dag_cbor.Bytes sig_) ]))
+
+  type sig_status =
+    [ `Valid | `Invalid | `Unsupported_curve of string | `Missing ]
+
+  let sign_p256 ~(priv : Mirage_crypto_ec.P256.Dsa.priv) (l : label) : label =
+    Lazy.force ensure_rng;
+    let digest = Hash.sha256 (encode_unsigned l) in
+    let r, s = Mirage_crypto_ec.P256.Dsa.sign ~key:priv digest in
+    let s =
+      if String.compare s Did_plc.Did_plc.p256_n_half > 0 then
+        Did_plc.Did_plc.sub_be Did_plc.Did_plc.p256_n s
+      else s
+    in
+    { l with ver = Some (Option.value ~default:1 l.ver); sig_ = Some (r ^ s) }
+
+  let sign_k256 ~(priv : K256.K256.priv) (l : label) : label =
+    let digest = Hash.sha256 (encode_unsigned l) in
+    let r, s = K256.K256.sign ~key:priv digest in
+    { l with ver = Some (Option.value ~default:1 l.ver); sig_ = Some (r ^ s) }
+
+  let verify_with_keys ~(keys : string list) (l : label) : sig_status =
+    match l.sig_ with
+    | None -> `Missing
+    | Some raw ->
+        if String.length raw <> 64 then `Invalid
+        else
+          let r = String.sub raw 0 32 in
+          let s = String.sub raw 32 32 in
+          let digest = Hash.sha256 (encode_unsigned l) in
+          let parsed =
+            List.filter_map
+              (fun k -> try Some (Did_key.of_string k) with _ -> None)
+              keys
+          in
+          let rec try_keys = function
+            | [] -> (
+                let other =
+                  List.find_map
+                    (fun k ->
+                      match k.Did_key.curve with
+                      | Did_key.Other n -> Some (Printf.sprintf "0x%x" n)
+                      | _ -> None)
+                    parsed
+                in
+                match other with Some c -> `Unsupported_curve c | None -> `Invalid
+                )
+            | k :: rest -> (
+                match k.Did_key.curve with
+                | Did_key.P256 -> (
+                    match Did_key.p256_pub k with
+                    | Some pub ->
+                        if
+                          Did_plc.Did_plc.is_low_s s
+                          && Mirage_crypto_ec.P256.Dsa.verify ~key:pub (r, s)
+                               digest
+                        then `Valid
+                        else try_keys rest
+                    | None -> try_keys rest)
+                | Did_key.K256 -> (
+                    match Did_key.k256_pub k with
+                    | Some pub ->
+                        if
+                          K256.K256.is_low_s s
+                          && K256.K256.verify ~key:pub (r, s) digest
+                        then `Valid
+                        else try_keys rest
+                    | None -> try_keys rest)
+                | Did_key.Other _ -> try_keys rest)
+          in
+          try_keys parsed
+
+  let json_of_label (l : label) : Yojson.Safe.t =
+    let fields =
+      [
+        ("src", `String l.src);
+        ("uri", `String l.uri);
+        ("val", `String l.val_);
+      ]
+      @ (match l.ver with Some n -> [ ("ver", `Int n) ] | None -> [])
+      @ (match l.cid with Some c -> [ ("cid", `String c) ] | None -> [])
+      @ (match l.neg with Some b -> [ ("neg", `Bool b) ] | None -> [])
+      @ (match l.cts with Some t -> [ ("cts", `String t) ] | None -> [])
+      @ (match l.exp with Some t -> [ ("exp", `String t) ] | None -> [])
+      @
+      match l.sig_ with
+      | Some b ->
+          [ ("sig", `Assoc [ ("$bytes", `String (Base64url.encode_std b)) ]) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  (* ---- subscribeLabels ------------------------------------------------- *)
+
+  type header = { op : int; t : string option }
+
+  type labels_msg = { seq : int64; labels : label list }
+  type info = { name : string; message : string option }
+
+  type message =
+    [ `Labels of labels_msg
+    | `Info of info
+    | `Error of string * string option
+    | `Unknown of string * Dag_cbor.value ]
+
+  let subscribe_url ?(host = "bsky.network") ?cursor () =
+    let base =
+      Printf.sprintf "wss://%s/xrpc/com.atproto.label.subscribeLabels" host
+    in
+    match cursor with
+    | None -> base
+    | Some c -> base ^ "?cursor=" ^ Int64.to_string c
+
+  let parse_header (v : Dag_cbor.value) : header =
+    let fields = Dag_cbor.get_map v in
+    {
+      op = Dag_cbor.as_int (Dag_cbor.require "op" fields);
+      t =
+        (match Dag_cbor.find "t" fields with
+        | Some (Dag_cbor.Text s) -> Some s
+        | _ -> None);
+    }
+
+  let parse_labels_msg (v : Dag_cbor.value) : labels_msg =
+    let fields = Dag_cbor.get_map v in
+    {
+      seq = Dag_cbor.as_int64 (Dag_cbor.require "seq" fields);
+      labels =
+        (match Dag_cbor.find "labels" fields with
+        | Some a -> List.map parse_label_cbor (Dag_cbor.as_array a)
+        | None -> []);
+    }
+
+  let decode_frame (bytes : string) : header * message =
+    match Dag_cbor.decode_sequence bytes with
+    | header_v :: body :: _ ->
+        let header = parse_header header_v in
+        let message =
+          if header.op = -1 then
+            let fields = Dag_cbor.get_map body in
+            let err =
+              match Dag_cbor.find "error" fields with
+              | Some (Dag_cbor.Text s) -> s
+              | _ -> "error"
+            in
+            let msg =
+              match Dag_cbor.find "message" fields with
+              | Some (Dag_cbor.Text s) -> Some s
+              | _ -> None
+            in
+            `Error (err, msg)
+          else
+            match header.t with
+            | Some "#labels" -> `Labels (parse_labels_msg body)
+            | Some "#info" ->
+                let fields = Dag_cbor.get_map body in
+                `Info
+                  {
+                    name = Dag_cbor.as_text (Dag_cbor.require "name" fields);
+                    message =
+                      (match Dag_cbor.find "message" fields with
+                      | Some (Dag_cbor.Text s) -> Some s
+                      | _ -> None);
+                  }
+            | Some other -> `Unknown (other, body)
+            | None -> `Unknown ("", body)
+        in
+        (header, message)
+    | _ -> failwith "Label.decode_frame: expected header and body CBOR values"
+
+  let encode_header (h : header) : string =
+    let fields =
+      ("op", Dag_cbor.Int h.op)
+      :: (match h.t with Some t -> [ ("t", Dag_cbor.Text t) ] | None -> [])
+    in
+    Dag_cbor.encode (Dag_cbor.Map fields)
+
+  let encode_labels_frame (m : labels_msg) : string =
+    let header = encode_header { op = 1; t = Some "#labels" } in
+    let body =
+      Dag_cbor.encode
+        (Dag_cbor.Map
+           [
+             ("seq", Dag_cbor.Int64 m.seq);
+             ( "labels",
+               Dag_cbor.Array
+                 (List.map
+                    (fun l -> Dag_cbor.decode (encode_signed l))
+                    m.labels) );
+           ])
+    in
+    header ^ body
 end

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -312,4 +312,61 @@ module Repo = struct
       Lwt_main.run (Cohttp_client.post_data_with_headers url bytes headers)
     in
     parse_blob_ref (Yojson.Safe.from_string body)
+
+  type missing_blob = { cid : string; record_uri : string }
+  type list_missing_blobs = { cursor : string option; blobs : missing_blob list }
+
+  let parse_missing_blob json : missing_blob =
+    let open Yojson.Safe.Util in
+    {
+      cid = (match json |> member "cid" with `String s -> s | _ -> "");
+      record_uri =
+        (match json |> member "recordUri" with `String s -> s | _ -> "");
+    }
+
+  let parse_list_missing_blobs json : list_missing_blobs =
+    let open Yojson.Safe.Util in
+    {
+      cursor =
+        (match json |> member "cursor" with `String s -> Some s | _ -> None);
+      blobs =
+        (match json |> member "blobs" with
+        | `List items -> List.map parse_missing_blob items
+        | _ -> []);
+    }
+
+  let list_missing_blobs (s : Session.session) ?cursor ?limit () :
+      list_missing_blobs =
+    let bearer_token = Session.bearer_token_from_session s in
+    let application_json = Cohttp_client.application_json_setting_tuple in
+    let headers =
+      Cohttp_client.create_headers_from_pairs [ application_json; bearer_token ]
+    in
+    let url =
+      App.create_endpoint_url (App.create_base_url s)
+        (create_repo_endpoint "listMissingBlobs")
+    in
+    let pairs =
+      (match cursor with Some c -> [ ("cursor", c) ] | None -> [])
+      @ match limit with Some n -> [ ("limit", string_of_int n) ] | None -> []
+    in
+    let body = Cohttp_client.create_body_from_pairs pairs in
+    let resp =
+      Lwt_main.run
+        (Cohttp_client.get_request_with_body_and_headers url body headers)
+    in
+    parse_list_missing_blobs (Yojson.Safe.from_string resp)
+
+  let import_repo_url (s : Session.session) : string =
+    App.create_endpoint_url (App.create_base_url s)
+      (create_repo_endpoint "importRepo")
+
+  let import_repo (s : Session.session) (car_bytes : string) : string =
+    let bearer_token = Session.bearer_token_from_session s in
+    let headers =
+      Cohttp_client.create_headers_from_pairs
+        [ ("Content-Type", "application/vnd.ipld.car"); bearer_token ]
+    in
+    let url = import_repo_url s in
+    Lwt_main.run (Cohttp_client.post_data_with_headers url car_bytes headers)
 end

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -314,7 +314,11 @@ module Repo = struct
     parse_blob_ref (Yojson.Safe.from_string body)
 
   type missing_blob = { cid : string; record_uri : string }
-  type list_missing_blobs = { cursor : string option; blobs : missing_blob list }
+
+  type list_missing_blobs = {
+    cursor : string option;
+    blobs : missing_blob list;
+  }
 
   let parse_missing_blob json : missing_blob =
     let open Yojson.Safe.Util in

--- a/src/server.ml
+++ b/src/server.ml
@@ -279,12 +279,8 @@ module Server = struct
 
   let get_service_auth_url ~aud ?lxm ?exp (s : Session.session) : string =
     let pairs =
-      ("aud", aud)
-      :: (match lxm with Some n -> [ ("lxm", n) ] | None -> [])
-      @
-      match exp with
-      | Some n -> [ ("exp", Int64.to_string n) ]
-      | None -> []
+      (("aud", aud) :: (match lxm with Some n -> [ ("lxm", n) ] | None -> []))
+      @ match exp with Some n -> [ ("exp", Int64.to_string n) ] | None -> []
     in
     let base =
       App.create_endpoint_url (App.create_base_url s)
@@ -321,9 +317,13 @@ module Server = struct
       valid_did =
         (match json |> member "validDid" with `Bool b -> Some b | _ -> None);
       expected_blobs =
-        (match json |> member "expectedBlobs" with `Int n -> Some n | _ -> None);
+        (match json |> member "expectedBlobs" with
+        | `Int n -> Some n
+        | _ -> None);
       imported_blobs =
-        (match json |> member "importedBlobs" with `Int n -> Some n | _ -> None);
+        (match json |> member "importedBlobs" with
+        | `Int n -> Some n
+        | _ -> None);
     }
 
   let deactivate_account_url (s : Session.session) : string =

--- a/src/server.ml
+++ b/src/server.ml
@@ -270,4 +270,71 @@ module Server = struct
            body headers)
     in
     revoke_app_password
+
+  type service_auth = { token : string }
+
+  let parse_service_auth json : service_auth =
+    let open Yojson.Safe.Util in
+    { token = json |> member "token" |> to_string }
+
+  let get_service_auth_url ~aud ?lxm ?exp (s : Session.session) : string =
+    let pairs =
+      ("aud", aud)
+      :: (match lxm with Some n -> [ ("lxm", n) ] | None -> [])
+      @
+      match exp with
+      | Some n -> [ ("exp", Int64.to_string n) ]
+      | None -> []
+    in
+    let base =
+      App.create_endpoint_url (App.create_base_url s)
+        (create_server_endpoint "getServiceAuth")
+    in
+    let qs = Cohttp_client.create_body_from_pairs pairs in
+    if qs = "" then base else base ^ "?" ^ qs
+
+  let get_service_auth (s : Session.session) ~aud ?lxm ?exp () : service_auth =
+    let _ = Xrpc.Xrpc.service_auth_body ~aud ?lxm ?exp () in
+    let bearer_token = Session.bearer_token_from_session s in
+    let application_json = Cohttp_client.application_json_setting_tuple in
+    let headers =
+      Cohttp_client.create_headers_from_pairs [ application_json; bearer_token ]
+    in
+    let url = get_service_auth_url ~aud ?lxm ?exp s in
+    let body =
+      Lwt_main.run (Cohttp_client.get_request_with_headers url headers)
+    in
+    parse_service_auth (Yojson.Safe.from_string body)
+
+  type account_status = {
+    activated : bool option;
+    valid_did : bool option;
+    expected_blobs : int option;
+    imported_blobs : int option;
+  }
+
+  let parse_account_status json : account_status =
+    let open Yojson.Safe.Util in
+    {
+      activated =
+        (match json |> member "activated" with `Bool b -> Some b | _ -> None);
+      valid_did =
+        (match json |> member "validDid" with `Bool b -> Some b | _ -> None);
+      expected_blobs =
+        (match json |> member "expectedBlobs" with `Int n -> Some n | _ -> None);
+      imported_blobs =
+        (match json |> member "importedBlobs" with `Int n -> Some n | _ -> None);
+    }
+
+  let deactivate_account_url (s : Session.session) : string =
+    App.create_endpoint_url (App.create_base_url s)
+      (create_server_endpoint "deactivateAccount")
+
+  let activate_account_url (s : Session.session) : string =
+    App.create_endpoint_url (App.create_base_url s)
+      (create_server_endpoint "activateAccount")
+
+  let check_account_status_url (s : Session.session) : string =
+    App.create_endpoint_url (App.create_base_url s)
+      (create_server_endpoint "checkAccountStatus")
 end

--- a/src/sync.ml
+++ b/src/sync.ml
@@ -246,8 +246,7 @@ module Sync = struct
     let open Yojson.Safe.Util in
     {
       did = json |> member "did" |> to_string;
-      active =
-        (match json |> member "active" with `Bool b -> b | _ -> false);
+      active = (match json |> member "active" with `Bool b -> b | _ -> false);
       status = string_opt json "status";
       rev = string_opt json "rev";
     }
@@ -263,7 +262,9 @@ module Sync = struct
         | `Intlit s -> Some (Int64.of_string s)
         | _ -> None);
       account_count =
-        (match json |> member "accountCount" with `Int n -> Some n | _ -> None);
+        (match json |> member "accountCount" with
+        | `Int n -> Some n
+        | _ -> None);
       status = string_opt json "status";
     }
 

--- a/src/sync.ml
+++ b/src/sync.ml
@@ -212,6 +212,124 @@ module Sync = struct
          [ ("cursor", cursor); ("limit", Option.map string_of_int limit) ])
     |> parse_list_repos
 
+  type repo_status = {
+    did : string;
+    active : bool;
+    status : string option;
+    rev : string option;
+  }
+
+  type host = {
+    hostname : string;
+    seq : int64 option;
+    account_count : int option;
+    status : string option;
+  }
+
+  type list_hosts = { cursor : string option; hosts : host list }
+
+  type host_status = {
+    hostname : string;
+    status : string option;
+    seq : int64 option;
+    account_count : int option;
+  }
+
+  type collection_repo = { did : string }
+
+  type list_repos_by_collection = {
+    cursor : string option;
+    repos : collection_repo list;
+  }
+
+  let parse_repo_status json : repo_status =
+    let open Yojson.Safe.Util in
+    {
+      did = json |> member "did" |> to_string;
+      active =
+        (match json |> member "active" with `Bool b -> b | _ -> false);
+      status = string_opt json "status";
+      rev = string_opt json "rev";
+    }
+
+  let parse_host json : host =
+    let open Yojson.Safe.Util in
+    {
+      hostname =
+        (match json |> member "hostname" with `String s -> s | _ -> "");
+      seq =
+        (match json |> member "seq" with
+        | `Int n -> Some (Int64.of_int n)
+        | `Intlit s -> Some (Int64.of_string s)
+        | _ -> None);
+      account_count =
+        (match json |> member "accountCount" with `Int n -> Some n | _ -> None);
+      status = string_opt json "status";
+    }
+
+  let parse_list_hosts json : list_hosts =
+    let open Yojson.Safe.Util in
+    {
+      cursor = string_opt json "cursor";
+      hosts =
+        (match json |> member "hosts" with
+        | `List items -> List.map parse_host items
+        | _ -> []);
+    }
+
+  let parse_host_status json : host_status =
+    let h = parse_host json in
+    {
+      hostname = h.hostname;
+      status = h.status;
+      seq = h.seq;
+      account_count = h.account_count;
+    }
+
+  let parse_list_repos_by_collection json : list_repos_by_collection =
+    let open Yojson.Safe.Util in
+    {
+      cursor = string_opt json "cursor";
+      repos =
+        (match json |> member "repos" with
+        | `List items ->
+            List.filter_map
+              (fun item ->
+                match item |> member "did" with
+                | `String did -> Some { did }
+                | _ -> None)
+              items
+        | _ -> []);
+    }
+
+  let get_repo_status ?host ?session (did : string) : repo_status =
+    request_json ?host ?session
+      (create_sync_endpoint "getRepoStatus")
+      [ ("did", did) ]
+    |> parse_repo_status
+
+  let list_hosts ?host ?session ?cursor ?limit () : list_hosts =
+    request_json ?host ?session
+      (create_sync_endpoint "listHosts")
+      (optional_pairs
+         [ ("cursor", cursor); ("limit", Option.map string_of_int limit) ])
+    |> parse_list_hosts
+
+  let get_host_status ?host ?session (hostname : string) : host_status =
+    request_json ?host ?session
+      (create_sync_endpoint "getHostStatus")
+      [ ("hostname", hostname) ]
+    |> parse_host_status
+
+  let list_repos_by_collection ?host ?session ?cursor ?limit
+      (collection : string) : list_repos_by_collection =
+    request_json ?host ?session
+      (create_sync_endpoint "listReposByCollection")
+      (("collection", collection)
+      :: optional_pairs
+           [ ("cursor", cursor); ("limit", Option.map string_of_int limit) ])
+    |> parse_list_repos_by_collection
+
   let request_crawl ?host ?session (hostname : string) : string =
     let host = host_of ?host session in
     let base_url = App.create_public_base_url ~host () in

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -8,17 +8,14 @@ module Syntax = struct
   exception Invalid of string
 
   let fail msg = raise (Invalid msg)
-
   let is_ascii_letter = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false
   let is_ascii_digit = function '0' .. '9' -> true | _ -> false
   let is_ascii_alpha = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false
-
   let is_ascii_alnum c = is_ascii_alpha c || is_ascii_digit c
 
   let ascii_lower s =
     String.map
-      (function
-        | 'A' .. 'Z' as c -> Char.chr (Char.code c + 32) | c -> c)
+      (function 'A' .. 'Z' as c -> Char.chr (Char.code c + 32) | c -> c)
       s
 
   let starts_with s prefix =
@@ -97,8 +94,7 @@ module Syntax = struct
   let did_max_len = 2048
 
   let is_did_char = function
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | ':' | '%' | '-' ->
-        true
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | ':' | '%' | '-' -> true
     | _ -> false
 
   let is_lower_letters s =
@@ -106,8 +102,7 @@ module Syntax = struct
     &&
     let rec loop i =
       if i >= String.length s then true
-      else
-        match s.[i] with 'a' .. 'z' -> loop (i + 1) | _ -> false
+      else match s.[i] with 'a' .. 'z' -> loop (i + 1) | _ -> false
     in
     loop 0
 
@@ -144,9 +139,7 @@ module Syntax = struct
       | _ -> None
 
   let is_blessed_did s =
-    match did_method s with
-    | Some "plc" | Some "web" -> true
-    | _ -> false
+    match did_method s with Some "plc" | Some "web" -> true | _ -> false
 
   (* ---- NSID ------------------------------------------------------------ *)
 
@@ -245,8 +238,7 @@ module Syntax = struct
   let record_key_max = 512
 
   let is_record_key_char = function
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '~' | '.' | ':' | '-' ->
-        true
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '~' | '.' | ':' | '-' -> true
     | _ -> false
 
   let is_valid_record_key (input : string) : bool =
@@ -269,16 +261,12 @@ module Syntax = struct
   let is_valid_at_identifier s = is_valid_did s || is_valid_handle s
 
   let ensure_at_identifier s =
-    if not (is_valid_at_identifier s) then
-      fail ("invalid at-identifier " ^ s)
+    if not (is_valid_at_identifier s) then fail ("invalid at-identifier " ^ s)
 
   (* ---- Datetime -------------------------------------------------------- *)
 
   let datetime_max_len = 64
-
-  let parse_int_slice s off len =
-    int_of_string (String.sub s off len)
-
+  let parse_int_slice s off len = int_of_string (String.sub s off len)
   let is_leap_year y = y mod 4 = 0 && (y mod 100 <> 0 || y mod 400 = 0)
 
   let days_in_month y m =
@@ -302,8 +290,7 @@ module Syntax = struct
     else if ends_with input "-00:00" then false
     else if
       not
-        (len >= 19
-        && is_digit_range input 0 4
+        (len >= 19 && is_digit_range input 0 4
         && input.[4] = '-'
         && is_digit_range input 5 2
         && input.[7] = '-'
@@ -346,9 +333,9 @@ module Syntax = struct
           in
           let frac_ok =
             frac = ""
-            || (String.length frac >= 2
+            || String.length frac >= 2
                && frac.[0] = '.'
-               && is_digit_range frac 1 (String.length frac - 1))
+               && is_digit_range frac 1 (String.length frac - 1)
           in
           if not frac_ok then false
           else
@@ -416,8 +403,7 @@ module Syntax = struct
     in
     loop 0
 
-  let is_digit_len s n =
-    String.length s = n && is_digit_range s 0 n
+  let is_digit_len s n = String.length s = n && is_digit_range s 0 n
 
   let grandfathered_tags =
     [
@@ -461,9 +447,7 @@ module Syntax = struct
         | first :: rest ->
             let private_only = ascii_lower first = "x" in
             let lang_ok =
-              private_only
-              || is_alpha_len first 2 3
-              || is_alpha_len first 4 4
+              private_only || is_alpha_len first 2 3 || is_alpha_len first 4 4
               || is_alpha_len first 5 8
             in
             if not lang_ok then false
@@ -492,19 +476,19 @@ module Syntax = struct
                     | `Variant_or_later ->
                         if
                           is_alnum_len p 5 8
-                          || (String.length p = 4 && is_ascii_digit p.[0]
-                             && is_alnum_len (String.sub p 1 3) 3 3)
+                          || String.length p = 4
+                             && is_ascii_digit p.[0]
+                             && is_alnum_len (String.sub p 1 3) 3 3
                         then consume `Variant_or_later ps
                         else consume `Extension_or_later (p :: ps)
                     | `Extension_or_later ->
-                        if String.length p = 1 && ascii_lower p <> "x"
-                        then consume (`Extension_rest 0) ps
+                        if String.length p = 1 && ascii_lower p <> "x" then
+                          consume (`Extension_rest 0) ps
                         else consume `Private (p :: ps)
                     | `Extension_rest n ->
                         if is_alnum_len p 2 8 then
                           consume (`Extension_rest (n + 1)) ps
-                        else if n >= 1 then
-                          consume `Extension_or_later (p :: ps)
+                        else if n >= 1 then consume `Extension_or_later (p :: ps)
                         else false
                     | `Private ->
                         if ascii_lower p = "x" then consume (`Private_rest 0) ps
@@ -515,8 +499,7 @@ module Syntax = struct
                         else false)
               in
               if private_only then consume (`Private_rest 0) rest
-              else if is_alpha_len first 2 3 then
-                consume `Extlang_or_later rest
+              else if is_alpha_len first 2 3 then consume `Extlang_or_later rest
               else consume `Script_or_later rest
 
   let ensure_language s =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -1,0 +1,546 @@
+(** AT Protocol identifier and string-format syntax.
+    https://atproto.com/specs/handle
+    https://atproto.com/specs/did
+    https://atproto.com/specs/nsid
+    https://atproto.com/specs/record-key
+    https://atproto.com/specs/lexicon#datetime *)
+module Syntax = struct
+  exception Invalid of string
+
+  let fail msg = raise (Invalid msg)
+
+  let is_ascii_letter = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false
+  let is_ascii_digit = function '0' .. '9' -> true | _ -> false
+  let is_ascii_alpha = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false
+
+  let is_ascii_alnum c = is_ascii_alpha c || is_ascii_digit c
+
+  let ascii_lower s =
+    String.map
+      (function
+        | 'A' .. 'Z' as c -> Char.chr (Char.code c + 32) | c -> c)
+      s
+
+  let starts_with s prefix =
+    let n = String.length prefix in
+    String.length s >= n && String.sub s 0 n = prefix
+
+  let ends_with s suffix =
+    let n = String.length suffix in
+    let len = String.length s in
+    len >= n && String.sub s (len - n) n = suffix
+
+  (* ---- Handle ---------------------------------------------------------- *)
+
+  let disallowed_tlds =
+    [
+      ".alt";
+      ".arpa";
+      ".example";
+      ".internal";
+      ".invalid";
+      ".local";
+      ".localhost";
+      ".onion";
+    ]
+
+  let handle_max_len = 253
+
+  let is_handle_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' -> true
+    | _ -> false
+
+  let is_valid_handle (input : string) : bool =
+    let len = String.length input in
+    if len = 0 || len > handle_max_len then false
+    else
+      let rec all_ok i =
+        if i >= len then true
+        else if is_handle_char input.[i] then all_ok (i + 1)
+        else false
+      in
+      if not (all_ok 0) then false
+      else
+        let labels = String.split_on_char '.' input in
+        let last = List.length labels - 1 in
+        if last < 1 then false
+        else
+          let rec check i = function
+            | [] -> true
+            | l :: rest ->
+                let n = String.length l in
+                if n < 1 || n > 63 then false
+                else if l.[0] = '-' || l.[n - 1] = '-' then false
+                else if i = last && not (is_ascii_letter l.[0]) then false
+                else check (i + 1) rest
+          in
+          check 0 labels
+
+  let ensure_handle s =
+    if not (is_valid_handle s) then fail ("invalid handle " ^ s)
+
+  let normalize_handle s = ascii_lower s
+
+  let normalize_and_ensure_handle s =
+    let n = normalize_handle s in
+    ensure_handle n;
+    n
+
+  let is_valid_tld (handle : string) : bool =
+    let lower = ascii_lower handle in
+    not (List.exists (fun tld -> ends_with lower tld) disallowed_tlds)
+
+  let invalid_handle = "handle.invalid"
+
+  (* ---- DID ------------------------------------------------------------- *)
+
+  let did_max_len = 2048
+
+  let is_did_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | ':' | '%' | '-' ->
+        true
+    | _ -> false
+
+  let is_lower_letters s =
+    String.length s > 0
+    &&
+    let rec loop i =
+      if i >= String.length s then true
+      else
+        match s.[i] with 'a' .. 'z' -> loop (i + 1) | _ -> false
+    in
+    loop 0
+
+  let is_valid_did (input : string) : bool =
+    let len = String.length input in
+    if len < 7 || len > did_max_len then false
+    else if not (starts_with input "did:") then false
+    else if input.[len - 1] = ':' || input.[len - 1] = '%' then false
+    else
+      let rec all_ok i =
+        if i >= len then true
+        else if is_did_char input.[i] then all_ok (i + 1)
+        else false
+      in
+      if not (all_ok 0) then false
+      else
+        match String.split_on_char ':' input with
+        | "did" :: method_ :: rest when rest <> [] ->
+            is_lower_letters method_
+            &&
+            let ident = String.concat ":" rest in
+            ident <> ""
+            && ident.[String.length ident - 1] <> ':'
+            && ident.[String.length ident - 1] <> '%'
+        | _ -> false
+
+  let ensure_did s = if not (is_valid_did s) then fail ("invalid DID " ^ s)
+
+  let did_method (input : string) : string option =
+    if not (is_valid_did input) then None
+    else
+      match String.split_on_char ':' input with
+      | "did" :: method_ :: _ -> Some method_
+      | _ -> None
+
+  let is_blessed_did s =
+    match did_method s with
+    | Some "plc" | Some "web" -> true
+    | _ -> false
+
+  (* ---- NSID ------------------------------------------------------------ *)
+
+  let nsid_max_len = 317
+
+  let is_nsid_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' -> true
+    | _ -> false
+
+  let is_valid_identifier_name (v : string) : bool =
+    String.length v > 0
+    && (not (is_ascii_digit v.[0]))
+    &&
+    let rec loop i =
+      if i >= String.length v then true
+      else if is_ascii_alnum v.[i] then loop (i + 1)
+      else false
+    in
+    loop 0
+
+  let is_valid_nsid (input : string) : bool =
+    let len = String.length input in
+    if len = 0 || len > nsid_max_len then false
+    else
+      let rec all_ok i =
+        if i >= len then true
+        else if is_nsid_char input.[i] then all_ok (i + 1)
+        else false
+      in
+      if not (all_ok 0) then false
+      else
+        let segments = String.split_on_char '.' input in
+        if List.length segments < 3 then false
+        else
+          let rec check = function
+            | [] -> true
+            | l :: rest ->
+                let n = String.length l in
+                if n < 1 || n > 63 then false
+                else if l.[0] = '-' || l.[n - 1] = '-' then false
+                else check rest
+          in
+          if not (check segments) then false
+          else if is_ascii_digit (List.hd segments).[0] then false
+          else is_valid_identifier_name (List.hd (List.rev segments))
+
+  let ensure_nsid s = if not (is_valid_nsid s) then fail ("invalid NSID " ^ s)
+
+  type nsid = { segments : string list }
+
+  let parse_nsid (input : string) : nsid =
+    ensure_nsid input;
+    { segments = String.split_on_char '.' input }
+
+  let nsid_name (n : nsid) : string = List.hd (List.rev n.segments)
+
+  (* DNS hostname form, matching @atproto/syntax (com.example.foo -> example.com). *)
+  let nsid_authority (n : nsid) : string =
+    n.segments |> List.rev |> List.tl |> String.concat "."
+
+  let nsid_authority_nsid (n : nsid) : string =
+    n.segments |> List.rev |> List.tl |> List.rev |> String.concat "."
+
+  let nsid_to_string (n : nsid) : string = String.concat "." n.segments
+
+  let create_nsid ~authority ~name : nsid =
+    let segs = List.rev (String.split_on_char '.' authority) @ [ name ] in
+    parse_nsid (String.concat "." segs)
+
+  let is_valid_nsid_glob (input : string) : bool =
+    if input = "*" then true
+    else if ends_with input ".*" then
+      let prefix = String.sub input 0 (String.length input - 2) in
+      (* authority-only glob: at least two segments *)
+      let segs = String.split_on_char '.' prefix in
+      List.length segs >= 2 && is_valid_nsid (prefix ^ ".x")
+    else false
+
+  type nsid_ref = { nsid : string; fragment : string option }
+
+  let parse_nsid_ref (input : string) : nsid_ref =
+    match String.index_opt input '#' with
+    | None ->
+        ensure_nsid input;
+        { nsid = input; fragment = None }
+    | Some i ->
+        let nsid = String.sub input 0 i in
+        let frag = String.sub input (i + 1) (String.length input - i - 1) in
+        ensure_nsid nsid;
+        if frag = "" || frag = "main" then
+          fail "NSID ref must not use an empty or #main fragment";
+        { nsid; fragment = Some frag }
+
+  (* ---- Record key ------------------------------------------------------ *)
+
+  let record_key_max = 512
+
+  let is_record_key_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '~' | '.' | ':' | '-' ->
+        true
+    | _ -> false
+
+  let is_valid_record_key (input : string) : bool =
+    let len = String.length input in
+    if len < 1 || len > record_key_max then false
+    else if input = "." || input = ".." then false
+    else
+      let rec loop i =
+        if i >= len then true
+        else if is_record_key_char input.[i] then loop (i + 1)
+        else false
+      in
+      loop 0
+
+  let ensure_record_key s =
+    if not (is_valid_record_key s) then fail ("invalid record key " ^ s)
+
+  (* ---- at-identifier (handle or DID) ----------------------------------- *)
+
+  let is_valid_at_identifier s = is_valid_did s || is_valid_handle s
+
+  let ensure_at_identifier s =
+    if not (is_valid_at_identifier s) then
+      fail ("invalid at-identifier " ^ s)
+
+  (* ---- Datetime -------------------------------------------------------- *)
+
+  let datetime_max_len = 64
+
+  let parse_int_slice s off len =
+    int_of_string (String.sub s off len)
+
+  let is_leap_year y = y mod 4 = 0 && (y mod 100 <> 0 || y mod 400 = 0)
+
+  let days_in_month y m =
+    match m with
+    | 1 | 3 | 5 | 7 | 8 | 10 | 12 -> 31
+    | 4 | 6 | 9 | 11 -> 30
+    | 2 -> if is_leap_year y then 29 else 28
+    | _ -> 0
+
+  let is_digit_range s off len =
+    let rec loop i =
+      if i >= len then true
+      else if is_ascii_digit s.[off + i] then loop (i + 1)
+      else false
+    in
+    loop 0
+
+  let is_valid_datetime (input : string) : bool =
+    let len = String.length input in
+    if len < 20 || len > datetime_max_len then false
+    else if ends_with input "-00:00" then false
+    else if
+      not
+        (len >= 19
+        && is_digit_range input 0 4
+        && input.[4] = '-'
+        && is_digit_range input 5 2
+        && input.[7] = '-'
+        && is_digit_range input 8 2
+        && input.[10] = 'T'
+        && is_digit_range input 11 2
+        && input.[13] = ':'
+        && is_digit_range input 14 2
+        && input.[16] = ':'
+        && is_digit_range input 17 2)
+    then false
+    else
+      try
+        let year = parse_int_slice input 0 4 in
+        let month = parse_int_slice input 5 2 in
+        let day = parse_int_slice input 8 2 in
+        let hour = parse_int_slice input 11 2 in
+        let minute = parse_int_slice input 14 2 in
+        let second = parse_int_slice input 17 2 in
+        if year < 0 || year > 9999 then false
+        else if month < 1 || month > 12 then false
+        else if day < 1 || day > days_in_month year month then false
+        else if hour > 23 || minute > 59 || second > 60 then false
+        else
+          let rest = String.sub input 19 (len - 19) in
+          let frac, offset =
+            if rest = "" then ("", "")
+            else if rest.[0] = '.' then
+              let rec digits i =
+                if i >= String.length rest then i
+                else if is_ascii_digit rest.[i] then digits (i + 1)
+                else i
+              in
+              let end_frac = digits 1 in
+              if end_frac = 1 then ("", rest)
+              else
+                ( String.sub rest 0 end_frac,
+                  String.sub rest end_frac (String.length rest - end_frac) )
+            else ("", rest)
+          in
+          let frac_ok =
+            frac = ""
+            || (String.length frac >= 2
+               && frac.[0] = '.'
+               && is_digit_range frac 1 (String.length frac - 1))
+          in
+          if not frac_ok then false
+          else
+            let offset_ok, off_h, off_m, off_sign =
+              if offset = "Z" then (true, 0, 0, 1)
+              else if
+                String.length offset = 6
+                && (offset.[0] = '+' || offset.[0] = '-')
+                && is_digit_range offset 1 2
+                && offset.[3] = ':'
+                && is_digit_range offset 4 2
+              then
+                let h = parse_int_slice offset 1 2 in
+                let m = parse_int_slice offset 4 2 in
+                let sign = if offset.[0] = '+' then 1 else -1 in
+                (h <= 23 && m <= 59, h, m, sign)
+              else (false, 0, 0, 1)
+            in
+            if not offset_ok then false
+            else
+              (* Reject values that normalize to a negative UTC year, e.g.
+                 0000-01-01T00:00:00+01:00. *)
+              let utc_min =
+                (hour * 60) + minute - (off_sign * ((off_h * 60) + off_m))
+              in
+              let day_shift =
+                if utc_min >= 0 then utc_min / (24 * 60)
+                else
+                  let adj = utc_min - (24 * 60) + 1 in
+                  (adj / (24 * 60)) - 1
+              in
+              not (year = 0 && day_shift < 0)
+      with _ -> false
+
+  let ensure_datetime s =
+    if not (is_valid_datetime s) then fail ("invalid datetime " ^ s)
+
+  let now_datetime () : string =
+    let tm = Unix.gmtime (Unix.gettimeofday ()) in
+    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02d.000Z" (tm.Unix.tm_year + 1900)
+      (tm.Unix.tm_mon + 1) tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min
+      tm.Unix.tm_sec
+
+  (* ---- Language (BCP 47 well-formed) ----------------------------------- *)
+
+  let is_alpha_len s lo hi =
+    let n = String.length s in
+    n >= lo && n <= hi
+    &&
+    let rec loop i =
+      if i >= n then true
+      else if is_ascii_alpha s.[i] then loop (i + 1)
+      else false
+    in
+    loop 0
+
+  let is_alnum_len s lo hi =
+    let n = String.length s in
+    n >= lo && n <= hi
+    &&
+    let rec loop i =
+      if i >= n then true
+      else if is_ascii_alnum s.[i] then loop (i + 1)
+      else false
+    in
+    loop 0
+
+  let is_digit_len s n =
+    String.length s = n && is_digit_range s 0 n
+
+  let grandfathered_tags =
+    [
+      "en-gb-oed";
+      "i-ami";
+      "i-bnn";
+      "i-default";
+      "i-enochian";
+      "i-hak";
+      "i-klingon";
+      "i-lux";
+      "i-mingo";
+      "i-navajo";
+      "i-pwn";
+      "i-tao";
+      "i-tay";
+      "i-tsu";
+      "sgn-be-fr";
+      "sgn-be-nl";
+      "sgn-ch-de";
+      "art-lojban";
+      "cel-gaulish";
+      "no-bok";
+      "no-nyn";
+      "zh-guoyu";
+      "zh-hakka";
+      "zh-min";
+      "zh-min-nan";
+      "zh-xiang";
+    ]
+
+  let is_valid_language (input : string) : bool =
+    if input = "" then false
+    else
+      let lower = ascii_lower input in
+      if List.mem lower grandfathered_tags then true
+      else
+        let parts = String.split_on_char '-' input in
+        match parts with
+        | [] -> false
+        | first :: rest ->
+            let private_only = ascii_lower first = "x" in
+            let lang_ok =
+              private_only
+              || is_alpha_len first 2 3
+              || is_alpha_len first 4 4
+              || is_alpha_len first 5 8
+            in
+            if not lang_ok then false
+            else
+              let rec consume expected = function
+                | [] -> true
+                | p :: ps -> (
+                    match expected with
+                    | `Extlang_or_later ->
+                        if is_alpha_len p 3 3 && String.length first <= 3 then
+                          consume `Extlang2 ps
+                        else consume `Script_or_later (p :: ps)
+                    | `Extlang2 ->
+                        if is_alpha_len p 3 3 then consume `Extlang3 ps
+                        else consume `Script_or_later (p :: ps)
+                    | `Extlang3 ->
+                        if is_alpha_len p 3 3 then consume `Script_or_later ps
+                        else consume `Script_or_later (p :: ps)
+                    | `Script_or_later ->
+                        if is_alpha_len p 4 4 then consume `Region_or_later ps
+                        else consume `Region_or_later (p :: ps)
+                    | `Region_or_later ->
+                        if is_alpha_len p 2 2 || is_digit_len p 3 then
+                          consume `Variant_or_later ps
+                        else consume `Variant_or_later (p :: ps)
+                    | `Variant_or_later ->
+                        if
+                          is_alnum_len p 5 8
+                          || (String.length p = 4 && is_ascii_digit p.[0]
+                             && is_alnum_len (String.sub p 1 3) 3 3)
+                        then consume `Variant_or_later ps
+                        else consume `Extension_or_later (p :: ps)
+                    | `Extension_or_later ->
+                        if String.length p = 1 && ascii_lower p <> "x"
+                        then consume (`Extension_rest 0) ps
+                        else consume `Private (p :: ps)
+                    | `Extension_rest n ->
+                        if is_alnum_len p 2 8 then
+                          consume (`Extension_rest (n + 1)) ps
+                        else if n >= 1 then
+                          consume `Extension_or_later (p :: ps)
+                        else false
+                    | `Private ->
+                        if ascii_lower p = "x" then consume (`Private_rest 0) ps
+                        else false
+                    | `Private_rest n ->
+                        if is_alnum_len p 1 8 then
+                          consume (`Private_rest (n + 1)) ps
+                        else false)
+              in
+              if private_only then consume (`Private_rest 0) rest
+              else if is_alpha_len first 2 3 then
+                consume `Extlang_or_later rest
+              else consume `Script_or_later rest
+
+  let ensure_language s =
+    if not (is_valid_language s) then fail ("invalid language tag " ^ s)
+
+  (* ---- Handle resolution helpers (no network) -------------------------- *)
+
+  let handle_txt_name (handle : string) : string =
+    ensure_handle handle;
+    "_atproto." ^ normalize_handle handle
+
+  let parse_txt_did (value : string) : string option =
+    let v = String.trim value in
+    if starts_with v "did=" then
+      let did = String.sub v 4 (String.length v - 4) in
+      if is_valid_did did then Some did else None
+    else None
+
+  let handle_well_known_url (handle : string) : string =
+    ensure_handle handle;
+    Printf.sprintf "https://%s/.well-known/atproto-did"
+      (normalize_handle handle)
+
+  let parse_well_known_did (body : string) : string option =
+    let did = String.trim body in
+    if is_valid_did did then Some did else None
+end

--- a/src/xrpc.ml
+++ b/src/xrpc.ml
@@ -1,0 +1,215 @@
+open Base64url
+
+(** XRPC protocol headers and service-auth JWT claims.
+    https://atproto.com/specs/xrpc
+    https://atproto.com/specs/label#labeler-http-headers *)
+module Xrpc = struct
+  exception Invalid of string
+
+  let fail msg = raise (Invalid msg)
+
+  let ascii_lower s =
+    String.map
+      (function 'A' .. 'Z' as c -> Char.chr (Char.code c + 32) | c -> c)
+      s
+
+  let trim s =
+    let n = String.length s in
+    let rec left i =
+      if i >= n then n
+      else match s.[i] with ' ' | '\t' -> left (i + 1) | _ -> i
+    in
+    let rec right i =
+      if i < 0 then 0
+      else match s.[i] with ' ' | '\t' -> right (i - 1) | _ -> i + 1
+    in
+    let lo = left 0 in
+    let hi = right (n - 1) in
+    if hi <= lo then "" else String.sub s lo (hi - lo)
+
+  let split_commas s =
+    String.split_on_char ',' s
+    |> List.map trim
+    |> List.filter (fun p -> p <> "")
+
+  (* ---- atproto-proxy --------------------------------------------------- *)
+
+  type proxy = { did : string; service : string }
+
+  let parse_proxy (value : string) : proxy =
+    let v = trim value in
+    match String.index_opt v '#' with
+    | None -> fail "atproto-proxy must be did#service"
+    | Some i ->
+        let did = String.sub v 0 i in
+        let service = String.sub v (i + 1) (String.length v - i - 1) in
+        if not (Syntax.Syntax.is_valid_did did) then
+          fail ("atproto-proxy DID is invalid: " ^ did);
+        if service = "" then fail "atproto-proxy service id is empty";
+        { did; service }
+
+  let proxy_to_string (p : proxy) : string = p.did ^ "#" ^ p.service
+
+  let proxy_header (p : proxy) : string * string =
+    ("atproto-proxy", proxy_to_string p)
+
+  let labeler_proxy (did : string) : proxy =
+    { did; service = "atproto_labeler" }
+
+  (* ---- atproto-accept-labelers / atproto-content-labelers -------------- *)
+
+  type labeler = { did : string; redact : bool }
+
+  let parse_labeler_item (item : string) : labeler =
+    let parts = String.split_on_char ';' item |> List.map trim in
+    match parts with
+    | [] -> fail "empty labeler item"
+    | did :: params ->
+        if not (Syntax.Syntax.is_valid_did did) then
+          fail ("labeler DID is invalid: " ^ did);
+        let redact =
+          List.exists (fun p -> ascii_lower p = "redact") params
+        in
+        { did; redact }
+
+  let parse_labelers (value : string) : labeler list =
+    let items = split_commas value in
+    let parsed = List.map parse_labeler_item items in
+    (* de-duplicate by DID, unioning redact flags (spec: combine parameters) *)
+    let acc = Hashtbl.create 8 in
+    let order = ref [] in
+    List.iter
+      (fun (l : labeler) ->
+        match Hashtbl.find_opt acc l.did with
+        | None ->
+            Hashtbl.add acc l.did l.redact;
+            order := l.did :: !order
+        | Some prev -> Hashtbl.replace acc l.did (prev || l.redact))
+      parsed;
+    List.rev_map
+      (fun did -> { did; redact = Hashtbl.find acc did })
+      !order
+
+  let labelers_to_string (ls : labeler list) : string =
+    String.concat ", "
+      (List.map
+         (fun (l : labeler) ->
+           if l.redact then l.did ^ ";redact" else l.did)
+         ls)
+
+  let accept_labelers_header (ls : labeler list) : string * string =
+    ("atproto-accept-labelers", labelers_to_string ls)
+
+  let content_labelers_header (ls : labeler list) : string * string =
+    ("atproto-content-labelers", labelers_to_string ls)
+
+  (* ---- Rate-limit and repo-rev headers -------------------------------- *)
+
+  type rate_limit = {
+    limit : int option;
+    remaining : int option;
+    reset : int64 option;
+    policy : string option;
+  }
+
+  let header_value headers name =
+    let lower = ascii_lower name in
+    List.find_map
+      (fun (k, v) -> if ascii_lower k = lower then Some (trim v) else None)
+      headers
+
+  let int_opt s =
+    try Some (int_of_string s) with _ -> None
+
+  let int64_opt s =
+    try Some (Int64.of_string s) with _ -> None
+
+  let parse_rate_limit (headers : (string * string) list) : rate_limit =
+    {
+      limit =
+        (match header_value headers "RateLimit-Limit" with
+        | Some s -> int_opt s
+        | None -> None);
+      remaining =
+        (match header_value headers "RateLimit-Remaining" with
+        | Some s -> int_opt s
+        | None -> None);
+      reset =
+        (match header_value headers "RateLimit-Reset" with
+        | Some s -> int64_opt s
+        | None -> None);
+      policy = header_value headers "RateLimit-Policy";
+    }
+
+  let repo_rev_header (rev : string) : string * string =
+    ("atproto-repo-rev", rev)
+
+  (* ---- Service-auth JWT (com.atproto.server.getServiceAuth) ----------- *)
+
+  type service_auth = {
+    iss : string;
+    aud : string;
+    exp : int64 option;
+    lxm : string option;
+    raw : string;
+  }
+
+  let split_jwt jwt =
+    match String.split_on_char '.' jwt with
+    | [ h; p; s ] -> (h, p, s)
+    | _ -> fail "service-auth JWT must have three base64url parts"
+
+  let parse_service_auth (jwt : string) : service_auth =
+    let _, payload, _ = split_jwt jwt in
+    let json = Yojson.Safe.from_string (Base64url.decode payload) in
+    let open Yojson.Safe.Util in
+    let iss =
+      match json |> member "iss" with
+      | `String s -> s
+      | _ -> fail "service-auth JWT missing iss"
+    in
+    let aud =
+      match json |> member "aud" with
+      | `String s -> s
+      | _ -> fail "service-auth JWT missing aud"
+    in
+    if not (Syntax.Syntax.is_valid_did iss) then
+      fail "service-auth iss must be a DID";
+    if not (Syntax.Syntax.is_valid_did aud) then
+      fail "service-auth aud must be a DID";
+    {
+      iss;
+      aud;
+      exp =
+        (match json |> member "exp" with
+        | `Int n -> Some (Int64.of_int n)
+        | `Intlit s -> Some (Int64.of_string s)
+        | _ -> None);
+      lxm =
+        (match json |> member "lxm" with
+        | `String s ->
+            if not (Syntax.Syntax.is_valid_nsid s) then
+              fail "service-auth lxm must be an NSID";
+            Some s
+        | _ -> None);
+      raw = jwt;
+    }
+
+  let service_auth_body ~aud ?lxm ?exp () : Yojson.Safe.t =
+    if not (Syntax.Syntax.is_valid_did aud) then
+      fail "getServiceAuth aud must be a DID";
+    (match lxm with
+    | Some n ->
+        if not (Syntax.Syntax.is_valid_nsid n) then
+          fail "getServiceAuth lxm must be an NSID"
+    | None -> ());
+    let fields =
+      [ ("aud", `String aud) ]
+      @ (match lxm with Some n -> [ ("lxm", `String n) ] | None -> [])
+      @
+      match exp with
+      | Some n -> [ ("exp", `Intlit (Int64.to_string n)) ]
+      | None -> []
+    in
+    `Assoc fields
+end

--- a/src/xrpc.ml
+++ b/src/xrpc.ml
@@ -28,8 +28,7 @@ module Xrpc = struct
     if hi <= lo then "" else String.sub s lo (hi - lo)
 
   let split_commas s =
-    String.split_on_char ',' s
-    |> List.map trim
+    String.split_on_char ',' s |> List.map trim
     |> List.filter (fun p -> p <> "")
 
   (* ---- atproto-proxy --------------------------------------------------- *)
@@ -67,9 +66,7 @@ module Xrpc = struct
     | did :: params ->
         if not (Syntax.Syntax.is_valid_did did) then
           fail ("labeler DID is invalid: " ^ did);
-        let redact =
-          List.exists (fun p -> ascii_lower p = "redact") params
-        in
+        let redact = List.exists (fun p -> ascii_lower p = "redact") params in
         { did; redact }
 
   let parse_labelers (value : string) : labeler list =
@@ -86,15 +83,12 @@ module Xrpc = struct
             order := l.did :: !order
         | Some prev -> Hashtbl.replace acc l.did (prev || l.redact))
       parsed;
-    List.rev_map
-      (fun did -> { did; redact = Hashtbl.find acc did })
-      !order
+    List.rev_map (fun did -> { did; redact = Hashtbl.find acc did }) !order
 
   let labelers_to_string (ls : labeler list) : string =
     String.concat ", "
       (List.map
-         (fun (l : labeler) ->
-           if l.redact then l.did ^ ";redact" else l.did)
+         (fun (l : labeler) -> if l.redact then l.did ^ ";redact" else l.did)
          ls)
 
   let accept_labelers_header (ls : labeler list) : string * string =
@@ -118,11 +112,8 @@ module Xrpc = struct
       (fun (k, v) -> if ascii_lower k = lower then Some (trim v) else None)
       headers
 
-  let int_opt s =
-    try Some (int_of_string s) with _ -> None
-
-  let int64_opt s =
-    try Some (Int64.of_string s) with _ -> None
+  let int_opt s = try Some (int_of_string s) with _ -> None
+  let int64_opt s = try Some (Int64.of_string s) with _ -> None
 
   let parse_rate_limit (headers : (string * string) list) : rate_limit =
     {

--- a/test/dune
+++ b/test/dune
@@ -36,7 +36,7 @@
   test_blocks
   test_download_image
   test_xrpc)
- (libraries)
+ (libraries
   async
   core
   uri

--- a/test/dune
+++ b/test/dune
@@ -29,12 +29,14 @@
   test_server
   test_session
   test_sync
+  test_syntax
   test_tid
   test_user
   test_blob
   test_blocks
-  test_download_image)
- (libraries
+  test_download_image
+  test_xrpc)
+ (libraries)
   async
   core
   uri
@@ -87,8 +89,10 @@
   test_server
   test_session
   test_sync
+  test_syntax
   test_tid
   test_user
   test_blob
   test_blocks
-  test_download_image))
+  test_download_image
+  test_xrpc))

--- a/test/test_identity.ml
+++ b/test/test_identity.ml
@@ -69,7 +69,8 @@ let test_parse_identity_info _ =
 let test_plc_operation_bodies _ =
   let signed =
     Identity.sign_plc_operation_body ~token:"email-token"
-      ~rotation_keys:[ "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK" ]
+      ~rotation_keys:
+        [ "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK" ]
       ~also_known_as:[ "at://alice.test" ] ()
   in
   let open Yojson.Safe.Util in
@@ -86,8 +87,11 @@ let test_recommended_did_credentials _ =
     `Assoc
       [
         ( "rotationKeys",
-          `List [ `String "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK" ]
-        );
+          `List
+            [
+              `String
+                "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK";
+            ] );
         ("alsoKnownAs", `List [ `String "at://alice.test" ]);
         ("verificationMethods", `Assoc []);
         ("services", `Assoc []);
@@ -95,11 +99,11 @@ let test_recommended_did_credentials _ =
   in
   let creds = Identity.parse_recommended_did_credentials json in
   OUnit2.assert_equal 1 (List.length creds.rotation_keys);
-  OUnit2.assert_equal (Some "at://alice.test") (List.nth_opt creds.also_known_as 0)
+  OUnit2.assert_equal (Some "at://alice.test")
+    (List.nth_opt creds.also_known_as 0)
 
 let test_handle_txt_helpers _ =
-  OUnit2.assert_equal
-    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+  OUnit2.assert_equal (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
     (Identity.parse_txt_did "did=did:plc:ewvi7nxzyoun6zhxrhs64oiz");
   OUnit2.assert_equal
     ~printer:(fun x -> x)

--- a/test/test_identity.ml
+++ b/test/test_identity.ml
@@ -52,6 +52,60 @@ let test_resolve_actor_live _ =
   with exn ->
     skip_if true ("Identity.resolve skipped: " ^ Printexc.to_string exn)
 
+let test_parse_identity_info _ =
+  let json =
+    `Assoc
+      [
+        ("did", `String "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+        ("handle", `String "jay.bsky.team");
+        ("didDoc", `Assoc [ ("id", `String "did:plc:ewvi7nxzyoun6zhxrhs64oiz") ]);
+      ]
+  in
+  let info = Identity.parse_identity_info json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "jay.bsky.team" info.handle;
+  OUnit2.assert_bool "didDoc present"
+    (match info.did_doc with Some _ -> true | None -> false)
+
+let test_plc_operation_bodies _ =
+  let signed =
+    Identity.sign_plc_operation_body ~token:"email-token"
+      ~rotation_keys:[ "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK" ]
+      ~also_known_as:[ "at://alice.test" ] ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "email-token"
+    (signed |> member "token" |> to_string);
+  let submitted = Identity.submit_plc_operation_body signed in
+  OUnit2.assert_bool "operation wrapped"
+    (match submitted |> member "operation" with `Assoc _ -> true | _ -> false)
+
+let test_recommended_did_credentials _ =
+  let json =
+    `Assoc
+      [
+        ( "rotationKeys",
+          `List [ `String "did:key:zDnaerDaTF5BXEavCrfUZPJjEBhG8KNmk45G65Kd8uKbVhcwK" ]
+        );
+        ("alsoKnownAs", `List [ `String "at://alice.test" ]);
+        ("verificationMethods", `Assoc []);
+        ("services", `Assoc []);
+      ]
+  in
+  let creds = Identity.parse_recommended_did_credentials json in
+  OUnit2.assert_equal 1 (List.length creds.rotation_keys);
+  OUnit2.assert_equal (Some "at://alice.test") (List.nth_opt creds.also_known_as 0)
+
+let test_handle_txt_helpers _ =
+  OUnit2.assert_equal
+    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+    (Identity.parse_txt_did "did=did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://jay.bsky.team/.well-known/atproto-did"
+    (Identity.handle_well_known_url "jay.bsky.team")
+
 let suite =
   "identity"
   >::: [
@@ -60,6 +114,10 @@ let suite =
          "test_resolve_did_key_offline" >:: test_resolve_did_key_offline;
          "test_resolve_handle_live" >:: test_resolve_handle_live;
          "test_resolve_actor_live" >:: test_resolve_actor_live;
+         "test_parse_identity_info" >:: test_parse_identity_info;
+         "test_plc_operation_bodies" >:: test_plc_operation_bodies;
+         "test_recommended_did_credentials" >:: test_recommended_did_credentials;
+         "test_handle_txt_helpers" >:: test_handle_txt_helpers;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -44,11 +44,108 @@ let test_parse_query_labels _ =
   OUnit2.assert_equal ~printer:(fun x -> x) "did:plc:labeler" label.src;
   OUnit2.assert_equal (Some 1) label.ver
 
+let sample_label : Label.label =
+  {
+    src = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+    uri = "at://did:plc:alice/app.bsky.feed.post/1";
+    cid = None;
+    val_ = "!warn";
+    neg = None;
+    cts = Some "2024-01-01T00:00:00.000Z";
+    exp = None;
+    ver = Some 1;
+    sig_ = None;
+  }
+
+let test_label_sign_verify_p256 _ =
+  let priv_hex =
+    "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"
+  in
+  let priv =
+    match
+      Mirage_crypto_ec.P256.Dsa.priv_of_octets
+        (Atproto.Hash.Hash.hex_decode priv_hex)
+    with
+    | Ok p -> p
+    | Error _ -> failwith "p256 key"
+  in
+  let pub = Mirage_crypto_ec.P256.Dsa.pub_of_priv priv in
+  let octets = Mirage_crypto_ec.P256.Dsa.pub_to_octets ~compress:true pub in
+  let did_key = Atproto.Did_key.Did_key.(to_string (of_p256_octets octets)) in
+  let signed = Label.sign_p256 ~priv sample_label in
+  OUnit2.assert_bool "sig missing"
+    (match signed.sig_ with Some s -> String.length s = 64 | None -> false);
+  OUnit2.assert_equal `Valid (Label.verify_with_keys ~keys:[ did_key ] signed);
+  let tampered = { signed with val_ = "scam" } in
+  OUnit2.assert_equal `Invalid
+    (Label.verify_with_keys ~keys:[ did_key ] tampered);
+  OUnit2.assert_equal `Missing
+    (Label.verify_with_keys ~keys:[ did_key ] sample_label)
+
+let test_label_sign_verify_k256 _ =
+  let d = String.make 32 '\x01' in
+  let priv =
+    match Atproto.K256.K256.priv_of_octets d with
+    | Ok p -> p
+    | Error _ -> failwith "k256 key"
+  in
+  let pub = Atproto.K256.K256.pub_of_priv priv in
+  let octets = Atproto.K256.K256.pub_to_octets ~compress:true pub in
+  let did_key = Atproto.Did_key.Did_key.(to_string (of_k256_octets octets)) in
+  let signed = Label.sign_k256 ~priv sample_label in
+  OUnit2.assert_equal `Valid (Label.verify_with_keys ~keys:[ did_key ] signed)
+
+let test_subscribe_labels_frame _ =
+  let frame =
+    Label.encode_labels_frame { seq = 7L; labels = [ sample_label ] }
+  in
+  let header, msg = Label.decode_frame frame in
+  OUnit2.assert_equal 1 header.op;
+  OUnit2.assert_equal (Some "#labels") header.t;
+  match msg with
+  | `Labels m ->
+      OUnit2.assert_equal ~printer:Int64.to_string 7L m.seq;
+      OUnit2.assert_equal 1 (List.length m.labels);
+      OUnit2.assert_equal ~printer:(fun x -> x) "!warn" (List.hd m.labels).val_
+  | _ -> OUnit2.assert_failure "expected #labels"
+
+let test_subscribe_url _ =
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "wss://mod.example.com/xrpc/com.atproto.label.subscribeLabels?cursor=0"
+    (Label.subscribe_url ~host:"mod.example.com" ~cursor:0L ())
+
+let test_json_sig_roundtrip _ =
+  let json =
+    `Assoc
+      [
+        ("src", `String "did:plc:labeler");
+        ("uri", `String "did:plc:alice");
+        ("val", `String "spam");
+        ("ver", `Int 1);
+        ("cts", `String "2024-01-01T00:00:00.000Z");
+        ( "sig",
+          `Assoc
+            [ ("$bytes", `String (Atproto.Base64url.Base64url.encode_std "abcd")) ]
+        );
+      ]
+  in
+  let l = Label.parse_label json in
+  OUnit2.assert_equal (Some "abcd") l.sig_;
+  let back = Label.json_of_label l in
+  let again = Label.parse_label back in
+  OUnit2.assert_equal again.sig_ l.sig_
+
 let suite =
   "suite"
   >::: [
          "test_query_labels" >:: test_query_labels;
          "test_parse_query_labels" >:: test_parse_query_labels;
+         "test_label_sign_verify_p256" >:: test_label_sign_verify_p256;
+         "test_label_sign_verify_k256" >:: test_label_sign_verify_k256;
+         "test_subscribe_labels_frame" >:: test_subscribe_labels_frame;
+         "test_subscribe_url" >:: test_subscribe_url;
+         "test_json_sig_roundtrip" >:: test_json_sig_roundtrip;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -126,8 +126,9 @@ let test_json_sig_roundtrip _ =
         ("cts", `String "2024-01-01T00:00:00.000Z");
         ( "sig",
           `Assoc
-            [ ("$bytes", `String (Atproto.Base64url.Base64url.encode_std "abcd")) ]
-        );
+            [
+              ("$bytes", `String (Atproto.Base64url.Base64url.encode_std "abcd"));
+            ] );
       ]
   in
   let l = Label.parse_label json in

--- a/test/test_repo.ml
+++ b/test/test_repo.ml
@@ -110,12 +110,53 @@ let test_parse_blob_ref _ =
     ~printer:(fun x -> x)
     "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku" blob.cid
 
+let test_parse_list_missing_blobs _ =
+  let json =
+    `Assoc
+      [
+        ("cursor", `String "next");
+        ( "blobs",
+          `List
+            [
+              `Assoc
+                [
+                  ( "cid",
+                    `String
+                      "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+                  );
+                  ( "recordUri",
+                    `String
+                      "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+                ];
+            ] );
+      ]
+  in
+  let missing = Repo.parse_list_missing_blobs json in
+  OUnit2.assert_equal (Some "next") missing.cursor;
+  OUnit2.assert_equal 1 (List.length missing.blobs);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+    (List.hd missing.blobs).cid
+
+let test_import_repo_url _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let test_session = create_test_session () in
+  let url = Repo.import_repo_url test_session in
+  OUnit2.assert_bool "importRepo URL"
+    (let n = String.length url in
+     n > 10 && String.sub url (n - 10) 10 = "importRepo")
+
 let suite =
   "suite"
   >::: [
          "test_describe_repo" >:: test_describe_repo;
          "test_apply_writes_body" >:: test_apply_writes_body;
          "test_parse_blob_ref" >:: test_parse_blob_ref;
+         "test_parse_list_missing_blobs" >:: test_parse_list_missing_blobs;
+         "test_import_repo_url" >:: test_import_repo_url;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -37,12 +37,48 @@ let test_list_app_passwords _ =
   Printf.printf "App Passwords: %s\n" app_passwords;
   OUnit2.assert_bool "App Passwords is not empty" (app_passwords <> "")
 
+let test_parse_service_auth _ =
+  let json = `Assoc [ ("token", `String "header.payload.sig") ] in
+  let auth = Server.parse_service_auth json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "header.payload.sig" auth.token
+
+let test_parse_account_status _ =
+  let json =
+    `Assoc
+      [
+        ("activated", `Bool true);
+        ("validDid", `Bool true);
+        ("expectedBlobs", `Int 3);
+        ("importedBlobs", `Int 3);
+      ]
+  in
+  let st = Server.parse_account_status json in
+  OUnit2.assert_equal (Some true) st.activated;
+  OUnit2.assert_equal (Some 3) st.expected_blobs
+
+let test_account_urls _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let s = create_test_session () in
+  OUnit2.assert_bool "deactivate"
+    (let u = Server.deactivate_account_url s in
+     String.length u > 18
+     && String.sub u (String.length u - 18) 18 = "deactivateAccount");
+  OUnit2.assert_bool "checkAccountStatus"
+    (let u = Server.check_account_status_url s in
+     String.length u > 18
+     && String.sub u (String.length u - 18) 18 = "checkAccountStatus")
+
 let suite =
   "suite"
   >::: [
          "test_describe_server" >:: test_describe_server;
          "test_get_account_invite_codes" >:: test_get_account_invite_codes;
          "test_list_app_passwords" >:: test_list_app_passwords;
+         "test_parse_service_auth" >:: test_parse_service_auth;
+         "test_parse_account_status" >:: test_parse_account_status;
+         "test_account_urls" >:: test_account_urls;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -85,6 +85,70 @@ let test_list_repos _ =
       (List.length repos.repos >= 0)
   with exn -> skip_if true ("listRepos skipped: " ^ Printexc.to_string exn)
 
+let test_parse_repo_status _ =
+  let json =
+    `Assoc
+      [
+        ("did", `String "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+        ("active", `Bool false);
+        ("status", `String "deactivated");
+        ("rev", `String "3jzfcijpj2z2a");
+      ]
+  in
+  let s = Sync.parse_repo_status json in
+  OUnit2.assert_equal false s.active;
+  OUnit2.assert_equal (Some "deactivated") s.status;
+  OUnit2.assert_equal (Some "3jzfcijpj2z2a") s.rev
+
+let test_parse_list_hosts _ =
+  let json =
+    `Assoc
+      [
+        ("cursor", `String "c2");
+        ( "hosts",
+          `List
+            [
+              `Assoc
+                [
+                  ("hostname", `String "morel.us-east.host.bsky.network");
+                  ("seq", `Int 99);
+                  ("accountCount", `Int 12);
+                  ("status", `String "active");
+                ];
+            ] );
+      ]
+  in
+  let h = Sync.parse_list_hosts json in
+  OUnit2.assert_equal (Some "c2") h.cursor;
+  OUnit2.assert_equal 1 (List.length h.hosts);
+  OUnit2.assert_equal (Some 99L) (List.hd h.hosts).seq
+
+let test_parse_list_repos_by_collection _ =
+  let json =
+    `Assoc
+      [
+        ( "repos",
+          `List
+            [
+              `Assoc [ ("did", `String "did:plc:aaaa"); ];
+              `Assoc [ ("did", `String "did:plc:bbbb"); ];
+            ] );
+      ]
+  in
+  let r = Sync.parse_list_repos_by_collection json in
+  OUnit2.assert_equal 2 (List.length r.repos);
+  OUnit2.assert_equal "did:plc:aaaa" (List.hd r.repos).did
+
+let test_get_repo_status_public _ =
+  try
+    with_public_timeout (fun () ->
+        let ident = public_actor () in
+        let host = public_pds_host ident in
+        let st = Sync.get_repo_status ~host ident.did in
+        OUnit2.assert_equal ~printer:(fun x -> x) ident.did st.did)
+  with exn ->
+    skip_if true ("getRepoStatus skipped: " ^ Printexc.to_string exn)
+
 let suite =
   "sync"
   >::: [
@@ -93,6 +157,11 @@ let suite =
          "test_get_head" >:: test_get_head;
          "test_get_repo_car" >:: test_get_repo_car;
          "test_list_repos" >:: test_list_repos;
+         "test_parse_repo_status" >:: test_parse_repo_status;
+         "test_parse_list_hosts" >:: test_parse_list_hosts;
+         "test_parse_list_repos_by_collection"
+         >:: test_parse_list_repos_by_collection;
+         "test_get_repo_status_public" >:: test_get_repo_status_public;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -130,8 +130,8 @@ let test_parse_list_repos_by_collection _ =
         ( "repos",
           `List
             [
-              `Assoc [ ("did", `String "did:plc:aaaa"); ];
-              `Assoc [ ("did", `String "did:plc:bbbb"); ];
+              `Assoc [ ("did", `String "did:plc:aaaa") ];
+              `Assoc [ ("did", `String "did:plc:bbbb") ];
             ] );
       ]
   in
@@ -146,8 +146,7 @@ let test_get_repo_status_public _ =
         let host = public_pds_host ident in
         let st = Sync.get_repo_status ~host ident.did in
         OUnit2.assert_equal ~printer:(fun x -> x) ident.did st.did)
-  with exn ->
-    skip_if true ("getRepoStatus skipped: " ^ Printexc.to_string exn)
+  with exn -> skip_if true ("getRepoStatus skipped: " ^ Printexc.to_string exn)
 
 let suite =
   "sync"

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -103,15 +103,23 @@ let test_nsid_spec_examples _ =
     ];
   List.iter
     (fun n -> assert_bad n Syntax.is_valid_nsid)
-    [ "com.example"; "com.example.3"; "example.com/foo"; "foo"; "8.example.foo" ];
+    [
+      "com.example"; "com.example.3"; "example.com/foo"; "foo"; "8.example.foo";
+    ];
   let nsid = Syntax.parse_nsid "com.example.fooBar" in
   OUnit2.assert_equal ~printer:(fun x -> x) "fooBar" (Syntax.nsid_name nsid);
-  OUnit2.assert_equal ~printer:(fun x -> x) "example.com"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "example.com"
     (Syntax.nsid_authority nsid);
-  OUnit2.assert_equal ~printer:(fun x -> x) "com.example"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.example"
     (Syntax.nsid_authority_nsid nsid);
   let created = Syntax.create_nsid ~authority:"example.com" ~name:"fooBar" in
-  OUnit2.assert_equal ~printer:(fun x -> x) "com.example.fooBar"
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.example.fooBar"
     (Syntax.nsid_to_string created)
 
 let test_nsid_glob_and_ref _ =
@@ -135,11 +143,12 @@ let test_record_key _ =
     [ "3jzfcijpj2z2a"; "self"; "literal:self"; "a"; String.make 512 'a' ];
   List.iter
     (fun k -> assert_bad k Syntax.is_valid_record_key)
-    [ ""; "."; ".."; "alpha/beta"; "#extra"; "@handle"; "any space"; "any+space" ]
+    [
+      ""; "."; ".."; "alpha/beta"; "#extra"; "@handle"; "any space"; "any+space";
+    ]
 
 let test_at_identifier _ =
-  OUnit2.assert_bool "handle"
-    (Syntax.is_valid_at_identifier "jay.bsky.team");
+  OUnit2.assert_bool "handle" (Syntax.is_valid_at_identifier "jay.bsky.team");
   OUnit2.assert_bool "did"
     (Syntax.is_valid_at_identifier "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
   OUnit2.assert_bool "neither" (not (Syntax.is_valid_at_identifier "not an id"))
@@ -185,12 +194,15 @@ let test_datetime_spec_examples _ =
     ];
   OUnit2.assert_bool "leap day 2024"
     (Syntax.is_valid_datetime "2024-02-29T00:00:00.000Z");
-  OUnit2.assert_bool "now is valid" (Syntax.is_valid_datetime (Syntax.now_datetime ()))
+  OUnit2.assert_bool "now is valid"
+    (Syntax.is_valid_datetime (Syntax.now_datetime ()))
 
 let test_language _ =
   List.iter
     (fun t -> assert_ok t Syntax.is_valid_language)
-    [ "ja"; "ban"; "pt-BR"; "hy-Latn-IT-arevela"; "zh-Hans"; "de-CH-1996"; "en" ];
+    [
+      "ja"; "ban"; "pt-BR"; "hy-Latn-IT-arevela"; "zh-Hans"; "de-CH-1996"; "en";
+    ];
   List.iter
     (fun t -> assert_bad t Syntax.is_valid_language)
     [ ""; "1"; "toolonglanguage"; "en--US"; "en-" ]
@@ -200,16 +212,14 @@ let test_handle_resolution_helpers _ =
     ~printer:(fun x -> x)
     "_atproto.user.example.com"
     (Syntax.handle_txt_name "user.example.com");
-  OUnit2.assert_equal
-    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+  OUnit2.assert_equal (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
     (Syntax.parse_txt_did "did=did:plc:ewvi7nxzyoun6zhxrhs64oiz");
   OUnit2.assert_equal None (Syntax.parse_txt_did "not-a-did");
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "https://user.example.app/.well-known/atproto-did"
     (Syntax.handle_well_known_url "user.example.app");
-  OUnit2.assert_equal
-    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+  OUnit2.assert_equal (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
     (Syntax.parse_well_known_did "  did:plc:ewvi7nxzyoun6zhxrhs64oiz \n")
 
 let suite =

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -1,0 +1,231 @@
+open OUnit2
+open Atproto.Syntax
+
+let assert_ok label pred =
+  OUnit2.assert_bool ("expected valid: " ^ label) (pred label)
+
+let assert_bad label pred =
+  OUnit2.assert_bool ("expected invalid: " ^ label) (not (pred label))
+
+let test_handle_spec_examples _ =
+  List.iter
+    (fun h -> assert_ok h Syntax.is_valid_handle)
+    [
+      "jay.bsky.social";
+      "8.cn";
+      "name.t--t";
+      "XX.LCS.MIT.EDU";
+      "a.co";
+      "xn--notarealidn.com";
+      "xn--fiqa61au8b7zsevnm8ak20mc4a87e.xn--fiqs8s";
+      "xn--ls8h.test";
+      "example.t";
+    ];
+  List.iter
+    (fun h -> assert_bad h Syntax.is_valid_handle)
+    [
+      "jo@hn.test";
+      "john..test";
+      "xn--bcher-.tld";
+      "john.0";
+      "cn.8";
+      "org";
+      "name.org.";
+      "";
+    ]
+
+let test_handle_normalize _ =
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "blueskyweb.xyz"
+    (Syntax.normalize_and_ensure_handle "BlueskyWeb.xyz")
+
+let test_handle_reserved_tld _ =
+  OUnit2.assert_bool "syntax allows .onion"
+    (Syntax.is_valid_handle
+       "2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion");
+  OUnit2.assert_bool ".onion must fail resolution TLD check"
+    (not
+       (Syntax.is_valid_tld
+          "2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion"));
+  OUnit2.assert_bool ".local must fail TLD check"
+    (not (Syntax.is_valid_tld "laptop.local"));
+  OUnit2.assert_bool ".arpa must fail TLD check"
+    (not (Syntax.is_valid_tld "blah.arpa"));
+  OUnit2.assert_bool ".test is allowed at TLD layer"
+    (Syntax.is_valid_tld "xn--ls8h.test")
+
+let test_did_spec_examples _ =
+  List.iter
+    (fun d -> assert_ok d Syntax.is_valid_did)
+    [
+      "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+      "did:web:user.example.com";
+      "did:method:val:two";
+      "did:m:v";
+      "did:method::::val";
+      "did:method:-:_:.";
+      "did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N";
+    ];
+  List.iter
+    (fun d -> assert_bad d Syntax.is_valid_did)
+    [
+      "did:METHOD:val";
+      "did:m123:val";
+      "DID:method:val";
+      "did:method:";
+      "did:method:val/two";
+      "did:method:val?two";
+      "did:method:val#two";
+    ];
+  OUnit2.assert_equal (Some "plc")
+    (Syntax.did_method "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+  OUnit2.assert_bool "plc is blessed"
+    (Syntax.is_blessed_did "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+  OUnit2.assert_bool "did:key is valid syntax but not blessed"
+    (Syntax.is_valid_did
+       "did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N"
+    && not
+         (Syntax.is_blessed_did
+            "did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N"))
+
+let test_nsid_spec_examples _ =
+  List.iter
+    (fun n -> assert_ok n Syntax.is_valid_nsid)
+    [
+      "com.example.fooBar";
+      "net.users.bob.ping";
+      "a-0.b-1.c";
+      "a.b.c";
+      "com.example.fooBarV2";
+      "cn.8.lex.stuff";
+      "com.atproto.sync.getRecord";
+    ];
+  List.iter
+    (fun n -> assert_bad n Syntax.is_valid_nsid)
+    [ "com.example"; "com.example.3"; "example.com/foo"; "foo"; "8.example.foo" ];
+  let nsid = Syntax.parse_nsid "com.example.fooBar" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "fooBar" (Syntax.nsid_name nsid);
+  OUnit2.assert_equal ~printer:(fun x -> x) "example.com"
+    (Syntax.nsid_authority nsid);
+  OUnit2.assert_equal ~printer:(fun x -> x) "com.example"
+    (Syntax.nsid_authority_nsid nsid);
+  let created = Syntax.create_nsid ~authority:"example.com" ~name:"fooBar" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "com.example.fooBar"
+    (Syntax.nsid_to_string created)
+
+let test_nsid_glob_and_ref _ =
+  OUnit2.assert_bool "bare glob" (Syntax.is_valid_nsid_glob "*");
+  OUnit2.assert_bool "authority glob"
+    (Syntax.is_valid_nsid_glob "com.atproto.*");
+  OUnit2.assert_bool "partial glob rejected"
+    (not (Syntax.is_valid_nsid_glob "com.atpro*"));
+  let r = Syntax.parse_nsid_ref "com.example.defs#userView" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "com.example.defs" r.nsid;
+  OUnit2.assert_equal (Some "userView") r.fragment;
+  OUnit2.assert_bool "#main rejected"
+    (try
+       ignore (Syntax.parse_nsid_ref "com.example.record#main");
+       false
+     with Syntax.Invalid _ -> true)
+
+let test_record_key _ =
+  List.iter
+    (fun k -> assert_ok k Syntax.is_valid_record_key)
+    [ "3jzfcijpj2z2a"; "self"; "literal:self"; "a"; String.make 512 'a' ];
+  List.iter
+    (fun k -> assert_bad k Syntax.is_valid_record_key)
+    [ ""; "."; ".."; "alpha/beta"; "#extra"; "@handle"; "any space"; "any+space" ]
+
+let test_at_identifier _ =
+  OUnit2.assert_bool "handle"
+    (Syntax.is_valid_at_identifier "jay.bsky.team");
+  OUnit2.assert_bool "did"
+    (Syntax.is_valid_at_identifier "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+  OUnit2.assert_bool "neither" (not (Syntax.is_valid_at_identifier "not an id"))
+
+let test_datetime_spec_examples _ =
+  List.iter
+    (fun d -> assert_ok d Syntax.is_valid_datetime)
+    [
+      "1985-04-12T23:20:50.123Z";
+      "1985-04-12T23:20:50.123456Z";
+      "1985-04-12T23:20:50.120Z";
+      "1985-04-12T23:20:50.120000Z";
+      "0001-01-01T00:00:00.000Z";
+      "0000-01-01T00:00:00.000Z";
+      "1985-04-12T23:20:50.12345678912345Z";
+      "1985-04-12T23:20:50Z";
+      "1985-04-12T23:20:50.0Z";
+      "1985-04-12T23:20:50.123+00:00";
+      "1985-04-12T23:20:50.123-07:00";
+    ];
+  List.iter
+    (fun d -> assert_bad d Syntax.is_valid_datetime)
+    [
+      "1985-04-12";
+      "1985-04-12T23:20Z";
+      "1985-04-12T23:20:5Z";
+      "1985-04-12T23:20:50.123";
+      "+001985-04-12T23:20:50.123Z";
+      "23:20:50.123Z";
+      "-1985-04-12T23:20:50.123Z";
+      "1985-4-12T23:20:50.123Z";
+      "01985-04-12T23:20:50.123Z";
+      "1985-04-12T23:20:50.123+00";
+      "1985-04-12T23:20:50.123+0000";
+      "1985-04-12t23:20:50.123Z";
+      "1985-04-12T23:20:50.123z";
+      "1985-04-12T23:20:50.123-00:00";
+      "1985-04-12 23:20:50.123Z";
+      "1985-04-12T23:99:50.123Z";
+      "1985-00-12T23:20:50.123Z";
+      "0000-01-01T00:00:00+01:00";
+      "1985-02-29T00:00:00Z";
+    ];
+  OUnit2.assert_bool "leap day 2024"
+    (Syntax.is_valid_datetime "2024-02-29T00:00:00.000Z");
+  OUnit2.assert_bool "now is valid" (Syntax.is_valid_datetime (Syntax.now_datetime ()))
+
+let test_language _ =
+  List.iter
+    (fun t -> assert_ok t Syntax.is_valid_language)
+    [ "ja"; "ban"; "pt-BR"; "hy-Latn-IT-arevela"; "zh-Hans"; "de-CH-1996"; "en" ];
+  List.iter
+    (fun t -> assert_bad t Syntax.is_valid_language)
+    [ ""; "1"; "toolonglanguage"; "en--US"; "en-" ]
+
+let test_handle_resolution_helpers _ =
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "_atproto.user.example.com"
+    (Syntax.handle_txt_name "user.example.com");
+  OUnit2.assert_equal
+    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+    (Syntax.parse_txt_did "did=did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+  OUnit2.assert_equal None (Syntax.parse_txt_did "not-a-did");
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://user.example.app/.well-known/atproto-did"
+    (Syntax.handle_well_known_url "user.example.app");
+  OUnit2.assert_equal
+    (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
+    (Syntax.parse_well_known_did "  did:plc:ewvi7nxzyoun6zhxrhs64oiz \n")
+
+let suite =
+  "syntax"
+  >::: [
+         "test_handle_spec_examples" >:: test_handle_spec_examples;
+         "test_handle_normalize" >:: test_handle_normalize;
+         "test_handle_reserved_tld" >:: test_handle_reserved_tld;
+         "test_did_spec_examples" >:: test_did_spec_examples;
+         "test_nsid_spec_examples" >:: test_nsid_spec_examples;
+         "test_nsid_glob_and_ref" >:: test_nsid_glob_and_ref;
+         "test_record_key" >:: test_record_key;
+         "test_at_identifier" >:: test_at_identifier;
+         "test_datetime_spec_examples" >:: test_datetime_spec_examples;
+         "test_language" >:: test_language;
+         "test_handle_resolution_helpers" >:: test_handle_resolution_helpers;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_xrpc.ml
+++ b/test/test_xrpc.ml
@@ -1,0 +1,108 @@
+open OUnit2
+open Atproto.Xrpc
+open Atproto.Base64url
+
+let test_proxy _ =
+  let p = Xrpc.parse_proxy "did:plc:abc123xyz0001112223333#atproto_labeler" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "atproto_labeler" p.service;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:abc123xyz0001112223333#atproto_labeler" (Xrpc.proxy_to_string p);
+  let h, v = Xrpc.proxy_header (Xrpc.labeler_proxy "did:web:mod.example.com") in
+  OUnit2.assert_equal "atproto-proxy" h;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:mod.example.com#atproto_labeler" v;
+  OUnit2.assert_bool "missing fragment rejected"
+    (try
+       ignore (Xrpc.parse_proxy "did:web:mod.example.com");
+       false
+     with Xrpc.Invalid _ -> true)
+
+let test_labelers _ =
+  let parsed =
+    Xrpc.parse_labelers
+      "did:web:mod.example.com;redact, did:plc:abc123xyz0001112223333, \
+       did:plc:xyz789aaa0001112223333"
+  in
+  OUnit2.assert_equal 3 (List.length parsed);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:mod.example.com" (List.nth parsed 0).did;
+  OUnit2.assert_bool "redact" (List.nth parsed 0).redact;
+  OUnit2.assert_bool "no redact" (not (List.nth parsed 1).redact);
+  let merged =
+    Xrpc.parse_labelers
+      "did:web:mod.example.com, did:web:mod.example.com;redact"
+  in
+  OUnit2.assert_equal 1 (List.length merged);
+  OUnit2.assert_bool "redact unioned" (List.hd merged).redact;
+  let h, v = Xrpc.accept_labelers_header merged in
+  OUnit2.assert_equal "atproto-accept-labelers" h;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:mod.example.com;redact" v
+
+let test_rate_limit _ =
+  let rl =
+    Xrpc.parse_rate_limit
+      [
+        ("RateLimit-Limit", "100");
+        ("RateLimit-Remaining", "42");
+        ("RateLimit-Reset", "1700000000");
+        ("RateLimit-Policy", "100;w=300");
+      ]
+  in
+  OUnit2.assert_equal (Some 100) rl.limit;
+  OUnit2.assert_equal (Some 42) rl.remaining;
+  OUnit2.assert_equal (Some 1_700_000_000L) rl.reset;
+  OUnit2.assert_equal (Some "100;w=300") rl.policy
+
+let test_repo_rev _ =
+  let h, v = Xrpc.repo_rev_header "3jzfcijpj2z2a" in
+  OUnit2.assert_equal "atproto-repo-rev" h;
+  OUnit2.assert_equal "3jzfcijpj2z2a" v
+
+let b64 json = Base64url.encode (Yojson.Safe.to_string json)
+
+let test_service_auth_jwt _ =
+  let header = `Assoc [ ("alg", `String "none"); ("typ", `String "JWT") ] in
+  let payload =
+    `Assoc
+      [
+        ("iss", `String "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+        ("aud", `String "did:web:mod.example.com");
+        ("exp", `Int 1_700_000_000);
+        ("lxm", `String "com.atproto.moderation.createReport");
+      ]
+  in
+  let jwt = b64 header ^ "." ^ b64 payload ^ ".sig" in
+  let claims = Xrpc.parse_service_auth jwt in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:ewvi7nxzyoun6zhxrhs64oiz" claims.iss;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:mod.example.com" claims.aud;
+  OUnit2.assert_equal (Some "com.atproto.moderation.createReport") claims.lxm;
+  let body =
+    Xrpc.service_auth_body ~aud:"did:web:mod.example.com"
+      ~lxm:"com.atproto.moderation.createReport" ~exp:1_700_000_000L ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:mod.example.com"
+    (body |> member "aud" |> to_string)
+
+let suite =
+  "xrpc"
+  >::: [
+         "test_proxy" >:: test_proxy;
+         "test_labelers" >:: test_labelers;
+         "test_rate_limit" >:: test_rate_limit;
+         "test_repo_rev" >:: test_repo_rev;
+         "test_service_auth_jwt" >:: test_service_auth_jwt;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_xrpc.ml
+++ b/test/test_xrpc.ml
@@ -39,9 +39,7 @@ let test_labelers _ =
   OUnit2.assert_bool "redact unioned" (List.hd merged).redact;
   let h, v = Xrpc.accept_labelers_header merged in
   OUnit2.assert_equal "atproto-accept-labelers" h;
-  OUnit2.assert_equal
-    ~printer:(fun x -> x)
-    "did:web:mod.example.com;redact" v
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:web:mod.example.com;redact" v
 
 let test_rate_limit _ =
   let rl =
@@ -81,9 +79,7 @@ let test_service_auth_jwt _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "did:plc:ewvi7nxzyoun6zhxrhs64oiz" claims.iss;
-  OUnit2.assert_equal
-    ~printer:(fun x -> x)
-    "did:web:mod.example.com" claims.aud;
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:web:mod.example.com" claims.aud;
   OUnit2.assert_equal (Some "com.atproto.moderation.createReport") claims.lxm;
   let body =
     Xrpc.service_auth_body ~aud:"did:web:mod.example.com"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the remaining AT Protocol core holes after PRs 70–72.

## What landed

**Syntax (`Syntax`)** — identifier and string-format validators matching the official specs / `@atproto/syntax` vectors:

- Handle (ASCII hostname rules, reserved TLD check, normalize)
- DID (generic atproto syntax, blessed `plc`/`web`)
- NSID (parse/create, authority/name, glob, `#fragment` refs)
- Record key, datetime (RFC 3339 ∩ ISO 8601, reject `-00:00` and invalid calendar), language (BCP 47 well-formed)
- Handle resolution helpers: `_atproto.` TXT `did=` parse and `/.well-known/atproto-did`

**XRPC (`Xrpc`)**

- `atproto-proxy` (`did#service`)
- `atproto-accept-labelers` / `atproto-content-labelers` (RFC 8941-style, `redact`, de-dupe)
- Rate-limit + `atproto-repo-rev` headers
- Service-auth JWT claims (`iss`/`aud`/`exp`/`lxm`)

**Labels** — `sig` (`$bytes`), unsigned DAG-CBOR sign/verify (p256 + k256, low-S), `subscribeLabels` frame encode/decode

**Sync / identity / repo / server**

- `getRepoStatus`, `listHosts`, `getHostStatus`, `listReposByCollection`
- `resolveIdentity` parse, PLC sign/submit bodies, recommended DID credentials
- `listMissingBlobs`, `importRepo`
- `getServiceAuth` URL + parse, account status / deactivate / activate URLs

## Protocol core status

The protocol core is complete. Leftovers are product-level only:

- OAuth browser redirect / client-metadata hosting / live token loop
- AppView product surfaces beyond existing profile/feed/graph/notification helpers
- Admin / ozone dashboards (createReport + labeler proxy headers are implemented)
- Live `getServiceAuth` against a real PDS (skipped without `ATP_AUTH`)

No invented Bluesky credentials. Auth suites skip without real `ATP_AUTH`. GitHub Action majors unchanged (`checkout@v4`, `setup-ocaml@v3`, `cache@v4`, `upload-artifact@v4`).

## Tests

`dune build` and `dune runtest` pass locally after ocamlformat 0.25.1. Unit coverage for official syntax vectors, XRPC headers, signed labels (p256/k256), subscribeLabels frames, and the new sync/identity/repo/server parsers. Public `getRepoStatus` is attempted and skipped on network failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fa159e2-ecb1-4977-9e12-f3ca1e047e7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fa159e2-ecb1-4977-9e12-f3ca1e047e7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

