### PR TITLE
Jetstream v2, video upload, OAuth scopes, and remaining library holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ let embed =
 (* firehose: one subscribeRepos frame from the public relay *)
 let _header, msg = Firehose.subscribe_one ()
 
+(* Jetstream v2 JSON tail — URL only here; subscribe_one talks to the public WS *)
+let _js =
+  Jetstream.subscribe_url
+    ~filter:
+      {
+        Jetstream.empty_filter with
+        collections = [ "app.bsky.feed.post" ];
+        kinds = [ Jetstream.Commit ];
+      }
+    ()
+
+(* granular OAuth scopes (atproto remains mandatory) *)
+let scopes = Oauth_scope.parse "atproto repo:app.bsky.feed.post"
+
 (* authenticated writes / private surfaces *)
 let username, password = Auth.username_and_password_from_env
 let session = Session.create_session username password

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ dune build
 dune runtest
 ```
 
+`dune build` also typechecks `examples/offline.ml` against the current public API (no network, no credentials).
+
 Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to a real `email:app-password` pair (placeholder values in `sample.env` do not count). Public-network tests (handle resolve, PLC directory, `getLatestCommit`, `subscribeRepos`, AppView feed/search/labeler reads) run without auth and skip only if the request itself fails.
 
 ## What this library covers
@@ -36,36 +38,45 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | AppView feed | `Feed` | Timeline, threads, generators (`getFeed` / `getFeedGenerator` / `getActorFeeds`), `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
-| Video | `Video` | `getJobStatus`, `getUploadLimits` |
+| Jetstream | `Jetstream` | v2 live tail (`wss://jetstream.us-west/east.bsky.network/xrpc/network.bsky.jetstream.subscribeEvents`), collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat, snapshot/replay URL+plan types (no archive token) |
+| Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
 | Chat / DMs | `Chat` | `chat.bsky.convo.*` with `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; `uploadBlob` parse |
-| Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status |
+| Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + updateHandle / PLC operation helpers |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
-| Sync | `Sync` | Current `getLatestCommit`, `getRepo` (CAR), `listBlobs`, `listRepos` |
+| Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
 | CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1 |
 | MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff inversion, p256/k256 commit sign+verify |
 | TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
-| Lexicon | `Lexicon` | Parse lexicon-1 JSON, `to_ocaml` codegen, JSON validate |
+| Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen, JSON validate |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
-| OAuth / DPoP | `Oauth` | PKCE S256, DPoP ES256 + nonce, client metadata, AS/resource metadata, redirect callback, PAR/token loop (injectable HTTP) |
+| OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
 | Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) |
 | XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit, service-auth JWT; chat + appview proxies |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
+| Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
+| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video; mention / link / tag |
+| Notifications | `Notification` | Unread count, list, updateSeen; unknown reasons parse as `` `Other `` |
+| User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef) |
+| Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
+| HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST, method enum |
 
 ## Remaining gaps
 
 These are product-level, not missing protocol cores:
 
 - Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
-- A hosted PDS, video byte upload, or live Ozone operator session (client request/response types and proxy headers are implemented)
+- A hosted PDS, hosted video transcoder, or live Ozone operator session (client request/response types, video byte-upload + job poll, and proxy headers are implemented)
+- Jetstream Network Replay / HTTP snapshot download against Bluesky's gated archive (plan/segment/block URLs and JSON types are implemented; live download needs an operator token this library does not invent)
+- Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 
-PLC k256 verify, MST firehose-diff inversion, signed-commit verify, OAuth client-metadata / PAR+token loop, and the AppView/Ozone/chat client surface are implemented in this stack (#70–#73 / this slice).
+Jetstream v2, granular OAuth scopes, Sync v1.1 `getBlocks` (public), live-shaped firehose MST verify, and the video byte-upload pipeline are in this slice. #70–#74 already landed identity/MST/OAuth-core/AppView/Ozone.
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -96,6 +107,14 @@ let meta =
     ~client_id:"https://client.example/client-metadata.json"
     ~redirect_uris:[ "https://client.example/cb" ] ()
 let _ = Oauth.validate_metadata meta
+
+(* video byte-upload pipeline — construct URL + embed; POST needs a service token *)
+let upload =
+  Video.upload_video_url ~did:"did:plc:abc123xyz0001112223333" ~name:"clip.mp4" ()
+let embed =
+  Video.video_embed_json
+    ~video:(`Assoc [ ("$type", `String "blob"); ("mimeType", `String "video/mp4") ])
+    ~alt:"demo" ()
 
 (* firehose: one subscribeRepos frame from the public relay *)
 let _header, msg = Firehose.subscribe_one ()

--- a/atproto.opam
+++ b/atproto.opam
@@ -2,29 +2,33 @@ opam-version: "2.0"
 maintainer: "david-engelmann david.engelmann44@gmail.com"
 authors: "david-engelmann david.engelmann44@gmail.com"
 homepage: "https://github.com/david-engelmann/atproto"
-
 bug-reports: "https://github.com/david-engelmann/atproto/issues"
 dev-repo: "git+https://github.com/david-engelmann/atproto.git"
+doc: "https://github.com/david-engelmann/atproto#readme"
 license: "MIT"
+tags: ["atproto" "bluesky" "xrpc" "lexicon"]
 build: [
     ["dune" "build" "-p" name "-j" jobs]
 ]
+run-test: [
+    ["dune" "runtest" "-p" name "-j" jobs]
+]
 depends: [
     "ocaml" {>= "4.14.0"}
+    "dune" {>= "2.9.0"}
     "core"
     "async"
-    "dune" {>= "2.0.0"}
-    "h2" {>= "0.10.0"}
     "uri" {>= "4.2.0"}
     "yojson"
     "ptime"
     "lwt" {>= "5.6.1"}
+    "h2" {>= "0.10.0"}
     "h2-lwt-unix" {>= "0.10.0"}
     "httpaf" {>= "0.7.1"}
+    "httpaf-lwt-unix"
     "cohttp" {>= "5.1.0"}
     "cohttp-lwt-unix"
     "cohttp-async"
-    "httpaf-lwt-unix"
     "ssl"
     "lwt_ssl"
     "jose"
@@ -34,17 +38,28 @@ depends: [
     "zarith"
     "ppx_jane"
     "ounit2" {with-test}
+    "ocamlformat" {with-test & = "0.25.1"}
     ]
 available: arch != "arm32" & arch != "x86_32"
-synopsis: "OCaml-based tools for AT Protocol"
-description: "
-OCaml-based tools for AT Protocol
+synopsis: "OCaml toolkit for the AT Protocol"
+description: """
+OCaml client and protocol library for the AT Protocol (XRPC, lexicons,
+repo sync, identity, AppView, Ozone, and chat).
 
-You can create a .env file with the minimum two variables
-- ATP_AUTH : EmailAddress:AppPassword
-    - Add your [App Password](https://bsky.app/settings/app-passwords)
-      credentials (using your normal email address as the username)
+Public modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video,
+Unspecced, Labeler, Chat, Ozone, Admin, Repo, Server, Identity, Did_plc,
+Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri, Lexicon,
+Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc, Error,
+Syntax, Embed, Facet, Notification, and Moderation.
 
-- ATP_HOST : bsky.social
-    - Add your atp host url without schema
-"
+Video support is a client for the hosted video service (byte upload +
+job-status poll). This package does not host a PDS, OAuth client-metadata
+document, browser login, or video transcoder.
+
+Configure a .env (see sample.env) with:
+- ATP_AUTH : EmailAddress:AppPassword (app password, not the account password)
+- ATP_HOST : bsky.social (PDS / entryway host without a scheme)
+
+Authenticated helpers skip live tests unless ATP_AUTH is a real credential
+pair. Public identity, PLC, firehose, and AppView reads do not require it.
+"""

--- a/atproto.opam
+++ b/atproto.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "0.1.0"
 maintainer: "david-engelmann david.engelmann44@gmail.com"
 authors: "david-engelmann david.engelmann44@gmail.com"
 homepage: "https://github.com/david-engelmann/atproto"

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,8 @@
 (lang dune 2.9)
 (name atproto)
+(license MIT)
+(authors "david-engelmann <david.engelmann44@gmail.com>")
+(maintainers "david-engelmann <david.engelmann44@gmail.com>")
+(source
+ (github david-engelmann/atproto))
+(documentation "https://github.com/david-engelmann/atproto")

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,6 @@
 (lang dune 2.9)
 (name atproto)
+(version 0.1.0)
 (license MIT)
 (authors "david-engelmann <david.engelmann44@gmail.com>")
 (maintainers "david-engelmann <david.engelmann44@gmail.com>")

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,4 @@
+(executable
+ (name offline)
+ (libraries atproto yojson)
+ (modules offline))

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -1,0 +1,141 @@
+(* Compiled (not live-run) examples for the public API documented in README.
+   `dune build` typechecks this against the current modules. *)
+
+open Atproto.Video
+open Atproto.Embed
+open Atproto.Facet
+open Atproto.Lexicon
+open Atproto.Tid
+open Atproto.Mst
+open Atproto.Oauth
+open Atproto.Xrpc
+open Atproto.Jetstream
+open Atproto.Oauth_scope
+open Atproto.Repo
+open Atproto.Server
+open Atproto.Http_method
+open Atproto.Hash
+open Atproto.Varint
+open Atproto.Syntax
+
+let () =
+  (* TID used as record keys and commit revs *)
+  assert (Tid.is_valid "3jzfcijpj2z2a");
+  (* MST layer for a repo key — official vector *)
+  assert (Mst.layer_for_key "blue" = 1);
+  (* OAuth client metadata (no hosted client required) *)
+  let meta =
+    Oauth.public_metadata
+      ~client_id:"https://client.example/client-metadata.json"
+      ~redirect_uris:[ "https://client.example/cb" ]
+      ()
+  in
+  Oauth.validate_metadata meta;
+  (* Video byte-upload pipeline — URL, service-auth audience, embed JSON *)
+  let url =
+    Video.upload_video_url ~did:"did:plc:abc123xyz0001112223333"
+      ~name:"clip.mp4" ()
+  in
+  assert (String.length url > 0);
+  let exp = Video.recommended_exp ~now:1_700_000_000.0 () in
+  assert (exp = Int64.add 1_700_000_000L Video.recommended_exp_seconds);
+  let blob =
+    `Assoc
+      [
+        ("$type", `String "blob");
+        ("ref", `Assoc [ ("$link", `String "bafyvideo") ]);
+        ("mimeType", `String "video/mp4");
+        ("size", `Int 8);
+      ]
+  in
+  let embed = Video.video_embed_json ~video:blob ~alt:"demo" () in
+  assert (
+    match Yojson.Safe.Util.member "$type" embed with
+    | `String "app.bsky.embed.video" -> true
+    | _ -> false);
+  (match
+     Embed.parse_embed
+       (`Assoc
+         [
+           ("$type", `String "app.bsky.embed.video");
+           ("video", blob);
+           ("alt", `String "demo");
+         ])
+   with
+  | `Video _ -> ()
+  | _ -> assert false);
+  let facet =
+    Facet.parse_facet
+      (`Assoc
+        [
+          ("index", `Assoc [ ("byteStart", `Int 0); ("byteEnd", `Int 4) ]);
+          ( "features",
+            `List
+              [
+                `Assoc
+                  [
+                    ("$type", `String "app.bsky.richtext.facet#tag");
+                    ("tag", `String "atp");
+                  ];
+              ] );
+        ])
+  in
+  (match facet with `Tag _ -> () | _ -> assert false);
+  let lex =
+    Lexicon.of_string
+      {|{"lexicon":1,"id":"com.example.ping","defs":{"main":{"type":"query","parameters":{"type":"params","properties":{}}}}}|}
+  in
+  assert (lex.id = "com.example.ping");
+  assert (Http_method.to_string Http_method.Get = "GET");
+  assert (Hash.sha256_hex "abc" <> "");
+  let n, _ = Varint.decode (Varint.encode 128) in
+  assert (n = 128);
+  assert (Syntax.is_valid_nsid "app.bsky.video.uploadVideo");
+  let writes =
+    Repo.apply_writes_body ~repo:"did:plc:abc123xyz0001112223333"
+      ~writes:
+        [
+          Repo.Delete
+            { collection = "app.bsky.feed.like"; rkey = "3jzfcijpj2z2a" };
+        ]
+      ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "repo" writes with
+    | `String _ -> true
+    | _ -> false);
+  let describe =
+    Server.parse_describe_server
+      (`Assoc
+        [
+          ("did", `String "did:web:bsky.social");
+          ("availableUserDomains", `List [ `String ".bsky.social" ]);
+        ])
+  in
+  assert (describe.did = "did:web:bsky.social");
+  let proxy = Xrpc.parse_proxy "did:web:api.bsky.chat#bsky_chat" in
+  assert (proxy.service = "bsky_chat");
+  let scopes = Oauth_scope.parse "atproto repo:app.bsky.feed.post" in
+  Oauth_scope.require_atproto scopes;
+  let ev =
+    Jetstream.parse_event
+      (`Assoc
+        [
+          ("$type", `String "message");
+          ( "payload",
+            `Assoc
+              [
+                ( "$type",
+                  `String "network.bsky.jetstream.subscribeEvents#commit" );
+                ("did", `String "did:plc:abc123xyz0001112223333");
+                ("seq", `Int 1);
+                ("time", `String "2026-01-01T00:00:00.000000Z");
+                ("operation", `String "create");
+                ("collection", `String "app.bsky.feed.post");
+                ("rkey", `String "3jzfcijpj2z2a");
+                ("rev", `String "3jzfcijpj2z2a");
+              ] );
+        ])
+  in
+  (match ev with `Commit _ -> () | _ -> assert false);
+  print_endline "examples/offline: public API typechecks and fixtures pass"

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -4,11 +4,8 @@ module Embed = struct
    * images
    * record
    * record_with_media
-   *
-   * need to parse embed similar to notification but with that bit about if
-   * the field is missing
-   *
-   * *)
+   * video
+   *)
   type ref = { ref_link : string }
 
   type image = {
@@ -45,88 +42,151 @@ module Embed = struct
   type image_view_embed = { embed_type : string; images : image_view list }
   type ext_embed = { embed_type : string; ext : ext }
   type ext_view_embed = { embed_type : string; ext : ext_view }
+  type strong_ref = { uri : string; cid : string }
+  type record_embed = { embed_type : string; record : strong_ref }
+  type aspect_ratio = { width : int; height : int }
+
+  type video_blob = {
+    cid : string;
+    mime_type : string;
+    size : int;
+    original : Yojson.Safe.t;
+  }
+
+  type video_embed = {
+    embed_type : string;
+    video : video_blob;
+    alt : string option;
+    aspect_ratio : aspect_ratio option;
+  }
+
+  type video_view_embed = {
+    embed_type : string;
+    cid : string;
+    playlist : string;
+    thumbnail : string option;
+    alt : string option;
+    aspect_ratio : aspect_ratio option;
+  }
+
+  type media =
+    [ `Image of image_embed
+    | `ImageView of image_view_embed
+    | `External of ext_embed
+    | `ExternalView of ext_view_embed
+    | `Video of video_embed
+    | `VideoView of video_view_embed ]
+
+  type record_with_media = {
+    embed_type : string;
+    record : record_embed;
+    media : media;
+  }
 
   type embed =
     [ `Image of image_embed
     | `ImageView of image_view_embed
     | `External of ext_embed
-    | `ExternalView of ext_view_embed ]
+    | `ExternalView of ext_view_embed
+    | `Record of record_embed
+    | `RecordWithMedia of record_with_media
+    | `Video of video_embed
+    | `VideoView of video_view_embed
+    | `Unknown of Yojson.Safe.t ]
+
+  let string_member json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
+
+  let string_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
+  let int_member json field =
+    match Yojson.Safe.Util.member field json with `Int n -> n | _ -> 0
 
   let parse_ref json : ref =
     let open Yojson.Safe.Util in
-    let ref_link = json |> member "$link" |> to_string in
+    let ref_link =
+      match json |> member "$link" with
+      | `String s -> s
+      | _ -> ( match json with `String s -> s | _ -> "")
+    in
     { ref_link }
 
   let parse_image json : image =
     let open Yojson.Safe.Util in
-    let image_type = json |> member "$type" |> to_string in
+    let image_type = string_member json "$type" in
     let ref = json |> member "ref" |> parse_ref in
-    let mime_type = json |> member "mimeType" |> to_string in
-    let size = json |> member "size" |> to_int in
+    let mime_type = string_member json "mimeType" in
+    let size = int_member json "size" in
     { image_type; ref; mime_type; size }
 
   let parse_thumb json : thumb =
-    let open Yojson.Safe.Util in
-    let thumb_type = json |> member "$type" |> to_string in
-    let ref = json |> member "ref" |> parse_ref in
-    let mime_type = json |> member "mimeType" |> to_string in
-    let size = json |> member "size" |> to_int in
-    { thumb_type; ref; mime_type; size }
+    let image_type = string_member json "$type" in
+    let ref = Yojson.Safe.Util.member "ref" json |> parse_ref in
+    let mime_type = string_member json "mimeType" in
+    let size = int_member json "size" in
+    { thumb_type = image_type; ref; mime_type; size }
 
   let parse_ext json : ext =
     let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
+    let uri = string_member json "uri" in
     let thumb = json |> member "thumb" |> parse_thumb in
-    let title = json |> member "title" |> to_string in
-    let description = json |> member "description" |> to_string in
+    let title = string_member json "title" in
+    let description = string_member json "description" in
     { uri; thumb; title; description }
 
   let parse_ext_view json : ext_view =
-    let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
-    let title = json |> member "title" |> to_string in
-    let description = json |> member "description" |> to_string in
-    let thumb = json |> member "thumb" |> to_string in
-    { uri; title; description; thumb }
+    {
+      uri = string_member json "uri";
+      title = string_member json "title";
+      description = string_member json "description";
+      thumb = string_member json "thumb";
+    }
 
   let parse_ext_embed json : ext_embed =
     let open Yojson.Safe.Util in
-    let embed_type = json |> member "$type" |> to_string in
+    let embed_type = string_member json "$type" in
     let ext = json |> member "external" |> parse_ext in
     { embed_type; ext }
 
   let parse_ext_view_embed json : ext_view_embed =
     let open Yojson.Safe.Util in
-    let embed_type = json |> member "$type" |> to_string in
+    let embed_type = string_member json "$type" in
     let ext = json |> member "external" |> parse_ext_view in
     { embed_type; ext }
 
   let parse_image_data json : image_data =
     let open Yojson.Safe.Util in
-    let alt = json |> member "alt" |> to_string in
+    let alt = string_member json "alt" in
     let image = json |> member "image" |> parse_image in
     { alt; image }
 
   let parse_image_view json : image_view =
-    let open Yojson.Safe.Util in
-    let thumb = json |> member "thumb" |> to_string in
-    let fullsize = json |> member "fullsize" |> to_string in
-    let alt = json |> member "alt" |> to_string in
-    { thumb; fullsize; alt }
+    {
+      thumb = string_member json "thumb";
+      fullsize = string_member json "fullsize";
+      alt = string_member json "alt";
+    }
 
   let parse_image_embed json : image_embed =
     let open Yojson.Safe.Util in
-    let embed_type = json |> member "$type" |> to_string in
+    let embed_type = string_member json "$type" in
     let images =
-      json |> member "images" |> to_list |> List.map parse_image_data
+      match json |> member "images" with
+      | `List items -> List.map parse_image_data items
+      | _ -> []
     in
     { embed_type; images }
 
   let parse_image_view_embed json : image_view_embed =
     let open Yojson.Safe.Util in
-    let embed_type = json |> member "$type" |> to_string in
+    let embed_type = string_member json "$type" in
     let images =
-      json |> member "images" |> to_list |> List.map parse_image_view
+      match json |> member "images" with
+      | `List items -> List.map parse_image_view items
+      | _ -> []
     in
     { embed_type; images }
 
@@ -135,10 +195,71 @@ module Embed = struct
     | `Assoc fields -> List.exists (fun (key, _) -> key = field) fields
     | _ -> false
 
-  let check_field_is_string field json : bool =
+  let parse_strong_ref json : strong_ref =
+    { uri = string_member json "uri"; cid = string_member json "cid" }
+
+  let parse_record_embed json : record_embed =
     let open Yojson.Safe.Util in
-    let test_field_value = member field json in
-    match test_field_value with `String _ -> true | _ -> false
+    let embed_type = string_member json "$type" in
+    let record =
+      match json |> member "record" with
+      | `Assoc _ as rec_ ->
+          if check_for_field "uri" rec_ then parse_strong_ref rec_
+          else
+            (* embed.record nests the strongRef one more level *)
+            parse_strong_ref (rec_ |> member "record")
+      | _ -> parse_strong_ref json
+    in
+    { embed_type; record }
+
+  let parse_aspect_ratio json : aspect_ratio option =
+    match json with
+    | `Assoc _ ->
+        let w = int_member json "width" in
+        let h = int_member json "height" in
+        if w = 0 && h = 0 then None else Some { width = w; height = h }
+    | _ -> None
+
+  let parse_video_blob json : video_blob =
+    let open Yojson.Safe.Util in
+    let cid =
+      match json |> member "ref" with
+      | `Assoc _ as ref_ -> (
+          match ref_ |> member "$link" with `String s -> s | _ -> "")
+      | `String s -> s
+      | _ -> string_member json "cid"
+    in
+    {
+      cid;
+      mime_type = string_member json "mimeType";
+      size = int_member json "size";
+      original = json;
+    }
+
+  let check_field_is_string field json : bool =
+    match Yojson.Safe.Util.member field json with
+    | `String _ -> true
+    | _ -> false
+
+  let parse_video_embed json : video_embed =
+    let open Yojson.Safe.Util in
+    {
+      embed_type = string_member json "$type";
+      video = json |> member "video" |> parse_video_blob;
+      alt = string_opt json "alt";
+      aspect_ratio = parse_aspect_ratio (json |> member "aspectRatio");
+    }
+
+  let parse_video_view_embed json : video_view_embed =
+    {
+      embed_type = string_member json "$type";
+      cid = string_member json "cid";
+      playlist = string_member json "playlist";
+      thumbnail = string_opt json "thumbnail";
+      alt = string_opt json "alt";
+      aspect_ratio =
+        parse_aspect_ratio (Yojson.Safe.Util.member "aspectRatio" json);
+    }
 
   let parse_to_correct_external_type json =
     let open Yojson.Safe.Util in
@@ -151,24 +272,71 @@ module Embed = struct
 
   let parse_to_correct_image_type json =
     let open Yojson.Safe.Util in
-    let image_field_check =
-      check_for_field "image" (json |> member "images" |> to_list |> List.hd)
-    in
-    match image_field_check with
-    | false -> `ImageView (parse_image_view_embed json)
-    | true -> `Image (parse_image_embed json)
+    match json |> member "images" with
+    | `List (hd :: _) ->
+        if check_for_field "image" hd then `Image (parse_image_embed json)
+        else `ImageView (parse_image_view_embed json)
+    | _ -> `ImageView (parse_image_view_embed json)
 
-  let parse_embed json : embed =
-    let images_field_check = check_for_field "images" json in
-    let external_field_check = check_for_field "external" json in
-    match images_field_check with
-    | true -> parse_to_correct_image_type json
-    | false -> (
-        match external_field_check with
-        | false -> failwith "haven't got to record record_with_media"
-        | true -> parse_to_correct_external_type json)
+  let parse_to_correct_video_type json =
+    if check_for_field "playlist" json || check_for_field "cid" json then
+      `VideoView (parse_video_view_embed json)
+    else `Video (parse_video_embed json)
+
+  let rec parse_media json : media =
+    match parse_embed json with
+    | `Image e -> `Image e
+    | `ImageView e -> `ImageView e
+    | `External e -> `External e
+    | `ExternalView e -> `ExternalView e
+    | `Video e -> `Video e
+    | `VideoView e -> `VideoView e
+    | _ -> `External (parse_ext_embed json)
+
+  and parse_record_with_media json : record_with_media =
+    let open Yojson.Safe.Util in
+    {
+      embed_type = string_member json "$type";
+      record = parse_record_embed json;
+      media = parse_media (json |> member "media");
+    }
+
+  and parse_embed json : embed =
+    let typ = string_member json "$type" in
+    if typ = "app.bsky.embed.video" || typ = "app.bsky.embed.video#main" then
+      `Video (parse_video_embed json)
+    else if typ = "app.bsky.embed.video#view" then
+      `VideoView (parse_video_view_embed json)
+    else if
+      typ = "app.bsky.embed.recordWithMedia"
+      || typ = "app.bsky.embed.recordWithMedia#main"
+      || typ = "app.bsky.embed.recordWithMedia#view"
+    then `RecordWithMedia (parse_record_with_media json)
+    else if typ = "app.bsky.embed.record" || typ = "app.bsky.embed.record#main"
+    then `Record (parse_record_embed json)
+    else if typ = "app.bsky.embed.images" || typ = "app.bsky.embed.images#main"
+    then parse_to_correct_image_type json
+    else if typ = "app.bsky.embed.images#view" then
+      `ImageView (parse_image_view_embed json)
+    else if
+      typ = "app.bsky.embed.external" || typ = "app.bsky.embed.external#main"
+    then parse_to_correct_external_type json
+    else if typ = "app.bsky.embed.external#view" then
+      `ExternalView (parse_ext_view_embed json)
+    else if check_for_field "images" json then parse_to_correct_image_type json
+    else if check_for_field "external" json then
+      parse_to_correct_external_type json
+    else if check_for_field "video" json || check_for_field "playlist" json then
+      parse_to_correct_video_type json
+    else if check_for_field "record" json && check_for_field "media" json then
+      `RecordWithMedia (parse_record_with_media json)
+    else if check_for_field "record" json then `Record (parse_record_embed json)
+    else `Unknown json
 
   let parse_embed_option json : embed option =
     let open Yojson.Safe.Util in
-    try Some (json |> member "embed" |> parse_embed) with Type_error _ -> None
+    match json |> member "embed" with
+    | `Null -> None
+    | `Assoc _ as inner -> ( try Some (parse_embed inner) with _ -> None)
+    | _ -> None
 end

--- a/src/bsky/facet.ml
+++ b/src/bsky/facet.ml
@@ -1,7 +1,8 @@
 module Facet = struct
   type facet_index = { byte_end : int; byte_start : int }
   type mention_feature = { did : string; mention_type : string }
-  type link_feature = { cid : string; link_type : string }
+  type link_feature = { uri : string; cid : string; link_type : string }
+  type tag_feature = { tag : string; tag_type : string }
 
   type mention_facet = {
     facet_type : string;
@@ -10,48 +11,64 @@ module Facet = struct
   }
 
   type link_facet = { facet_index : facet_index; features : link_feature list }
-  type facet = [ `Mention of mention_facet | `Link of link_facet ]
+  type tag_facet = { facet_index : facet_index; features : tag_feature list }
+
+  type facet =
+    [ `Mention of mention_facet | `Link of link_facet | `Tag of tag_facet ]
+
+  let string_member json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
 
   let parse_link_feature json : link_feature =
-    let open Yojson.Safe.Util in
-    let cid = json |> member "cid" |> to_string in
-    let link_type = json |> member "$type" |> to_string in
-    { cid; link_type }
+    let uri = string_member json "uri" in
+    let cid = string_member json "cid" in
+    let link_type = string_member json "$type" in
+    { uri; cid; link_type }
 
   let parse_mention_feature json : mention_feature =
-    let open Yojson.Safe.Util in
-    let did = json |> member "did" |> to_string in
-    let mention_type = json |> member "$type" |> to_string in
+    let did = string_member json "did" in
+    let mention_type = string_member json "$type" in
     { did; mention_type }
+
+  let parse_tag_feature json : tag_feature =
+    let tag = string_member json "tag" in
+    let tag_type = string_member json "$type" in
+    { tag; tag_type }
 
   let parse_facet_index json : facet_index =
     let open Yojson.Safe.Util in
-    let byte_end = json |> member "byteEnd" |> to_int in
-    let byte_start = json |> member "byteStart" |> to_int in
+    let byte_end = match json |> member "byteEnd" with `Int n -> n | _ -> 0 in
+    let byte_start =
+      match json |> member "byteStart" with `Int n -> n | _ -> 0
+    in
     { byte_end; byte_start }
 
   let convert_body_to_json (body : string) : Yojson.Safe.t =
     let json = Yojson.Safe.from_string body in
     json
 
-  let check_for_facet_type_presence json =
-    match Yojson.Safe.Util.member "$type" json with `Null -> false | _ -> true
+  let feature_type json = string_member json "$type"
+
+  let is_type suffix json =
+    let t = feature_type json in
+    let n = String.length suffix in
+    String.length t >= n && String.sub t (String.length t - n) n = suffix
 
   let parse_facet json : facet =
     let open Yojson.Safe.Util in
-    let facet_check = check_for_facet_type_presence json in
-    match facet_check with
-    | false ->
-        let facet_index = json |> member "index" |> parse_facet_index in
-        let features =
-          json |> member "features" |> to_list |> List.map parse_link_feature
-        in
-        `Link { facet_index; features }
-    | true ->
-        let facet_type = json |> member "$type" |> to_string in
-        let facet_index = json |> member "index" |> parse_facet_index in
-        let features =
-          json |> member "features" |> to_list |> List.map parse_mention_feature
-        in
-        `Mention { facet_type; facet_index; features }
+    let facet_index = json |> member "index" |> parse_facet_index in
+    let features_json =
+      match json |> member "features" with `List xs -> xs | _ -> []
+    in
+    let first = match features_json with hd :: _ -> hd | [] -> `Null in
+    if is_type "#mention" first || is_type "mention" first then
+      let facet_type = string_member json "$type" in
+      let features = List.map parse_mention_feature features_json in
+      `Mention { facet_type; facet_index; features }
+    else if is_type "#tag" first || is_type "tag" first then
+      let features = List.map parse_tag_feature features_json in
+      `Tag { facet_index; features }
+    else
+      let features = List.map parse_link_feature features_json in
+      `Link { facet_index; features }
 end

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -35,12 +35,14 @@ module Notification = struct
   }
 
   type unread_count = { count : int }
+  type other_record = { reason : string; raw : Yojson.Safe.t }
 
   type record =
     [ `Like of like_record
     | `Follow of follow_record
     | `Repost of repost_record
-    | `Reply of reply_record ]
+    | `Reply of reply_record
+    | `Other of other_record ]
 
   type notification = {
     uri : string;
@@ -112,11 +114,15 @@ module Notification = struct
     | "reply" ->
         let text = json |> member "text" |> to_string in
         let record_type = json |> member "$type" |> to_string in
-        let langs = json |> member "langs" |> to_list |> List.map to_string in
+        let langs =
+          match json |> member "langs" with
+          | `List items -> List.map to_string items
+          | _ -> []
+        in
         let reply = json |> member "reply" |> parse_reply in
         let created_at = json |> member "createdAt" |> to_string in
         `Reply { text; record_type; langs; reply; created_at }
-    | _ -> failwith ("Unknown Record Type: " ^ reason)
+    | _ -> `Other { reason; raw = json }
 
   let parse_notification json : notification =
     let open Yojson.Safe.Util in

--- a/src/bsky/video.ml
+++ b/src/bsky/video.ml
@@ -99,22 +99,25 @@ module Video = struct
         state
     in
     if upper = "JOB_STATE_COMPLETED" || upper = "COMPLETED" then Completed
-    else if
-      upper = "JOB_STATE_FAILED" || upper = "FAILED" || upper = "ALREADY_EXISTS"
-    then Failed
+    else if upper = "JOB_STATE_FAILED" || upper = "FAILED" then Failed
     else In_progress
 
-  let is_completed (st : job_status) : bool =
-    classify_state st.state = Completed
+  let blob_ready (st : job_status) : bool = Option.is_some st.blob
 
-  let is_failed (st : job_status) : bool = classify_state st.state = Failed
+  (* already_exists is not a hard failure — the tutorial notes the job
+     may still carry a blob ref that can be embedded. *)
+  let is_completed (st : job_status) : bool =
+    classify_state st.state = Completed || blob_ready st
+
+  let is_failed (st : job_status) : bool =
+    classify_state st.state = Failed && not (blob_ready st)
 
   let is_terminal (st : job_status) : bool =
+    blob_ready st
+    ||
     match classify_state st.state with
     | Completed | Failed -> true
     | In_progress -> false
-
-  let blob_ready (st : job_status) : bool = Option.is_some st.blob
 
   let already_exists (st : job_status) : bool =
     match st.error with

--- a/src/bsky/video.ml
+++ b/src/bsky/video.ml
@@ -1,8 +1,22 @@
 open Session
 open Client
 
-(** app.bsky.video — upload limits and processing job status. *)
+(** app.bsky.video — upload limits, raw-byte upload, and processing job status.
+
+    This is a client for the hosted video service (default [video.bsky.app]).
+    It does not run a transcoding service. The recommended flow is:
+
+    1. mint a PDS-scoped service-auth token ([pds_audience] +
+       [upload_blob_lxm], ~30 min [recommended_exp])
+    2. POST the bytes to [upload_video]
+    3. poll [get_job_status] until a blob ref is present
+    4. embed the blob with [video_embed_json] *)
 module Video = struct
+  let default_host = "video.bsky.app"
+  let upload_nsid = "app.bsky.video.uploadVideo"
+  let upload_blob_lxm = "com.atproto.repo.uploadBlob"
+  let recommended_exp_seconds = 1800L
+
   type job_status = {
     job_id : string;
     did : string;
@@ -21,6 +35,33 @@ module Video = struct
     message : string option;
     error : string option;
   }
+
+  type job_phase = Completed | Failed | In_progress
+  type aspect_ratio = { width : int; height : int }
+
+  let host_of_endpoint (url : string) : string =
+    let strip prefix =
+      let plen = String.length prefix in
+      if String.length url >= plen && String.sub url 0 plen = prefix then
+        String.sub url plen (String.length url - plen)
+      else url
+    in
+    let rest =
+      let after_https = strip "https://" in
+      if after_https = url then strip "http://" else after_https
+    in
+    match String.index_opt rest '/' with
+    | None -> rest
+    | Some i -> String.sub rest 0 i
+
+  let pds_audience ?host (s : Session.session) : string =
+    let raw = match host with Some h -> h | None -> s.Session.atp_host in
+    "did:web:" ^ host_of_endpoint raw
+
+  let recommended_exp ?(now = Unix.gettimeofday ()) () : int64 =
+    Int64.add (Int64.of_float now) recommended_exp_seconds
+
+  let video_host ?host () = Option.value host ~default:default_host
 
   let parse_job_status json : job_status =
     {
@@ -51,8 +92,53 @@ module Video = struct
       error = Client.string_opt json "error";
     }
 
+  let classify_state (state : string) : job_phase =
+    let upper =
+      String.map
+        (function 'a' .. 'z' as c -> Char.chr (Char.code c - 32) | c -> c)
+        state
+    in
+    if upper = "JOB_STATE_COMPLETED" || upper = "COMPLETED" then Completed
+    else if
+      upper = "JOB_STATE_FAILED" || upper = "FAILED" || upper = "ALREADY_EXISTS"
+    then Failed
+    else In_progress
+
+  let is_completed (st : job_status) : bool =
+    classify_state st.state = Completed
+
+  let is_failed (st : job_status) : bool = classify_state st.state = Failed
+
+  let is_terminal (st : job_status) : bool =
+    match classify_state st.state with
+    | Completed | Failed -> true
+    | In_progress -> false
+
+  let blob_ready (st : job_status) : bool = Option.is_some st.blob
+
+  let already_exists (st : job_status) : bool =
+    match st.error with
+    | Some e ->
+        let upper =
+          String.map
+            (function 'a' .. 'z' as c -> Char.chr (Char.code c - 32) | c -> c)
+            e
+        in
+        upper = "ALREADY_EXISTS"
+    | None -> false
+
+  let parse_upload_response json : job_status =
+    let st = parse_job_status_response json in
+    (* already_exists may put jobId / blob on the error object itself. *)
+    if st.job_id = "" then
+      match Yojson.Safe.Util.member "jobId" json with
+      | `String id -> { st with job_id = id }
+      | _ -> st
+    else st
+
   let get_job_status ?session ?host ~job_id () : job_status =
-    Client.get_json ?session ?host "app.bsky.video.getJobStatus"
+    Client.get_json ?session ~host:(video_host ?host ())
+      "app.bsky.video.getJobStatus"
       [ ("jobId", job_id) ]
     |> parse_job_status_response
 
@@ -60,6 +146,72 @@ module Video = struct
     Client.get_json ~session:s "app.bsky.video.getUploadLimits" []
     |> parse_upload_limits
 
-  let upload_video_url ?session ?host () =
-    Client.nsid_url ?session ?host "app.bsky.video.uploadVideo"
+  let upload_video_url ?host ~did ~name () =
+    let base = Client.nsid_url ~host:(video_host ?host ()) upload_nsid in
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs
+        [ ("did", did); ("name", name) ]
+    in
+    if qs = "" then base else base ^ "?" ^ qs
+
+  let upload_header_pairs ~token ~content_type =
+    [ ("Authorization", "Bearer " ^ token); ("Content-Type", content_type) ]
+
+  let upload_video ?host ~token ~did ~name ?(content_type = "video/mp4")
+      (bytes : string) : job_status =
+    let url = upload_video_url ?host ~did ~name () in
+    let headers =
+      Cohttp_client.Cohttp_client.create_headers_from_pairs
+        (upload_header_pairs ~token ~content_type)
+    in
+    let body =
+      Lwt_main.run
+        (Cohttp_client.Cohttp_client.post_data_with_headers url bytes headers)
+    in
+    parse_upload_response (Yojson.Safe.from_string body)
+
+  let poll_job_status ?(get_status : (string -> job_status) option)
+      ?(sleep : (unit -> unit) option) ?session ?host ~job_id
+      ?(max_attempts = 60) () : job_status =
+    let get =
+      match get_status with
+      | Some f -> f
+      | None -> fun id -> get_job_status ?session ?host ~job_id:id ()
+    in
+    let rest =
+      match sleep with Some f -> f | None -> fun () -> Unix.sleepf 1.0
+    in
+    let rec loop attempt =
+      let st = get job_id in
+      if blob_ready st || is_terminal st || attempt >= max_attempts then st
+      else (
+        rest ();
+        loop (attempt + 1))
+    in
+    loop 1
+
+  let ensure_blob ?get_status ?sleep ?session ?host (st : job_status) :
+      job_status =
+    if blob_ready st then st
+    else if st.job_id = "" then st
+    else poll_job_status ?get_status ?sleep ?session ?host ~job_id:st.job_id ()
+
+  let mint_upload_token (s : Session.session) ?pds_host ?exp () : string =
+    let aud = pds_audience ?host:pds_host s in
+    let exp = match exp with Some e -> e | None -> recommended_exp () in
+    (Server.Server.get_service_auth s ~aud ~lxm:upload_blob_lxm ~exp ()).token
+
+  let aspect_ratio_json (ar : aspect_ratio) : Yojson.Safe.t =
+    `Assoc [ ("width", `Int ar.width); ("height", `Int ar.height) ]
+
+  let video_embed_json ~video ?alt ?aspect_ratio () : Yojson.Safe.t =
+    let fields =
+      [ ("$type", `String "app.bsky.embed.video"); ("video", video) ]
+      @ (match alt with Some a -> [ ("alt", `String a) ] | None -> [])
+      @
+      match aspect_ratio with
+      | Some ar -> [ ("aspectRatio", aspect_ratio_json ar) ]
+      | None -> []
+    in
+    `Assoc fields
 end

--- a/src/dune
+++ b/src/dune
@@ -54,6 +54,7 @@
   Http_client
   Http_method
   Identity
+  Jetstream
   K256
   Label
   Labeler
@@ -62,6 +63,7 @@
   Mst
   Notification
   Oauth
+  Oauth_scope
   Ozone
   Repo
   Request

--- a/src/http_method.ml
+++ b/src/http_method.ml
@@ -1,12 +1,19 @@
 module Http_method = struct
-  type http_method = Get | Post
-  (*| Put
-    | Delete
-    | Patch*)
+  type http_method = Get | Post | Put | Delete | Patch
 
   let lookup_http_method meth : http_method =
-    match meth with
+    match String.lowercase_ascii meth with
     | "get" -> Get
     | "post" -> Post
+    | "put" -> Put
+    | "delete" -> Delete
+    | "patch" -> Patch
     | _ -> failwith "Not Recognized Method"
+
+  let to_string = function
+    | Get -> "GET"
+    | Post -> "POST"
+    | Put -> "PUT"
+    | Delete -> "DELETE"
+    | Patch -> "PATCH"
 end

--- a/src/jetstream.ml
+++ b/src/jetstream.ml
@@ -1,0 +1,502 @@
+open Websocket
+
+(** Jetstream JSON firehose — live tail for v2 (recommended) and v1.
+
+    Spec: https://bsky.network/docs/jetstream/
+    Lexicon: network.bsky.jetstream.subscribeEvents (xrpc.v1.json)
+
+    Network Replay / snapshot HTTP methods are typed here but are not called
+    live (public instances gate the archive; this library does not invent a
+    token). *)
+module Jetstream = struct
+  let v2_west_host = "jetstream.us-west.bsky.network"
+  let v2_east_host = "jetstream.us-east.bsky.network"
+  let v1_west_host = "jetstream1.us-west.bsky.network"
+  let v1_east_host = "jetstream2.us-east.bsky.network"
+  let default_host = v2_west_host
+  let v2_path = "/xrpc/network.bsky.jetstream.subscribeEvents"
+  let v1_path = "/subscribe"
+  let subscribe_nsid = "network.bsky.jetstream.subscribeEvents"
+  let max_collections = 100
+  let max_dids = 10_000
+  let time_us_floor = 1_000_000_000_000_000L
+
+  type version = V1 | V2
+  type kind = Commit | Identity | Account | Sync
+  type cursor = Seq of int64 | Time_us of int64
+
+  type filter = {
+    collections : string list;
+    dids : string list;
+    kinds : kind list;
+    cursor : cursor option;
+    max_message_size_bytes : int option;
+  }
+
+  let empty_filter =
+    {
+      collections = [];
+      dids = [];
+      kinds = [];
+      cursor = None;
+      max_message_size_bytes = None;
+    }
+
+  let kind_to_string = function
+    | Commit -> "commit"
+    | Identity -> "identity"
+    | Account -> "account"
+    | Sync -> "sync"
+
+  let kind_of_string = function
+    | "commit" -> Some Commit
+    | "identity" -> Some Identity
+    | "account" -> Some Account
+    | "sync" -> Some Sync
+    | _ -> None
+
+  exception Invalid_filter of string
+
+  let validate_filter (f : filter) : unit =
+    if List.length f.collections > max_collections then
+      raise
+        (Invalid_filter (Printf.sprintf "collections cap is %d" max_collections));
+    if List.length f.dids > max_dids then
+      raise (Invalid_filter (Printf.sprintf "dids cap is %d" max_dids));
+    List.iter
+      (fun d ->
+        if not (Syntax.Syntax.is_valid_did d) then
+          raise (Invalid_filter ("invalid did " ^ d)))
+      f.dids;
+    if f.collections <> [] && f.kinds <> [] && not (List.mem Commit f.kinds)
+    then
+      raise
+        (Invalid_filter
+           "collections filter requires kinds to include commit (or omit kinds)")
+
+  let cursor_of_int64 (n : int64) : cursor =
+    if n >= time_us_floor then Time_us n else Seq n
+
+  let cursor_to_string = function Seq n | Time_us n -> Int64.to_string n
+  let repeat_params key values = List.map (fun v -> (key, v)) values
+
+  let filter_pairs ?(version = V2) (f : filter) : (string * string) list =
+    let coll_key, did_key =
+      match version with
+      | V2 -> ("collections", "dids")
+      | V1 -> ("wantedCollections", "wantedDids")
+    in
+    repeat_params coll_key f.collections
+    @ repeat_params did_key f.dids
+    @ (match version with
+      | V2 -> repeat_params "kinds" (List.map kind_to_string f.kinds)
+      | V1 -> [])
+    @ (match f.cursor with
+      | Some c -> [ ("cursor", cursor_to_string c) ]
+      | None -> [])
+    @
+    match (version, f.max_message_size_bytes) with
+    | V2, Some n when n > 0 -> [ ("maxMessageSizeBytes", string_of_int n) ]
+    | _ -> []
+
+  let subscribe_url ?(host = default_host) ?(version = V2)
+      ?(filter = empty_filter) () =
+    validate_filter filter;
+    let path = match version with V2 -> v2_path | V1 -> v1_path in
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs
+        (filter_pairs ~version filter)
+    in
+    let base = Printf.sprintf "wss://%s%s" host path in
+    if qs = "" then base else base ^ "?" ^ qs
+
+  type commit = {
+    did : string;
+    seq : int64;
+    time : string;
+    operation : string;
+    collection : string;
+    rkey : string;
+    rev : string;
+    cid : string option;
+    record : Yojson.Safe.t option;
+  }
+
+  type identity = {
+    did : string;
+    seq : int64;
+    time : string;
+    handle : string option;
+  }
+
+  type account = {
+    did : string;
+    seq : int64;
+    time : string;
+    active : bool;
+    status : string option;
+  }
+
+  type sync = { did : string; seq : int64; time : string; rev : string }
+  type info = { name : string; message : string option }
+
+  type event =
+    [ `Commit of commit
+    | `Identity of identity
+    | `Account of account
+    | `Sync of sync
+    | `Info of info
+    | `Unknown of Yojson.Safe.t ]
+
+  let string_member json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
+
+  let string_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
+  let bool_member json field =
+    match Yojson.Safe.Util.member field json with `Bool b -> b | _ -> false
+
+  let int64_member json field =
+    match Yojson.Safe.Util.member field json with
+    | `Int n -> Int64.of_int n
+    | `Intlit s -> Int64.of_string s
+    | `String s -> ( try Int64.of_string s with _ -> 0L)
+    | _ -> 0L
+
+  let payload_type_fragment typ =
+    match String.rindex_opt typ '#' with
+    | None -> typ
+    | Some i -> String.sub typ (i + 1) (String.length typ - i - 1)
+
+  let parse_commit json : commit =
+    {
+      did = string_member json "did";
+      seq = int64_member json "seq";
+      time = string_member json "time";
+      operation = string_member json "operation";
+      collection = string_member json "collection";
+      rkey = string_member json "rkey";
+      rev = string_member json "rev";
+      cid = string_opt json "cid";
+      record =
+        (match Yojson.Safe.Util.member "record" json with
+        | `Null -> None
+        | other -> Some other);
+    }
+
+  let parse_identity json : identity =
+    let inner =
+      match Yojson.Safe.Util.member "identity" json with
+      | `Assoc _ as obj -> obj
+      | _ -> json
+    in
+    {
+      did = string_member json "did";
+      seq = int64_member json "seq";
+      time = string_member json "time";
+      handle =
+        (match string_opt inner "handle" with
+        | Some _ as h -> h
+        | None -> string_opt json "handle");
+    }
+
+  let parse_account json : account =
+    let inner =
+      match Yojson.Safe.Util.member "account" json with
+      | `Assoc _ as obj -> obj
+      | _ -> json
+    in
+    {
+      did = string_member json "did";
+      seq = int64_member json "seq";
+      time = string_member json "time";
+      active =
+        (match Yojson.Safe.Util.member "active" inner with
+        | `Bool b -> b
+        | _ -> bool_member json "active");
+      status =
+        (match string_opt inner "status" with
+        | Some _ as s -> s
+        | None -> string_opt json "status");
+    }
+
+  let parse_sync json : sync =
+    let inner =
+      match Yojson.Safe.Util.member "sync" json with
+      | `Assoc _ as obj -> obj
+      | _ -> json
+    in
+    {
+      did = string_member json "did";
+      seq = int64_member json "seq";
+      time = string_member json "time";
+      rev =
+        (match string_opt inner "rev" with
+        | Some r -> r
+        | None -> string_member json "rev");
+    }
+
+  let parse_info json : info =
+    { name = string_member json "name"; message = string_opt json "message" }
+
+  let parse_v1_commit did time_us json : commit =
+    {
+      did;
+      seq = time_us;
+      time = "";
+      operation = string_member json "operation";
+      collection = string_member json "collection";
+      rkey = string_member json "rkey";
+      rev = string_member json "rev";
+      cid = string_opt json "cid";
+      record =
+        (match Yojson.Safe.Util.member "record" json with
+        | `Null -> None
+        | other -> Some other);
+    }
+
+  let parse_kind_payload kind json : event =
+    match kind with
+    | "commit" -> `Commit (parse_commit json)
+    | "identity" -> `Identity (parse_identity json)
+    | "account" -> `Account (parse_account json)
+    | "sync" -> `Sync (parse_sync json)
+    | "info" -> `Info (parse_info json)
+    | _ -> `Unknown json
+
+  let parse_event json : event =
+    match Yojson.Safe.Util.member "payload" json with
+    | `Assoc _ as payload ->
+        let frag = payload_type_fragment (string_member payload "$type") in
+        parse_kind_payload frag payload
+    | _ -> (
+        match string_opt json "kind" with
+        | Some kind -> (
+            let did = string_member json "did" in
+            let time_us = int64_member json "time_us" in
+            match kind with
+            | "commit" ->
+                `Commit
+                  (parse_v1_commit did time_us
+                     (Yojson.Safe.Util.member "commit" json))
+            | "identity" ->
+                `Identity
+                  (parse_identity
+                     (match Yojson.Safe.Util.member "identity" json with
+                     | `Assoc _ as inner -> inner
+                     | _ -> json))
+            | "account" ->
+                `Account
+                  (parse_account
+                     (match Yojson.Safe.Util.member "account" json with
+                     | `Assoc _ as inner -> inner
+                     | _ -> json))
+            | "sync" -> `Sync (parse_sync json)
+            | _ -> `Unknown json)
+        | None ->
+            let typ = payload_type_fragment (string_member json "$type") in
+            if typ = "" then `Unknown json else parse_kind_payload typ json)
+
+  let parse_frame (body : string) : event =
+    parse_event (Yojson.Safe.from_string body)
+
+  let seq_of (ev : event) : int64 option =
+    match ev with
+    | `Commit (c : commit) -> Some c.seq
+    | `Identity (i : identity) -> Some i.seq
+    | `Account (a : account) -> Some a.seq
+    | `Sync (s : sync) -> Some s.seq
+    | `Info _ | `Unknown _ -> None
+
+  let event_key (ev : event) : string =
+    match ev with
+    | `Commit (c : commit) ->
+        Printf.sprintf "c:%s/%s/%s@%Ld" c.did c.collection c.rkey c.seq
+    | `Identity (i : identity) -> Printf.sprintf "i:%s@%Ld" i.did i.seq
+    | `Account (a : account) -> Printf.sprintf "a:%s@%Ld" a.did a.seq
+    | `Sync (s : sync) -> Printf.sprintf "s:%s@%Ld" s.did s.seq
+    | `Info (i : info) -> "info:" ^ i.name
+    | `Unknown _ -> "unknown"
+
+  let record_uri (c : commit) : string =
+    Printf.sprintf "at://%s/%s/%s" c.did c.collection c.rkey
+
+  type seen = {
+    keys : (string, unit) Hashtbl.t;
+    order : string Queue.t;
+    cap : int;
+  }
+
+  let create_seen ?(cap = 4096) () : seen =
+    { keys = Hashtbl.create cap; order = Queue.create (); cap }
+
+  let remember (s : seen) (ev : event) : unit =
+    let key = event_key ev in
+    if not (Hashtbl.mem s.keys key) then (
+      Hashtbl.add s.keys key ();
+      Queue.add key s.order;
+      if Queue.length s.order > s.cap then
+        let old = Queue.take s.order in
+        Hashtbl.remove s.keys old)
+
+  let is_duplicate (s : seen) (ev : event) : bool =
+    Hashtbl.mem s.keys (event_key ev)
+
+  let with_cursor (f : filter) (c : cursor) : filter =
+    { f with cursor = Some c }
+
+  let subscribe ?(host = default_host) ?(version = V2) ?(filter = empty_filter)
+      ?max_messages ?(max_reconnects = 0)
+      ?(sleep = fun n -> Unix.sleepf (min 8.0 (2.0 ** float_of_int n))) f =
+    validate_filter filter;
+    let filter = ref filter in
+    let seen = create_seen () in
+    let received = ref 0 in
+    let rec attempt n =
+      let url = subscribe_url ~host ~version ~filter:!filter () in
+      try
+        Websocket.with_connection url (fun ws ->
+            let rec loop () =
+              match max_messages with
+              | Some m when !received >= m -> ()
+              | _ -> (
+                  match Websocket.recv_message ws with
+                  | Websocket.Text payload | Websocket.Binary payload ->
+                      let ev = parse_frame payload in
+                      (match seq_of ev with
+                      | Some s -> filter := with_cursor !filter (Seq s)
+                      | None -> ());
+                      if not (is_duplicate seen ev) then (
+                        remember seen ev;
+                        incr received;
+                        f ev);
+                      loop ()
+                  | Websocket.Close _ -> ()
+                  | Websocket.Ping _ | Websocket.Pong _ -> loop ())
+            in
+            loop ())
+      with exn ->
+        if n >= max_reconnects then raise exn
+        else (
+          sleep n;
+          attempt (n + 1))
+    in
+    attempt 0
+
+  let subscribe_one ?host ?version ?filter () : event =
+    let cell = ref None in
+    subscribe ?host ?version ?filter ~max_messages:1 ~max_reconnects:0
+      (fun ev -> cell := Some ev);
+    match !cell with
+    | Some ev -> ev
+    | None -> failwith "Jetstream.subscribe_one: no event received"
+
+  (* ---- HTTP snapshot / replay (typed; no invented archive token) -------- *)
+
+  type block_range = { first : int; last : int }
+
+  type snapshot_segment = {
+    name : string;
+    index : int;
+    checksum : string;
+    min_seq : int64;
+    max_seq : int64;
+    mode : string;
+    blocks : block_range list;
+  }
+
+  type snapshot_stats = {
+    segments_examined : int;
+    segments_matched : int;
+    blocks_matched : int;
+    entries : int;
+  }
+
+  type snapshot_plan = {
+    planned_through_seq : int64;
+    sealed_tip_seq : int64;
+    segments : snapshot_segment list;
+    stats : snapshot_stats;
+  }
+
+  let plan_snapshot_url ?(host = default_host) () =
+    Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.planSnapshot" host
+
+  let get_segment_url ?(host = default_host) ~name () =
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs [ ("name", name) ]
+    in
+    Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.getSegment?%s" host
+      qs
+
+  let get_block_url ?(host = default_host) ~name ~index () =
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs
+        [ ("name", name); ("index", string_of_int index) ]
+    in
+    Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.getBlock?%s" host qs
+
+  let plan_snapshot_body ?kinds ?dids ?collections ?after_seq ?before_seq () :
+      Yojson.Safe.t =
+    let list_field key = function
+      | None | Some [] -> []
+      | Some xs -> [ (key, `List (List.map (fun s -> `String s) xs)) ]
+    in
+    let int64_field key = function
+      | None -> []
+      | Some n -> [ (key, `Intlit (Int64.to_string n)) ]
+    in
+    `Assoc
+      (list_field "kinds" kinds @ list_field "dids" dids
+      @ list_field "collections" collections
+      @ int64_field "afterSeq" after_seq
+      @ int64_field "beforeSeq" before_seq)
+
+  let parse_block_range json : block_range =
+    {
+      first =
+        (match Yojson.Safe.Util.member "first" json with `Int n -> n | _ -> 0);
+      last =
+        (match Yojson.Safe.Util.member "last" json with `Int n -> n | _ -> 0);
+    }
+
+  let parse_snapshot_segment json : snapshot_segment =
+    {
+      name = string_member json "name";
+      index =
+        (match Yojson.Safe.Util.member "index" json with `Int n -> n | _ -> 0);
+      checksum = string_member json "checksum";
+      min_seq = int64_member json "minSeq";
+      max_seq = int64_member json "maxSeq";
+      mode = string_member json "mode";
+      blocks =
+        (match Yojson.Safe.Util.member "blocks" json with
+        | `List xs -> List.map parse_block_range xs
+        | _ -> []);
+    }
+
+  let parse_snapshot_stats json : snapshot_stats =
+    let int_field field =
+      match Yojson.Safe.Util.member field json with `Int n -> n | _ -> 0
+    in
+    {
+      segments_examined = int_field "segmentsExamined";
+      segments_matched = int_field "segmentsMatched";
+      blocks_matched = int_field "blocksMatched";
+      entries = int_field "entries";
+    }
+
+  let parse_snapshot_plan json : snapshot_plan =
+    {
+      planned_through_seq = int64_member json "plannedThroughSeq";
+      sealed_tip_seq = int64_member json "sealedTipSeq";
+      segments =
+        (match Yojson.Safe.Util.member "segments" json with
+        | `List xs -> List.map parse_snapshot_segment xs
+        | _ -> []);
+      stats = parse_snapshot_stats (Yojson.Safe.Util.member "stats" json);
+    }
+end

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -24,12 +24,20 @@ module Lexicon = struct
     | String_def
     | Unknown_def of string
 
+  type schema_shape = {
+    encoding : string option;
+    required : string list;
+    properties : (string * primitive) list;
+  }
+
   type def = {
     name : string;
     kind : definition;
     description : string option;
     required : string list;
     properties : (string * primitive) list;
+    input : schema_shape;
+    output : schema_shape;
   }
 
   type document = {
@@ -76,6 +84,16 @@ module Lexicon = struct
     match json |> member "type" with
     | `String "ref" -> Ref
     | `String "union" -> Union
+    | `String "array" -> (
+        match json |> member "items" with
+        | `Assoc _ as items -> (
+            match items |> member "type" with
+            | `String "ref" -> Ref
+            | `String "union" -> Union
+            | `String t -> lookup_primitive t
+            | _ -> Unknown)
+        | _ -> Unknown)
+    | `String "blob" -> Bytes
     | `String t -> lookup_primitive t
     | _ -> Unknown
 
@@ -90,6 +108,25 @@ module Lexicon = struct
     | `List items ->
         List.filter_map (function `String s -> Some s | _ -> None) items
     | _ -> []
+
+  let empty_shape : schema_shape =
+    { encoding = None; required = []; properties = [] }
+
+  let unwrap_schema json =
+    match Yojson.Safe.Util.member "schema" json with
+    | `Assoc _ as schema -> schema
+    | _ -> json
+
+  let parse_io_schema json field : schema_shape =
+    match Yojson.Safe.Util.member field json with
+    | `Assoc _ as obj ->
+        let body = unwrap_schema obj in
+        {
+          encoding = string_opt obj "encoding";
+          required = parse_required body;
+          properties = parse_properties body;
+        }
+    | _ -> empty_shape
 
   let shape_json json =
     let open Yojson.Safe.Util in
@@ -116,6 +153,8 @@ module Lexicon = struct
       description = string_opt json "description";
       required = parse_required body;
       properties = parse_properties body;
+      input = parse_io_schema json "input";
+      output = parse_io_schema json "output";
     }
 
   let of_json json : document =
@@ -179,24 +218,39 @@ module Lexicon = struct
     Printf.bprintf buf "module %s = struct\n" modname;
     Printf.bprintf buf "  let id = %S\n" doc.id;
     Printf.bprintf buf "  let lexicon = %d\n\n" doc.lexicon;
+    let emit_record buf indent name required props =
+      match props with
+      | [] -> Printf.bprintf buf "%stype %s = unit\n" indent name
+      | props ->
+          Printf.bprintf buf "%stype %s = {\n" indent name;
+          List.iter
+            (fun (n, prim) ->
+              let optional = not (List.mem n required) in
+              Printf.bprintf buf "%s  %s : %s%s;\n" indent (ocaml_ident n)
+                (primitive_to_ocaml prim)
+                (if optional then " option" else ""))
+            props;
+          Printf.bprintf buf "%s}\n" indent
+    in
     List.iter
       (fun (d : def) ->
         let inner = String.capitalize_ascii (ocaml_ident d.name) in
         Printf.bprintf buf "  (** %s *)\n" (kind_label d.kind);
         Printf.bprintf buf "  module %s = struct\n" inner;
         Printf.bprintf buf "    let name = %S\n" d.name;
-        (match d.properties with
-        | [] -> Printf.bprintf buf "    type t = unit\n"
-        | props ->
-            Printf.bprintf buf "    type t = {\n";
-            List.iter
-              (fun (n, prim) ->
-                let optional = not (List.mem n d.required) in
-                Printf.bprintf buf "      %s : %s%s;\n" (ocaml_ident n)
-                  (primitive_to_ocaml prim)
-                  (if optional then " option" else ""))
-              props;
-            Printf.bprintf buf "    }\n");
+        emit_record buf "    " "t" d.required d.properties;
+        (match d.input.encoding with
+        | Some enc -> Printf.bprintf buf "    let input_encoding = %S\n" enc
+        | None -> ());
+        (match d.input.properties with
+        | [] -> ()
+        | props -> emit_record buf "    " "input" d.input.required props);
+        (match d.output.encoding with
+        | Some enc -> Printf.bprintf buf "    let output_encoding = %S\n" enc
+        | None -> ());
+        (match d.output.properties with
+        | [] -> ()
+        | props -> emit_record buf "    " "output" d.output.required props);
         Printf.bprintf buf "  end\n\n")
       doc.defs;
     Printf.bprintf buf "end\n";

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -482,6 +482,7 @@ module Oauth = struct
       failwith "Oauth: response_types must include code";
     if not (contains_scope ~scope:m.scope "atproto") then
       failwith "Oauth: scope must include atproto";
+    ignore (Oauth_scope.Oauth_scope.parse_and_require m.scope);
     if m.redirect_uris = [] then
       failwith "Oauth: redirect_uris must contain at least one URI";
     if m.token_endpoint_auth_signing_alg = Some "none" then

--- a/src/oauth_scope.ml
+++ b/src/oauth_scope.ml
@@ -106,10 +106,10 @@ module Oauth_scope = struct
     | Repo ->
         List.iter
           (fun c ->
+            if c <> "*" && String.length c > 0 && c.[String.length c - 1] = '*'
+            then fail "repo collection globs are not allowed";
             if (not (is_wildcard c)) && not (Syntax.Syntax.is_valid_nsid c) then
-              fail ("repo collection must be an NSID or *: " ^ c);
-            if String.length c > 2 && c.[String.length c - 1] = '*' && c <> "*"
-            then fail "repo collection globs are not allowed")
+              fail ("repo collection must be an NSID or *: " ^ c))
           (collections_of s);
         List.iter
           (fun a ->

--- a/src/oauth_scope.ml
+++ b/src/oauth_scope.ml
@@ -1,0 +1,211 @@
+(** AT Protocol OAuth authorization scopes (granular permissions).
+
+    Grammar: [resource[:positional][?key=value&key=value]]
+    https://github.com/bluesky-social/proposals/blob/main/0011-auth-scopes/README.md
+    August 2025 implementation notes:
+    https://github.com/bluesky-social/atproto/discussions/4118
+
+    The [atproto] scope remains mandatory on every session. Transitional
+    scopes ([transition:generic], [transition:chat.bsky], [transition:email])
+    are still accepted. *)
+module Oauth_scope = struct
+  exception Invalid of string
+
+  let fail msg = raise (Invalid msg)
+
+  type resource_kind =
+    | Atproto
+    | Transition
+    | Repo
+    | Rpc
+    | Blob
+    | Identity
+    | Account
+    | Include
+    | Other of string
+
+  type t = {
+    resource : resource_kind;
+    positional : string option;
+    params : (string * string) list;
+  }
+
+  let resource_name = function
+    | Atproto -> "atproto"
+    | Transition -> "transition"
+    | Repo -> "repo"
+    | Rpc -> "rpc"
+    | Blob -> "blob"
+    | Identity -> "identity"
+    | Account -> "account"
+    | Include -> "include"
+    | Other s -> s
+
+  let resource_of_string = function
+    | "atproto" -> Atproto
+    | "transition" -> Transition
+    | "repo" -> Repo
+    | "rpc" -> Rpc
+    | "blob" -> Blob
+    | "identity" -> Identity
+    | "account" -> Account
+    | "include" -> Include
+    | other -> Other other
+
+  let split_once s sep =
+    match String.index_opt s sep with
+    | None -> (s, None)
+    | Some i ->
+        (String.sub s 0 i, Some (String.sub s (i + 1) (String.length s - i - 1)))
+
+  let pct_decode s = try Uri.pct_decode s with _ -> s
+  let pct_encode s = Uri.pct_encode ~component:`Query_value s
+
+  let parse_params qs =
+    if qs = "" then []
+    else
+      String.split_on_char '&' qs
+      |> List.filter (fun p -> p <> "")
+      |> List.map (fun p ->
+             let k, v = split_once p '=' in
+             (pct_decode k, match v with Some x -> pct_decode x | None -> ""))
+
+  let params_get key params =
+    List.filter_map (fun (k, v) -> if k = key then Some v else None) params
+
+  let param_one key params =
+    match params_get key params with [] -> None | hd :: _ -> Some hd
+
+  let collections_of (s : t) : string list =
+    match s.positional with
+    | Some p when p <> "" -> p :: params_get "collection" s.params
+    | _ -> params_get "collection" s.params
+
+  let actions_of (s : t) : string list =
+    let acts = params_get "action" s.params in
+    if acts = [] then [ "create"; "update"; "delete" ] else acts
+
+  let lxm_of (s : t) : string list =
+    match s.positional with
+    | Some p when p <> "" -> p :: params_get "lxm" s.params
+    | _ -> params_get "lxm" s.params
+
+  let aud_of (s : t) : string list = params_get "aud" s.params
+  let is_wildcard = function "*" -> true | _ -> false
+
+  let validate (s : t) : unit =
+    match s.resource with
+    | Atproto ->
+        if s.positional <> None || s.params <> [] then
+          fail "atproto scope takes no parameters"
+    | Transition -> (
+        match s.positional with
+        | Some ("generic" | "chat.bsky" | "email") -> ()
+        | Some other -> fail ("unknown transition scope " ^ other)
+        | None -> fail "transition scope requires a positional value")
+    | Repo ->
+        List.iter
+          (fun c ->
+            if (not (is_wildcard c)) && not (Syntax.Syntax.is_valid_nsid c) then
+              fail ("repo collection must be an NSID or *: " ^ c);
+            if String.length c > 2 && c.[String.length c - 1] = '*' && c <> "*"
+            then fail "repo collection globs are not allowed")
+          (collections_of s);
+        List.iter
+          (fun a ->
+            match a with
+            | "create" | "update" | "delete" | "*" -> ()
+            | other ->
+                fail ("repo action must be create|update|delete: " ^ other))
+          (params_get "action" s.params)
+    | Rpc ->
+        let lxms = lxm_of s in
+        let auds = aud_of s in
+        if lxms = [] then fail "rpc scope requires lxm";
+        if auds = [] then fail "rpc scope requires aud";
+        let lxm_star = List.exists is_wildcard lxms in
+        let aud_star = List.exists is_wildcard auds in
+        if lxm_star && aud_star then
+          fail "rpc scope cannot wildcard both lxm and aud";
+        List.iter
+          (fun l ->
+            if (not (is_wildcard l)) && not (Syntax.Syntax.is_valid_nsid l) then
+              fail ("rpc lxm must be an NSID or *: " ^ l))
+          lxms
+    | Identity -> (
+        match (s.positional, param_one "attr" s.params) with
+        | Some a, _ | None, Some a ->
+            if not (a = "*" || a = "handle") then
+              fail ("identity attr must be handle or *: " ^ a)
+        | None, None -> fail "identity scope requires attr")
+    | Account -> (
+        match (s.positional, param_one "attr" s.params) with
+        | Some a, _ | None, Some a ->
+            if not (List.mem a [ "email"; "repo"; "status" ]) then
+              fail ("account attr must be email|repo|status: " ^ a)
+        | None, None -> fail "account scope requires attr")
+    | Include -> (
+        match s.positional with
+        | Some nsid ->
+            if not (Syntax.Syntax.is_valid_nsid nsid) then
+              fail ("include positional must be an NSID: " ^ nsid)
+        | None -> fail "include scope requires a permission-set NSID")
+    | Blob | Other _ -> ()
+
+  let parse_one (raw : string) : t =
+    let token = String.trim raw in
+    if token = "" then fail "empty scope token";
+    let head, query = split_once token '?' in
+    let resource_s, positional = split_once head ':' in
+    if resource_s = "" then fail "scope resource is empty";
+    let s =
+      {
+        resource = resource_of_string resource_s;
+        positional =
+          (match positional with
+          | Some p when p <> "" -> Some (pct_decode p)
+          | _ -> None);
+        params = (match query with Some q -> parse_params q | None -> []);
+      }
+    in
+    validate s;
+    s
+
+  let split_scopes (scope : string) : string list =
+    String.split_on_char ' ' scope |> List.filter (fun t -> t <> "")
+
+  let parse (scope : string) : t list = List.map parse_one (split_scopes scope)
+
+  let to_string (s : t) : string =
+    let head =
+      match s.positional with
+      | Some p -> resource_name s.resource ^ ":" ^ pct_encode p
+      | None -> resource_name s.resource
+    in
+    match s.params with
+    | [] -> head
+    | ps ->
+        head ^ "?"
+        ^ String.concat "&"
+            (List.map (fun (k, v) -> pct_encode k ^ "=" ^ pct_encode v) ps)
+
+  let serialize (scopes : t list) : string =
+    String.concat " " (List.map to_string scopes)
+
+  let has_atproto (scopes : t list) : bool =
+    List.exists (fun s -> s.resource = Atproto) scopes
+
+  let require_atproto (scopes : t list) : unit =
+    if not (has_atproto scopes) then fail "scope list must include atproto"
+
+  let token_set scope = split_scopes scope |> List.sort_uniq String.compare
+
+  let is_subset ~requested ~declared =
+    let dec = token_set declared in
+    List.for_all (fun t -> List.mem t dec) (split_scopes requested)
+
+  let parse_and_require (scope : string) : t list =
+    let scopes = parse scope in
+    require_atproto scopes;
+    scopes
+end

--- a/src/server.ml
+++ b/src/server.ml
@@ -355,6 +355,9 @@ module Server = struct
 
   let parse_describe_server json : server_description =
     let open Yojson.Safe.Util in
+    let safe_member obj field =
+      match obj with `Assoc _ -> obj |> member field | _ -> `Null
+    in
     let links = json |> member "links" in
     let contact = json |> member "contact" in
     {
@@ -379,16 +382,18 @@ module Server = struct
       links =
         {
           privacy_policy =
-            (match links |> member "privacyPolicy" with
+            (match safe_member links "privacyPolicy" with
             | `String s -> Some s
             | _ -> None);
           terms_of_service =
-            (match links |> member "termsOfService" with
+            (match safe_member links "termsOfService" with
             | `String s -> Some s
             | _ -> None);
         };
       contact_email =
-        (match contact |> member "email" with `String s -> Some s | _ -> None);
+        (match safe_member contact "email" with
+        | `String s -> Some s
+        | _ -> None);
     }
 
   let describe_server_parsed ?session ?host () : server_description =

--- a/src/sync.ml
+++ b/src/sync.ml
@@ -170,9 +170,8 @@ module Sync = struct
             Lwt_io.write oc blob)
     | _ -> Lwt.return ()
 
-  let get_blocks (s : Session.session) (did : string) (cids : string list) :
-      string Lwt.t =
-    let host = s.atp_host in
+  let get_blocks_url ?host ?session ~did ~cids () : string =
+    let host = host_of ?host session in
     let base_url = App.create_public_base_url ~host () in
     let url =
       App.create_endpoint_url base_url (create_sync_endpoint "getBlocks")
@@ -182,8 +181,19 @@ module Sync = struct
       ^
       if cids = [] then "" else "&" ^ Cohttp_client.add_query_params "cids" cids
     in
-    let headers = headers_of (Some s) in
-    Cohttp_client.get_request_with_body_and_headers url body headers
+    if body = "" then url else url ^ "?" ^ body
+
+  let get_blocks_bytes ?host ?session ~did ~cids () : string =
+    let url = get_blocks_url ?host ?session ~did ~cids () in
+    let headers = headers_of session in
+    Lwt_main.run (Cohttp_client.get_request_with_headers url headers)
+
+  let get_blocks_car ?host ?session ~did ~cids () : Car.t =
+    Car.parse (get_blocks_bytes ?host ?session ~did ~cids ())
+
+  let get_blocks (s : Session.session) (did : string) (cids : string list) :
+      string Lwt.t =
+    Lwt.return (get_blocks_bytes ~session:s ~did ~cids ())
 
   let get_record ?host ?session ?commit (did : string) (collection : string)
       (rkey : string) : string =

--- a/test/dune
+++ b/test/dune
@@ -5,6 +5,7 @@
   test_admin
   test_at_uri
   test_auth
+  test_base64url
   test_bookmark
   test_car
   test_chat
@@ -13,13 +14,17 @@
   test_did_key
   test_did_plc
   test_did_web
+  test_embed
   test_error
+  test_facet
   test_feed
   test_firehose
   test_graph
+  test_hash
   test_http_client
   test_http_method
   test_identity
+  test_jetstream
   test_label
   test_labeler
   test_lexicon
@@ -27,6 +32,7 @@
   test_mst
   test_notification
   test_oauth
+  test_oauth_scope
   test_ozone
   test_request
   test_repo
@@ -38,6 +44,7 @@
   test_tid
   test_unspecced
   test_user
+  test_varint
   test_blob
   test_blocks
   test_download_image
@@ -72,6 +79,7 @@
   test_admin
   test_at_uri
   test_auth
+  test_base64url
   test_bookmark
   test_car
   test_chat
@@ -80,13 +88,17 @@
   test_did_key
   test_did_plc
   test_did_web
+  test_embed
   test_error
+  test_facet
   test_feed
   test_firehose
   test_graph
+  test_hash
   test_http_client
   test_http_method
   test_identity
+  test_jetstream
   test_label
   test_labeler
   test_lexicon
@@ -94,6 +106,7 @@
   test_mst
   test_notification
   test_oauth
+  test_oauth_scope
   test_ozone
   test_request
   test_repo
@@ -105,6 +118,7 @@
   test_tid
   test_unspecced
   test_user
+  test_varint
   test_blob
   test_blocks
   test_download_image

--- a/test/dune
+++ b/test/dune
@@ -5,6 +5,7 @@
   test_admin
   test_at_uri
   test_auth
+  test_base32
   test_base64url
   test_bookmark
   test_car
@@ -79,6 +80,7 @@
   test_admin
   test_at_uri
   test_auth
+  test_base32
   test_base64url
   test_bookmark
   test_car

--- a/test/test_base32.ml
+++ b/test/test_base32.ml
@@ -1,0 +1,42 @@
+open OUnit2
+open Atproto.Base32
+
+let test_empty _ =
+  OUnit2.assert_equal ~printer:(fun x -> x) "" (Base32.encode "");
+  OUnit2.assert_equal ~printer:(fun x -> x) "" (Base32.decode "")
+
+let test_roundtrip _ =
+  List.iter
+    (fun s ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        s
+        (Base32.decode (Base32.encode s)))
+    [ "f"; "fo"; "foo"; "foob"; "fooba"; "foobar"; "hello world" ]
+
+let test_rfc4648_vectors _ =
+  (* RFC 4648 lowercase, unpadded — same alphabet CIDv1 multibase uses. *)
+  OUnit2.assert_equal ~printer:(fun x -> x) "my" (Base32.encode "f");
+  OUnit2.assert_equal ~printer:(fun x -> x) "mzxw6" (Base32.encode "foo");
+  OUnit2.assert_equal ~printer:(fun x -> x) "mzxw6ytb" (Base32.encode "fooba");
+  OUnit2.assert_equal ~printer:(fun x -> x) "fooba" (Base32.decode "mzxw6ytb")
+
+let test_cid_multibase_prefix _ =
+  let digest = String.make 32 '\xab' in
+  let encoded = Base32.encode digest in
+  OUnit2.assert_equal ~printer:(fun x -> x) digest (Base32.decode encoded);
+  OUnit2.assert_bool "lowercase alphabet"
+    (String.for_all
+       (function 'a' .. 'z' | '2' .. '7' -> true | _ -> false)
+       encoded)
+
+let suite =
+  "base32"
+  >::: [
+         "test_empty" >:: test_empty;
+         "test_roundtrip" >:: test_roundtrip;
+         "test_rfc4648_vectors" >:: test_rfc4648_vectors;
+         "test_cid_multibase_prefix" >:: test_cid_multibase_prefix;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_base64url.ml
+++ b/test/test_base64url.ml
@@ -1,0 +1,42 @@
+open OUnit2
+open Atproto.Base64url
+open Atproto.Base58
+
+(* RFC 4648 §10 vectors *)
+let test_std_vectors _ =
+  OUnit2.assert_equal ~printer:(fun x -> x) "Zg==" (Base64url.encode_std "f");
+  OUnit2.assert_equal ~printer:(fun x -> x) "Zm8=" (Base64url.encode_std "fo");
+  OUnit2.assert_equal ~printer:(fun x -> x) "Zm9v" (Base64url.encode_std "foo");
+  OUnit2.assert_equal ~printer:(fun x -> x) "f" (Base64url.decode_std "Zg==");
+  OUnit2.assert_equal ~printer:(fun x -> x) "foo" (Base64url.decode_std "Zm9v")
+
+let test_url_unpadded _ =
+  let raw = "hello?>" in
+  let encoded = Base64url.encode raw in
+  OUnit2.assert_bool "no padding" (not (String.contains encoded '='));
+  OUnit2.assert_equal ~printer:(fun x -> x) raw (Base64url.decode encoded)
+
+let test_base58_hello _ =
+  (* Bitcoin-style base58 of "Hello World" *)
+  let encoded = Base58.encode "Hello World" in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "Hello World" (Base58.decode encoded)
+
+let test_base58_leading_zeros _ =
+  let raw = "\x00\x00hi" in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    raw
+    (Base58.decode (Base58.encode raw))
+
+let suite =
+  "base64url"
+  >::: [
+         "test_std_vectors" >:: test_std_vectors;
+         "test_url_unpadded" >:: test_url_unpadded;
+         "test_base58_hello" >:: test_base58_hello;
+         "test_base58_leading_zeros" >:: test_base58_leading_zeros;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -1,0 +1,187 @@
+open OUnit2
+open Atproto.Embed
+
+let test_parse_images _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.images");
+        ( "images",
+          `List
+            [
+              `Assoc
+                [
+                  ("alt", `String "cat");
+                  ( "image",
+                    `Assoc
+                      [
+                        ("$type", `String "blob");
+                        ( "ref",
+                          `Assoc
+                            [
+                              ( "$link",
+                                `String
+                                  "bafyimage0000000000000000000000000000000000"
+                              );
+                            ] );
+                        ("mimeType", `String "image/jpeg");
+                        ("size", `Int 12);
+                      ] );
+                ];
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `Image e ->
+      OUnit2.assert_equal 1 (List.length e.images);
+      OUnit2.assert_equal ~printer:(fun x -> x) "cat" (List.hd e.images).alt
+  | _ -> OUnit2.assert_failure "expected image embed"
+
+let test_parse_video _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.video");
+        ( "video",
+          `Assoc
+            [
+              ("$type", `String "blob");
+              ( "ref",
+                `Assoc
+                  [
+                    ( "$link",
+                      `String
+                        "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+                    );
+                  ] );
+              ("mimeType", `String "video/mp4");
+              ("size", `Int 99);
+            ] );
+        ("alt", `String "clip");
+        ("aspectRatio", `Assoc [ ("width", `Int 16); ("height", `Int 9) ]);
+      ]
+  in
+  match Embed.parse_embed json with
+  | `Video e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "video/mp4" e.video.mime_type;
+      OUnit2.assert_equal (Some "clip") e.alt;
+      OUnit2.assert_equal (Some { Embed.width = 16; height = 9 }) e.aspect_ratio
+  | _ -> OUnit2.assert_failure "expected video embed"
+
+let test_parse_video_view _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.video#view");
+        ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+        ("playlist", `String "https://video.bsky.app/watch/playlist.m3u8");
+        ("thumbnail", `String "https://video.bsky.app/watch/thumb.jpg");
+      ]
+  in
+  match Embed.parse_embed json with
+  | `VideoView e -> OUnit2.assert_bool "playlist" (String.length e.playlist > 0)
+  | _ -> OUnit2.assert_failure "expected video view"
+
+let test_parse_record _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.record");
+        ( "record",
+          `Assoc
+            [
+              ( "uri",
+                `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+              ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `Record e ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" e.record.uri
+  | _ -> OUnit2.assert_failure "expected record embed"
+
+let test_parse_record_with_media _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.recordWithMedia");
+        ( "record",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.record");
+              ( "record",
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+                    ( "cid",
+                      `String "bafyreihdummy000000000000000000000000000000000"
+                    );
+                  ] );
+            ] );
+        ( "media",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.images");
+              ( "images",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ("alt", `String "pic");
+                        ( "image",
+                          `Assoc
+                            [
+                              ("$type", `String "blob");
+                              ( "ref",
+                                `Assoc
+                                  [
+                                    ( "$link",
+                                      `String
+                                        "bafyimage0000000000000000000000000000000000"
+                                    );
+                                  ] );
+                              ("mimeType", `String "image/png");
+                              ("size", `Int 4);
+                            ] );
+                      ];
+                  ] );
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `RecordWithMedia e -> (
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+        e.record.record.uri;
+      match e.media with
+      | `Image img -> OUnit2.assert_equal 1 (List.length img.images)
+      | _ -> OUnit2.assert_failure "expected image media")
+  | other ->
+      OUnit2.assert_failure
+        (match other with `Unknown _ -> "unknown" | _ -> "wrong variant")
+
+let test_unknown_is_not_fail _ =
+  match
+    Embed.parse_embed (`Assoc [ ("$type", `String "app.bsky.embed.unknown") ])
+  with
+  | `Unknown _ -> ()
+  | _ -> OUnit2.assert_failure "expected unknown embed"
+
+let suite =
+  "embed"
+  >::: [
+         "test_parse_images" >:: test_parse_images;
+         "test_parse_video" >:: test_parse_video;
+         "test_parse_video_view" >:: test_parse_video_view;
+         "test_parse_record" >:: test_parse_record;
+         "test_parse_record_with_media" >:: test_parse_record_with_media;
+         "test_unknown_is_not_fail" >:: test_unknown_is_not_fail;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_facet.ml
+++ b/test/test_facet.ml
@@ -1,0 +1,82 @@
+open OUnit2
+open Atproto.Facet
+
+let test_parse_mention _ =
+  let json =
+    `Assoc
+      [
+        ("index", `Assoc [ ("byteStart", `Int 0); ("byteEnd", `Int 5) ]);
+        ( "features",
+          `List
+            [
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.richtext.facet#mention");
+                  ("did", `String "did:plc:abc123xyz0001112223333");
+                ];
+            ] );
+      ]
+  in
+  match Facet.parse_facet json with
+  | `Mention m ->
+      OUnit2.assert_equal 0 m.facet_index.byte_start;
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:abc123xyz0001112223333" (List.hd m.features).did
+  | _ -> OUnit2.assert_failure "expected mention"
+
+let test_parse_link _ =
+  let json =
+    `Assoc
+      [
+        ("index", `Assoc [ ("byteStart", `Int 6); ("byteEnd", `Int 20) ]);
+        ( "features",
+          `List
+            [
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.richtext.facet#link");
+                  ("uri", `String "https://atproto.com");
+                ];
+            ] );
+      ]
+  in
+  match Facet.parse_facet json with
+  | `Link l ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "https://atproto.com" (List.hd l.features).uri
+  | _ -> OUnit2.assert_failure "expected link"
+
+let test_parse_tag _ =
+  let json =
+    `Assoc
+      [
+        ("index", `Assoc [ ("byteStart", `Int 21); ("byteEnd", `Int 29) ]);
+        ( "features",
+          `List
+            [
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.richtext.facet#tag");
+                  ("tag", `String "atproto");
+                ];
+            ] );
+      ]
+  in
+  match Facet.parse_facet json with
+  | `Tag t ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "atproto" (List.hd t.features).tag
+  | _ -> OUnit2.assert_failure "expected tag"
+
+let suite =
+  "facet"
+  >::: [
+         "test_parse_mention" >:: test_parse_mention;
+         "test_parse_link" >:: test_parse_link;
+         "test_parse_tag" >:: test_parse_tag;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_firehose.ml
+++ b/test/test_firehose.ml
@@ -207,6 +207,53 @@ let test_invert_synthetic_commit _ =
         (Cid.equal inverted expected)
   | None -> OUnit2.assert_failure "fixture missing prevData"
 
+let test_verify_live_shaped_cbor_frame _ =
+  let commit = synthetic_inverted_commit () in
+  let header = Firehose.encode_header { op = 1; t = Some "#commit" } in
+  let op0 = List.hd commit.ops in
+  let body =
+    Dag_cbor.encode
+      (Dag_cbor.Map
+         [
+           ("seq", Dag_cbor.Int 1);
+           ("rebase", Dag_cbor.Bool false);
+           ("tooBig", Dag_cbor.Bool false);
+           ("repo", Dag_cbor.Text commit.repo);
+           ("commit", Dag_cbor.Cid commit.commit);
+           ("rev", Dag_cbor.Text commit.rev);
+           ("since", Dag_cbor.Null);
+           ( "prevData",
+             match commit.prev_data with
+             | Some c -> Dag_cbor.Cid c
+             | None -> Dag_cbor.Null );
+           ("blocks", Dag_cbor.Bytes commit.raw_blocks);
+           ( "ops",
+             Dag_cbor.Array
+               [
+                 Dag_cbor.Map
+                   ([
+                      ("action", Dag_cbor.Text op0.action);
+                      ("path", Dag_cbor.Text op0.path);
+                    ]
+                   @
+                   match op0.cid with
+                   | Some c -> [ ("cid", Dag_cbor.Cid c) ]
+                   | None -> [ ("cid", Dag_cbor.Null) ]);
+               ] );
+           ("blobs", Dag_cbor.Array []);
+           ("time", Dag_cbor.Text commit.time);
+         ])
+  in
+  match Firehose.decode_frame (header ^ body) with
+  | _, `Commit decoded ->
+      Firehose.verify_commit decoded;
+      let inverted = Firehose.invert_commit decoded in
+      OUnit2.assert_bool "live-shaped prevData"
+        (match decoded.prev_data with
+        | Some expected -> Cid.equal inverted expected
+        | None -> false)
+  | _ -> OUnit2.assert_failure "expected #commit frame"
+
 let test_invert_rejects_wrong_op _ =
   let commit = synthetic_inverted_commit () in
   let bad =
@@ -380,6 +427,8 @@ let suite =
          "test_decode_update_and_delete_ops"
          >:: test_decode_update_and_delete_ops;
          "test_invert_synthetic_commit" >:: test_invert_synthetic_commit;
+         "test_verify_live_shaped_cbor_frame"
+         >:: test_verify_live_shaped_cbor_frame;
          "test_invert_rejects_wrong_op" >:: test_invert_rejects_wrong_op;
          "test_websocket_accept_rfc6455" >:: test_websocket_accept_rfc6455;
          "test_websocket_unmasked_roundtrip"

--- a/test/test_hash.ml
+++ b/test/test_hash.ml
@@ -1,0 +1,37 @@
+open OUnit2
+open Atproto.Hash
+
+(* SHA-256("abc") from FIPS 180-4 *)
+let sha256_abc =
+  "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+let test_sha256_abc _ =
+  OUnit2.assert_equal ~printer:(fun x -> x) sha256_abc (Hash.sha256_hex "abc")
+
+let test_hex_roundtrip _ =
+  let raw = Hash.sha256 "hello atproto" in
+  let hex = Hash.hex_encode raw in
+  OUnit2.assert_equal ~printer:string_of_int 64 (String.length hex);
+  OUnit2.assert_equal ~printer:(fun x -> x) raw (Hash.hex_decode hex)
+
+let test_hex_decode_odd _ =
+  OUnit2.assert_raises (Failure "Hash.hex_decode: odd length") (fun () ->
+      ignore (Hash.hex_decode "abc"))
+
+let test_sha1_known _ =
+  (* SHA-1("") = da39a3ee5e6b4b0d3255bfef95601890afd80709 *)
+  let digest = Hash.sha1 "" in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709" (Hash.hex_encode digest)
+
+let suite =
+  "hash"
+  >::: [
+         "test_sha256_abc" >:: test_sha256_abc;
+         "test_hex_roundtrip" >:: test_hex_roundtrip;
+         "test_hex_decode_odd" >:: test_hex_decode_odd;
+         "test_sha1_known" >:: test_sha1_known;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_http_method.ml
+++ b/test/test_http_method.ml
@@ -14,12 +14,28 @@ let test_lookup_http_method_with_post _ =
     (Http_method.lookup_http_method "post")
     sample_post_http_method
 
+let test_lookup_remaining_verbs _ =
+  OUnit2.assert_equal Http_method.Put (Http_method.lookup_http_method "PUT");
+  OUnit2.assert_equal Http_method.Delete
+    (Http_method.lookup_http_method "Delete");
+  OUnit2.assert_equal Http_method.Patch (Http_method.lookup_http_method "patch");
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "PATCH"
+    (Http_method.to_string Patch)
+
+let test_unknown_method _ =
+  OUnit2.assert_raises (Failure "Not Recognized Method") (fun () ->
+      ignore (Http_method.lookup_http_method "trace"))
+
 let suite =
   "suite"
   >::: [
          "test_lookup_http_method_with_get" >:: test_lookup_http_method_with_get;
          "test_lookup_http_method_with_post"
          >:: test_lookup_http_method_with_post;
+         "test_lookup_remaining_verbs" >:: test_lookup_remaining_verbs;
+         "test_unknown_method" >:: test_unknown_method;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_jetstream.ml
+++ b/test/test_jetstream.ml
@@ -1,0 +1,289 @@
+open OUnit2
+open Atproto.Jetstream
+
+let v2_commit_json =
+  `Assoc
+    [
+      ("$type", `String "message");
+      ( "payload",
+        `Assoc
+          [
+            ("$type", `String "network.bsky.jetstream.subscribeEvents#commit");
+            ("did", `String "did:plc:7e6kocyzb77xkncplrkoojej");
+            ("seq", `Intlit "24664288881");
+            ("time", `String "2026-08-13T06:47:43.959305Z");
+            ("operation", `String "create");
+            ("collection", `String "app.bsky.feed.like");
+            ("rkey", `String "3msx2efqdxs27");
+            ("rev", `String "3msx2efqjtc27");
+            ( "cid",
+              `String
+                "bafyreigwnxqttkhzha2ig4io6wwht3qiugtor4ruglceyfdbnyq53a55fe" );
+            ( "record",
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.feed.like");
+                  ("createdAt", `String "2026-08-13T06:47:44.859Z");
+                ] );
+          ] );
+    ]
+
+let v1_commit_json =
+  `Assoc
+    [
+      ("did", `String "did:plc:7e6kocyzb77xkncplrkoojej");
+      ("time_us", `Intlit "1724084535744408");
+      ("kind", `String "commit");
+      ( "commit",
+        `Assoc
+          [
+            ("rev", `String "3jzfcijpj2z2a");
+            ("operation", `String "create");
+            ("collection", `String "app.bsky.feed.post");
+            ("rkey", `String "3jzfcijpj2z2a");
+            ("record", `Assoc [ ("text", `String "hi") ]);
+            ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+          ] );
+    ]
+
+let test_parse_v2_commit _ =
+  match Jetstream.parse_event v2_commit_json with
+  | `Commit c ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "app.bsky.feed.like" c.collection;
+      OUnit2.assert_equal ~printer:(fun x -> x) "create" c.operation;
+      OUnit2.assert_equal ~printer:Int64.to_string 24664288881L c.seq;
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "at://did:plc:7e6kocyzb77xkncplrkoojej/app.bsky.feed.like/3msx2efqdxs27"
+        (Jetstream.record_uri c)
+  | _ -> OUnit2.assert_failure "expected v2 commit"
+
+let test_parse_v1_commit _ =
+  match Jetstream.parse_event v1_commit_json with
+  | `Commit c ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "app.bsky.feed.post" c.collection;
+      OUnit2.assert_equal ~printer:Int64.to_string 1724084535744408L c.seq
+  | _ -> OUnit2.assert_failure "expected v1 commit"
+
+let test_parse_v2_identity _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "message");
+        ( "payload",
+          `Assoc
+            [
+              ( "$type",
+                `String "network.bsky.jetstream.subscribeEvents#identity" );
+              ("did", `String "did:plc:abc123xyz0001112223333");
+              ("seq", `Int 9);
+              ("time", `String "2026-01-01T00:00:00.000000Z");
+              ( "identity",
+                `Assoc
+                  [
+                    ("did", `String "did:plc:abc123xyz0001112223333");
+                    ("handle", `String "jay.bsky.team");
+                    ("seq", `Int 1);
+                    ("time", `String "2026-01-01T00:00:00.000Z");
+                  ] );
+            ] );
+      ]
+  in
+  match Jetstream.parse_event json with
+  | `Identity i ->
+      OUnit2.assert_equal (Some "jay.bsky.team") i.handle;
+      OUnit2.assert_equal ~printer:Int64.to_string 9L i.seq
+  | _ -> OUnit2.assert_failure "expected identity"
+
+let test_subscribe_url_filters _ =
+  let url =
+    Jetstream.subscribe_url
+      ~filter:
+        {
+          Jetstream.collections = [ "app.bsky.feed.post"; "app.bsky.feed.like" ];
+          dids = [ "did:plc:abc123xyz0001112223333" ];
+          kinds = [ Jetstream.Commit ];
+          cursor = Some (Jetstream.Seq 12345L);
+          max_message_size_bytes = None;
+        }
+      ()
+  in
+  let has needle =
+    let rec contains i =
+      i + String.length needle <= String.length url
+      && (String.sub url i (String.length needle) = needle || contains (i + 1))
+    in
+    contains 0
+  in
+  OUnit2.assert_bool "v2 host" (has "jetstream.us-west.bsky.network");
+  OUnit2.assert_bool "nsid" (has "network.bsky.jetstream.subscribeEvents");
+  OUnit2.assert_bool "collections" (has "collections=");
+  OUnit2.assert_bool "kinds" (has "kinds=commit");
+  OUnit2.assert_bool "cursor" (has "cursor=12345")
+
+let test_v1_url _ =
+  let url =
+    Jetstream.subscribe_url ~host:Jetstream.v1_west_host ~version:Jetstream.V1
+      ~filter:
+        {
+          Jetstream.empty_filter with
+          collections = [ "app.bsky.feed.post" ];
+          cursor = Some (Jetstream.Time_us 1724084535744408L);
+        }
+      ()
+  in
+  OUnit2.assert_bool "v1 path"
+    (let needle = "/subscribe" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  OUnit2.assert_bool "wantedCollections"
+    (let needle = "wantedCollections=" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0)
+
+let test_cursor_magnitude _ =
+  OUnit2.assert_equal (Jetstream.Seq 99L) (Jetstream.cursor_of_int64 99L);
+  match Jetstream.cursor_of_int64 1724084535744408L with
+  | Jetstream.Time_us n ->
+      OUnit2.assert_equal ~printer:Int64.to_string 1724084535744408L n
+  | Jetstream.Seq _ -> OUnit2.assert_failure "expected time_us cursor"
+
+let test_filter_limits _ =
+  OUnit2.assert_raises (Jetstream.Invalid_filter "collections cap is 100")
+    (fun () ->
+      Jetstream.validate_filter
+        {
+          Jetstream.empty_filter with
+          collections =
+            List.init 101 (fun i -> "app.bsky.feed.n" ^ string_of_int i);
+        });
+  OUnit2.assert_raises
+    (Jetstream.Invalid_filter
+       "collections filter requires kinds to include commit (or omit kinds)")
+    (fun () ->
+      Jetstream.validate_filter
+        {
+          Jetstream.empty_filter with
+          collections = [ "app.bsky.feed.post" ];
+          kinds = [ Jetstream.Identity ];
+        })
+
+let test_dedupe _ =
+  let seen = Jetstream.create_seen ~cap:2 () in
+  let ev = Jetstream.parse_event v2_commit_json in
+  OUnit2.assert_bool "first" (not (Jetstream.is_duplicate seen ev));
+  Jetstream.remember seen ev;
+  OUnit2.assert_bool "dup" (Jetstream.is_duplicate seen ev)
+
+let test_reconnect_cursor _ =
+  let ev = Jetstream.parse_event v2_commit_json in
+  match Jetstream.seq_of ev with
+  | Some s ->
+      let f = Jetstream.with_cursor Jetstream.empty_filter (Jetstream.Seq s) in
+      OUnit2.assert_equal (Some (Jetstream.Seq s)) f.cursor
+  | None -> OUnit2.assert_failure "commit should have seq"
+
+let test_plan_snapshot _ =
+  let body =
+    Jetstream.plan_snapshot_body ~kinds:[ "commit" ]
+      ~collections:[ "app.bsky.feed.post" ] ~after_seq:10L ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "commit"
+    (body |> member "kinds" |> to_list |> List.hd |> to_string);
+  let plan =
+    Jetstream.parse_snapshot_plan
+      (`Assoc
+        [
+          ("plannedThroughSeq", `Int 20);
+          ("sealedTipSeq", `Int 20);
+          ( "segments",
+            `List
+              [
+                `Assoc
+                  [
+                    ("name", `String "seg-0");
+                    ("index", `Int 0);
+                    ("checksum", `String "0123456789abcdef");
+                    ("minSeq", `Int 1);
+                    ("maxSeq", `Int 20);
+                    ("mode", `String "segment");
+                  ];
+              ] );
+          ( "stats",
+            `Assoc
+              [
+                ("segmentsExamined", `Int 1);
+                ("segmentsMatched", `Int 1);
+                ("blocksMatched", `Int 0);
+                ("entries", `Int 1);
+              ] );
+        ])
+  in
+  OUnit2.assert_equal ~printer:Int64.to_string 20L plan.sealed_tip_seq;
+  OUnit2.assert_equal 1 (List.length plan.segments);
+  OUnit2.assert_bool "plan URL"
+    (let u = Jetstream.plan_snapshot_url () in
+     let needle = "planSnapshot" in
+     let rec contains i =
+       i + String.length needle <= String.length u
+       && (String.sub u i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0)
+
+let test_subscribe_live _ =
+  let old =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
+  in
+  ignore (Unix.alarm 20);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm old)
+    (fun () ->
+      try
+        let ev =
+          Jetstream.subscribe_one
+            ~filter:
+              {
+                Jetstream.empty_filter with
+                collections = [ "app.bsky.feed.post" ];
+                kinds = [ Jetstream.Commit ];
+              }
+            ()
+        in
+        match ev with
+        | `Commit _ | `Identity _ | `Account _ | `Sync _ | `Info _ | `Unknown _
+          ->
+            OUnit2.assert_bool "decoded a Jetstream frame" true
+      with exn -> skip_if true ("jetstream skipped: " ^ Printexc.to_string exn))
+
+let suite =
+  "jetstream"
+  >::: [
+         "test_parse_v2_commit" >:: test_parse_v2_commit;
+         "test_parse_v1_commit" >:: test_parse_v1_commit;
+         "test_parse_v2_identity" >:: test_parse_v2_identity;
+         "test_subscribe_url_filters" >:: test_subscribe_url_filters;
+         "test_v1_url" >:: test_v1_url;
+         "test_cursor_magnitude" >:: test_cursor_magnitude;
+         "test_filter_limits" >:: test_filter_limits;
+         "test_dedupe" >:: test_dedupe;
+         "test_reconnect_cursor" >:: test_reconnect_cursor;
+         "test_plan_snapshot" >:: test_plan_snapshot;
+         "test_subscribe_live" >:: test_subscribe_live;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_jetstream.ml
+++ b/test/test_jetstream.ml
@@ -158,6 +158,14 @@ let test_cursor_magnitude _ =
       OUnit2.assert_equal ~printer:Int64.to_string 1724084535744408L n
   | Jetstream.Seq _ -> OUnit2.assert_failure "expected time_us cursor"
 
+let test_collection_wildcard_allowed _ =
+  Jetstream.validate_filter
+    {
+      Jetstream.empty_filter with
+      collections = [ "app.bsky.feed.*" ];
+      kinds = [ Jetstream.Commit ];
+    }
+
 let test_filter_limits _ =
   OUnit2.assert_raises (Jetstream.Invalid_filter "collections cap is 100")
     (fun () ->
@@ -279,6 +287,7 @@ let suite =
          "test_subscribe_url_filters" >:: test_subscribe_url_filters;
          "test_v1_url" >:: test_v1_url;
          "test_cursor_magnitude" >:: test_cursor_magnitude;
+         "test_collection_wildcard_allowed" >:: test_collection_wildcard_allowed;
          "test_filter_limits" >:: test_filter_limits;
          "test_dedupe" >:: test_dedupe;
          "test_reconnect_cursor" >:: test_reconnect_cursor;

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -69,6 +69,64 @@ let test_nested_parameters_and_codegen _ =
       | Ok () -> ()
       | Error e -> OUnit2.assert_failure e)
 
+let procedure_sample =
+  {|
+{
+  "lexicon": 1,
+  "id": "app.bsky.video.uploadVideo",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Upload a video as raw bytes.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": { "type": "string", "format": "did" },
+          "name": { "type": "string" }
+        }
+      },
+      "input": {
+        "encoding": "video/*"
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["jobId"],
+          "properties": {
+            "jobId": { "type": "string" },
+            "blob": { "type": "blob" }
+          }
+        }
+      }
+    }
+  }
+}
+|}
+
+let test_procedure_input_output _ =
+  let doc = Lexicon.of_string procedure_sample in
+  match Lexicon.main doc with
+  | None -> OUnit2.assert_failure "missing main"
+  | Some main ->
+      OUnit2.assert_equal Lexicon.Procedure main.kind;
+      OUnit2.assert_equal [ "did" ] main.required;
+      OUnit2.assert_equal (Some "video/*") main.input.encoding;
+      OUnit2.assert_equal (Some "application/json") main.output.encoding;
+      OUnit2.assert_equal [ "jobId" ] main.output.required;
+      OUnit2.assert_equal (Some Lexicon.Bytes)
+        (List.assoc_opt "blob" main.output.properties);
+      let ocaml = Lexicon.to_ocaml doc in
+      OUnit2.assert_bool "codegen mentions input encoding"
+        (let needle = "video/*" in
+         let rec contains i =
+           i + String.length needle <= String.length ocaml
+           && (String.sub ocaml i (String.length needle) = needle
+              || contains (i + 1))
+         in
+         contains 0)
+
 let test_validate_errors _ =
   let doc = Lexicon.of_string sample in
   match Lexicon.main doc with
@@ -88,6 +146,7 @@ let suite =
          "test_lookup_helpers" >:: test_lookup_helpers;
          "test_nested_parameters_and_codegen"
          >:: test_nested_parameters_and_codegen;
+         "test_procedure_input_output" >:: test_procedure_input_output;
          "test_validate_errors" >:: test_validate_errors;
        ]
 

--- a/test/test_moderation.ml
+++ b/test/test_moderation.ml
@@ -14,6 +14,53 @@ let create_test_session _ =
   let username, password = Auth.username_and_password_from_env in
   Session.create_session username password
 
+let test_report_bodies _ =
+  let data =
+    Moderation.create_report_data_from_strong_ref
+      "com.atproto.moderation.defs#reasonSpam" ~reason:"bots" sample_strong_ref
+  in
+  let json = Yojson.Safe.from_string data in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.atproto.moderation.defs#reasonSpam"
+    (json |> member "reasonType" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bots"
+    (json |> member "reason" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.atproto.repo.strongRef"
+    (json |> member "subject" |> member "$type" |> to_string);
+  let repo =
+    Moderation.create_report_data_from_repo_ref
+      "com.atproto.moderation.defs#reasonOther"
+      { did = "did:plc:abc123xyz0001112223333" }
+  in
+  let repo_json = Yojson.Safe.from_string repo in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.atproto.admin.defs#repoRef"
+    (repo_json |> member "subject" |> member "$type" |> to_string)
+
+let test_parse_report_response _ =
+  let json =
+    `Assoc
+      [
+        ("id", `Int 7);
+        ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ("reasonType", `String "com.atproto.moderation.defs#reasonSpam");
+        ("reportedBy", `String "did:plc:abc123xyz0001112223333");
+        ("subject", `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]);
+      ]
+  in
+  let r = Moderation.parse_report_response json in
+  OUnit2.assert_equal 7 r.id;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:abc123xyz0001112223333" r.reported_by
+
 let test_create_report_no_reason _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -29,6 +76,10 @@ let test_create_report_no_reason _ =
 
 let suite =
   "suite"
-  >::: [ "test_create_report_no_reason" >:: test_create_report_no_reason ]
+  >::: [
+         "test_report_bodies" >:: test_report_bodies;
+         "test_parse_report_response" >:: test_parse_report_response;
+         "test_create_report_no_reason" >:: test_create_report_no_reason;
+       ]
 
 let () = run_test_tt_main suite

--- a/test/test_notification.ml
+++ b/test/test_notification.ml
@@ -7,6 +7,38 @@ let create_test_session _ =
   let username, password = Auth.username_and_password_from_env in
   Session.create_session username password
 
+let test_parse_unread_and_like _ =
+  let count = Notification.parse_unread_count (`Assoc [ ("count", `Int 3) ]) in
+  OUnit2.assert_equal 3 count.count;
+  let like =
+    Notification.parse_record
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.feed.like");
+          ( "subject",
+            `Assoc
+              [
+                ( "uri",
+                  `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+                );
+                ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+              ] );
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ])
+      "like"
+  in
+  (match like with
+  | `Like r ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "app.bsky.feed.like" r.record_type
+  | _ -> OUnit2.assert_failure "expected like");
+  match
+    Notification.parse_record (`Assoc [ ("text", `String "hi") ]) "quote"
+  with
+  | `Other o -> OUnit2.assert_equal ~printer:(fun x -> x) "quote" o.reason
+  | _ -> OUnit2.assert_failure "expected other record for quote"
+
 let test_get_unread_count _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -45,6 +77,7 @@ let test_update_seen _ =
 let suite =
   "suite"
   >::: [
+         "test_parse_unread_and_like" >:: test_parse_unread_and_like;
          "test_get_unread_count" >:: test_get_unread_count;
          "test_list_notifications" >:: test_list_notifications;
          "test_update_seen" >:: test_update_seen;

--- a/test/test_oauth_scope.ml
+++ b/test/test_oauth_scope.ml
@@ -1,0 +1,88 @@
+open OUnit2
+open Atproto.Oauth_scope
+
+let test_atproto_and_transition _ =
+  let scopes = Oauth_scope.parse "atproto transition:generic" in
+  OUnit2.assert_equal 2 (List.length scopes);
+  Oauth_scope.require_atproto scopes;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "atproto transition:generic"
+    (Oauth_scope.serialize scopes)
+
+let test_repo_and_rpc _ =
+  let repo = Oauth_scope.parse_one "repo:app.bsky.feed.post" in
+  OUnit2.assert_equal Oauth_scope.Repo repo.resource;
+  OUnit2.assert_equal (Some "app.bsky.feed.post") repo.positional;
+  let rpc =
+    Oauth_scope.parse_one
+      "rpc:com.atproto.moderation.createReport?aud=did:web:api.bsky.app%23bsky_appview"
+  in
+  OUnit2.assert_equal
+    [ "com.atproto.moderation.createReport" ]
+    (Oauth_scope.lxm_of rpc);
+  OUnit2.assert_equal
+    [ "did:web:api.bsky.app#bsky_appview" ]
+    (Oauth_scope.aud_of rpc)
+
+let test_rpc_double_wildcard_rejected _ =
+  OUnit2.assert_raises
+    (Oauth_scope.Invalid "rpc scope cannot wildcard both lxm and aud")
+    (fun () -> ignore (Oauth_scope.parse_one "rpc:*?aud=*"))
+
+let test_repo_glob_rejected _ =
+  OUnit2.assert_raises
+    (Oauth_scope.Invalid "repo collection globs are not allowed") (fun () ->
+      ignore (Oauth_scope.parse_one "repo:app.bsky.*"))
+
+let test_blob_and_include _ =
+  let blob = Oauth_scope.parse_one "blob:*/*" in
+  OUnit2.assert_equal Oauth_scope.Blob blob.resource;
+  let inc = Oauth_scope.parse_one "include:app.bsky.authBasicFeatures?aud=*" in
+  OUnit2.assert_equal Oauth_scope.Include inc.resource;
+  OUnit2.assert_equal (Some "app.bsky.authBasicFeatures") inc.positional
+
+let test_account_identity _ =
+  let acc = Oauth_scope.parse_one "account:email?action=read" in
+  OUnit2.assert_equal Oauth_scope.Account acc.resource;
+  let id_ = Oauth_scope.parse_one "identity:handle" in
+  OUnit2.assert_equal Oauth_scope.Identity id_.resource
+
+let test_subset_and_require _ =
+  OUnit2.assert_bool "subset"
+    (Oauth_scope.is_subset ~requested:"atproto repo:app.bsky.feed.post"
+       ~declared:"atproto repo:app.bsky.feed.post transition:generic");
+  OUnit2.assert_bool "not subset"
+    (not
+       (Oauth_scope.is_subset ~requested:"atproto transition:generic"
+          ~declared:"atproto"));
+  OUnit2.assert_raises (Oauth_scope.Invalid "scope list must include atproto")
+    (fun () -> ignore (Oauth_scope.parse_and_require "repo:app.bsky.feed.post"))
+
+let test_metadata_parses_granular _ =
+  let meta =
+    Atproto.Oauth.Oauth.public_metadata
+      ~client_id:"https://client.example/client-metadata.json"
+      ~redirect_uris:[ "https://client.example/cb" ]
+      ~scope:
+        "atproto repo:app.bsky.actor.profile \
+         rpc:app.bsky.feed.getTimeline?aud=*"
+      ()
+  in
+  Atproto.Oauth.Oauth.validate_metadata meta
+
+let suite =
+  "oauth_scope"
+  >::: [
+         "test_atproto_and_transition" >:: test_atproto_and_transition;
+         "test_repo_and_rpc" >:: test_repo_and_rpc;
+         "test_rpc_double_wildcard_rejected"
+         >:: test_rpc_double_wildcard_rejected;
+         "test_repo_glob_rejected" >:: test_repo_glob_rejected;
+         "test_blob_and_include" >:: test_blob_and_include;
+         "test_account_identity" >:: test_account_identity;
+         "test_subset_and_require" >:: test_subset_and_require;
+         "test_metadata_parses_granular" >:: test_metadata_parses_granular;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_oauth_scope.ml
+++ b/test/test_oauth_scope.ml
@@ -33,7 +33,10 @@ let test_rpc_double_wildcard_rejected _ =
 let test_repo_glob_rejected _ =
   OUnit2.assert_raises
     (Oauth_scope.Invalid "repo collection globs are not allowed") (fun () ->
-      ignore (Oauth_scope.parse_one "repo:app.bsky.*"))
+      ignore (Oauth_scope.parse_one "repo:app.bsky.*"));
+  OUnit2.assert_raises
+    (Oauth_scope.Invalid "repo collection must be an NSID or *: not-a-nsid")
+    (fun () -> ignore (Oauth_scope.parse_one "repo:not-a-nsid"))
 
 let test_blob_and_include _ =
   let blob = Oauth_scope.parse_one "blob:*/*" in

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -102,6 +102,19 @@ let test_parse_describe_server _ =
   OUnit2.assert_bool "domains"
     (List.mem ".bsky.social" desc.available_user_domains)
 
+let test_parse_describe_server_missing_contact _ =
+  let desc =
+    Server.parse_describe_server
+      (`Assoc
+        [
+          ("did", `String "did:web:pds.example");
+          ("availableUserDomains", `List [ `String ".example" ]);
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:web:pds.example" desc.did;
+  OUnit2.assert_equal None desc.contact_email;
+  OUnit2.assert_equal None desc.links.privacy_policy
+
 let test_reserve_signing_key_body _ =
   let body =
     Server.reserve_signing_key_body ~did:"did:plc:abc123xyz0001112223333" ()
@@ -132,6 +145,8 @@ let suite =
          "test_parse_account_status" >:: test_parse_account_status;
          "test_account_urls" >:: test_account_urls;
          "test_parse_describe_server" >:: test_parse_describe_server;
+         "test_parse_describe_server_missing_contact"
+         >:: test_parse_describe_server_missing_contact;
          "test_reserve_signing_key_body" >:: test_reserve_signing_key_body;
          "test_describe_server_public" >:: test_describe_server_public;
        ]

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -139,6 +139,28 @@ let test_parse_list_repos_by_collection _ =
   OUnit2.assert_equal 2 (List.length r.repos);
   OUnit2.assert_equal "did:plc:aaaa" (List.hd r.repos).did
 
+let test_get_blocks_url _ =
+  let url =
+    Sync.get_blocks_url ~host:"bsky.social"
+      ~did:"did:plc:abc123xyz0001112223333"
+      ~cids:[ "bafyreihdummy000000000000000000000000000000000" ]
+      ()
+  in
+  OUnit2.assert_bool "getBlocks"
+    (let needle = "getBlocks" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  OUnit2.assert_bool "cids"
+    (let needle = "cids=" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0)
+
 let test_get_repo_status_public _ =
   try
     with_public_timeout (fun () ->
@@ -160,6 +182,7 @@ let suite =
          "test_parse_list_hosts" >:: test_parse_list_hosts;
          "test_parse_list_repos_by_collection"
          >:: test_parse_list_repos_by_collection;
+         "test_get_blocks_url" >:: test_get_blocks_url;
          "test_get_repo_status_public" >:: test_get_repo_status_public;
        ]
 

--- a/test/test_varint.ml
+++ b/test/test_varint.ml
@@ -1,0 +1,36 @@
+open OUnit2
+open Atproto.Varint
+
+let roundtrip n =
+  let encoded = Varint.encode n in
+  let decoded, consumed = Varint.decode encoded in
+  OUnit2.assert_equal ~printer:string_of_int n decoded;
+  OUnit2.assert_equal ~printer:string_of_int (String.length encoded) consumed
+
+let test_small _ = List.iter roundtrip [ 0; 1; 127; 128; 255; 300; 16384 ]
+
+let test_truncated _ =
+  OUnit2.assert_raises (Failure "Varint.decode: truncated") (fun () ->
+      ignore (Varint.decode "\x80"))
+
+let test_negative _ =
+  OUnit2.assert_raises (Invalid_argument "Varint.encode: negative") (fun () ->
+      ignore (Varint.encode (-1)))
+
+let test_decode_from _ =
+  let prefix = "xx" in
+  let body = Varint.encode 42 in
+  let n, off = Varint.decode_from (prefix ^ body) 2 in
+  OUnit2.assert_equal ~printer:string_of_int 42 n;
+  OUnit2.assert_equal ~printer:string_of_int (2 + String.length body) off
+
+let suite =
+  "varint"
+  >::: [
+         "test_small" >:: test_small;
+         "test_truncated" >:: test_truncated;
+         "test_negative" >:: test_negative;
+         "test_decode_from" >:: test_decode_from;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_video.ml
+++ b/test/test_video.ml
@@ -2,6 +2,21 @@ open OUnit2
 open Atproto.Video
 open Atproto.Auth
 
+let sample_blob =
+  `Assoc
+    [
+      ("$type", `String "blob");
+      ( "ref",
+        `Assoc
+          [
+            ( "$link",
+              `String
+                "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku" );
+          ] );
+      ("mimeType", `String "video/mp4");
+      ("size", `Int 2048);
+    ]
+
 let test_parse_job_status _ =
   let json =
     `Assoc
@@ -34,6 +49,203 @@ let test_parse_upload_limits _ =
   OUnit2.assert_equal true lim.can_upload;
   OUnit2.assert_equal (Some 10) lim.remaining_daily_videos
 
+let test_upload_video_url _ =
+  let url =
+    Video.upload_video_url ~did:"did:plc:abc123xyz0001112223333"
+      ~name:"clip.mp4" ()
+  in
+  OUnit2.assert_bool "host" (String.length url > 20);
+  OUnit2.assert_bool "nsid"
+    (let needle = "app.bsky.video.uploadVideo" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  OUnit2.assert_bool "did query"
+    (let needle = "did=did%3Aplc%3Aabc123xyz0001112223333" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0
+     ||
+     let needle = "did=did:plc:abc123xyz0001112223333" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  OUnit2.assert_bool "default host"
+    (let needle = "video.bsky.app" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0)
+
+let test_pds_audience _ =
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:bsky.social"
+    (Video.pds_audience
+       {
+         username = "x";
+         password = "y";
+         atp_host = "bsky.social";
+         auth =
+           {
+             exp = 0;
+             iat = 0;
+             scope = "com.atproto.access";
+             did = "did:plc:abc123xyz0001112223333";
+             jti = None;
+             token = "t";
+             refresh_token = None;
+           };
+       });
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:pds.example"
+    (Video.pds_audience ~host:"https://pds.example/xrpc"
+       {
+         username = "x";
+         password = "y";
+         atp_host = "bsky.social";
+         auth =
+           {
+             exp = 0;
+             iat = 0;
+             scope = "com.atproto.access";
+             did = "did:plc:abc123xyz0001112223333";
+             jti = None;
+             token = "t";
+             refresh_token = None;
+           };
+       })
+
+let test_recommended_exp _ =
+  let exp = Video.recommended_exp ~now:1_700_000_000.0 () in
+  OUnit2.assert_equal ~printer:Int64.to_string
+    (Int64.add 1_700_000_000L 1800L)
+    exp
+
+let test_job_phase _ =
+  OUnit2.assert_equal Video.Completed
+    (Video.classify_state "JOB_STATE_COMPLETED");
+  OUnit2.assert_equal Video.Failed (Video.classify_state "JOB_STATE_FAILED");
+  OUnit2.assert_equal Video.In_progress
+    (Video.classify_state "JOB_STATE_CREATED");
+  let done_ =
+    Video.parse_job_status
+      (`Assoc
+        [
+          ("jobId", `String "j");
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("state", `String "JOB_STATE_COMPLETED");
+          ("blob", sample_blob);
+        ])
+  in
+  OUnit2.assert_bool "completed" (Video.is_completed done_);
+  OUnit2.assert_bool "terminal" (Video.is_terminal done_);
+  OUnit2.assert_bool "blob" (Video.blob_ready done_)
+
+let test_already_exists _ =
+  let json =
+    `Assoc
+      [
+        ("error", `String "already_exists");
+        ("jobId", `String "job-dup");
+        ("blob", sample_blob);
+      ]
+  in
+  let st = Video.parse_upload_response json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "job-dup" st.job_id;
+  OUnit2.assert_bool "already_exists" (Video.already_exists st);
+  OUnit2.assert_bool "blob present" (Video.blob_ready st)
+
+let test_poll_until_blob _ =
+  let n = ref 0 in
+  let get_status _ =
+    incr n;
+    if !n < 3 then
+      Video.parse_job_status
+        (`Assoc
+          [
+            ("jobId", `String "job-p");
+            ("did", `String "did:plc:abc123xyz0001112223333");
+            ("state", `String "JOB_STATE_ENCODING");
+            ("progress", `Int (!n * 10));
+          ])
+    else
+      Video.parse_job_status
+        (`Assoc
+          [
+            ("jobId", `String "job-p");
+            ("did", `String "did:plc:abc123xyz0001112223333");
+            ("state", `String "JOB_STATE_COMPLETED");
+            ("progress", `Int 100);
+            ("blob", sample_blob);
+          ])
+  in
+  let slept = ref 0 in
+  let st =
+    Video.poll_job_status ~get_status
+      ~sleep:(fun () -> incr slept)
+      ~job_id:"job-p" ()
+  in
+  OUnit2.assert_equal 3 !n;
+  OUnit2.assert_equal 2 !slept;
+  OUnit2.assert_bool "blob" (Video.blob_ready st);
+  OUnit2.assert_bool "completed" (Video.is_completed st)
+
+let test_ensure_blob_short_circuit _ =
+  let called = ref false in
+  let ready =
+    Video.parse_job_status
+      (`Assoc
+        [
+          ("jobId", `String "job-e");
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("state", `String "JOB_STATE_COMPLETED");
+          ("blob", sample_blob);
+        ])
+  in
+  let out =
+    Video.ensure_blob
+      ~get_status:(fun _ ->
+        called := true;
+        ready)
+      ready
+  in
+  OUnit2.assert_bool "did not poll" (not !called);
+  OUnit2.assert_bool "blob" (Video.blob_ready out)
+
+let test_video_embed_json _ =
+  let embed =
+    Video.video_embed_json ~video:sample_blob ~alt:"demo"
+      ~aspect_ratio:{ width = 16; height = 9 } ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.embed.video"
+    (embed |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "demo"
+    (embed |> member "alt" |> to_string);
+  OUnit2.assert_equal 16
+    (embed |> member "aspectRatio" |> member "width" |> to_int)
+
+let test_upload_headers _ =
+  let pairs =
+    Video.upload_header_pairs ~token:"svc" ~content_type:"video/mp4"
+  in
+  OUnit2.assert_equal
+    [ ("Authorization", "Bearer svc"); ("Content-Type", "video/mp4") ]
+    pairs
+
 let test_upload_limits_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -49,6 +261,15 @@ let suite =
   >::: [
          "test_parse_job_status" >:: test_parse_job_status;
          "test_parse_upload_limits" >:: test_parse_upload_limits;
+         "test_upload_video_url" >:: test_upload_video_url;
+         "test_pds_audience" >:: test_pds_audience;
+         "test_recommended_exp" >:: test_recommended_exp;
+         "test_job_phase" >:: test_job_phase;
+         "test_already_exists" >:: test_already_exists;
+         "test_poll_until_blob" >:: test_poll_until_blob;
+         "test_ensure_blob_short_circuit" >:: test_ensure_blob_short_circuit;
+         "test_video_embed_json" >:: test_video_embed_json;
+         "test_upload_headers" >:: test_upload_headers;
          "test_upload_limits_auth_skipped" >:: test_upload_limits_auth_skipped;
        ]
 

--- a/test/test_video.ml
+++ b/test/test_video.ml
@@ -162,7 +162,9 @@ let test_already_exists _ =
   let st = Video.parse_upload_response json in
   OUnit2.assert_equal ~printer:(fun x -> x) "job-dup" st.job_id;
   OUnit2.assert_bool "already_exists" (Video.already_exists st);
-  OUnit2.assert_bool "blob present" (Video.blob_ready st)
+  OUnit2.assert_bool "blob present" (Video.blob_ready st);
+  OUnit2.assert_bool "not failed" (not (Video.is_failed st));
+  OUnit2.assert_bool "completed via blob" (Video.is_completed st)
 
 let test_poll_until_blob _ =
   let n = ref 0 in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Based on `main` at merge commit `bbd6b67` (PR #74). Opened against `main`, not stacked on `cursor/atproto-appview-ozone-e3a1-cc75`. The merged #74 branch is untouched.

## Protocol / library

- **Video upload pipeline** (`Video`): byte POST to `video.bsky.app` `uploadVideo`, service-auth audience `did:web:<pds>` + `com.atproto.repo.uploadBlob`, job poll, `video_embed_json`. `already_exists` is not a hard failure when a blob ref is present (official tutorial). No hosted transcoder.
- **Jetstream v2**: live WebSocket tail, filters (including `app.bsky.feed.*` wildcards), seq / unix-µs cursors, reconnect/dedupe, typed events, v1 `/subscribe` compat. Snapshot HTTP types only — no invented archive token.
- **OAuth scopes**: granular `repo:` / `rpc:` / `blob:` / `include:` / `transition:` grammar; `atproto` still required.
- **Sync v1.1**: public `getBlocks` + live-shaped firehose MST/`prevData` verify.

## Packaging and remaining holes

- `atproto.opam` / `dune-project` (version 0.1.0, `run-test`, synopsis), compiling `examples/offline.ml`, README coverage.
- Older-module tests: Base32 (RFC 4648), Base64url/Base58, Hash, Varint.
- Lexicon procedure input/output encodings; embed / facet / notification parse without `failwith`; HTTP PUT/DELETE/PATCH.

**Not in this PR:** hosted OAuth client-metadata URL, browser login, invented credentials, permissioned data / LtHash (no stable spec), Jetstream Network Replay live download.

Fixes # (issue)

`dune build` and `dune runtest` pass. Auth suites skip without real `ATP_AUTH`. Action majors unchanged (`checkout@v4`, `setup-ocaml@v3`, `cache@v4`, `upload-artifact@v4`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-275e2249-fb34-44b7-be70-a0729962db01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-275e2249-fb34-44b7-be70-a0729962db01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

