### PR TITLE
Service-auth JWT verify + TAP-like repo sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | AppView feed | `Feed` | Timeline, threads, generators (`getFeed` / `getFeedGenerator` / `getActorFeeds`), `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
-| Jetstream | `Jetstream` | v2 live tail (`wss://jetstream.us-west/east.bsky.network/xrpc/network.bsky.jetstream.subscribeEvents`), collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat, snapshot/replay URL+plan types + skippable unauthenticated `try_plan_snapshot` (no invented archive token) |
+| Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner (`planSnapshot`/`planBackfill`/`listSegments` types, page window, download jobs, live cutover `?cursor=sealedTipSeq`, Range resume) + skippable unauthenticated HTTP (no invented archive token) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
@@ -74,7 +74,7 @@ These are product-level, not missing protocol cores:
 
 - Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
 - A hosted PDS, hosted Tap service, hosted video transcoder, or live Ozone operator session (client request/response types, video byte-upload + job poll, TAP-like repo sync helpers, and proxy headers are implemented)
-- Jetstream Network Replay / HTTP snapshot download against Bluesky's gated archive (plan/segment/block URLs, JSON types, and a skippable unauthenticated `try_plan_snapshot` are implemented; a live download still needs an operator token this library does not invent)
+- Jetstream Network Replay / HTTP snapshot **download** against Bluesky's gated archive (planner, `listSegments` types, cutover cursor, Range resume, and skippable unauthenticated HTTP are implemented; a live archive download still needs an operator token this library does not invent)
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Defined CAR block ordering and collection-subset repo exports (Sync 1.1 leftovers; no stable export layout to implement yet)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | AppView feed | `Feed` | Timeline, threads, generators (`getFeed` / `getFeedGenerator` / `getActorFeeds`), `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
-| Jetstream | `Jetstream` | v2 live tail (`wss://jetstream.us-west/east.bsky.network/xrpc/network.bsky.jetstream.subscribeEvents`), collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat, snapshot/replay URL+plan types (no archive token) |
+| Jetstream | `Jetstream` | v2 live tail (`wss://jetstream.us-west/east.bsky.network/xrpc/network.bsky.jetstream.subscribeEvents`), collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat, snapshot/replay URL+plan types + skippable unauthenticated `try_plan_snapshot` (no invented archive token) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
@@ -46,19 +46,20 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Ozone | `Ozone` | `tools.ozone.moderation.*` + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; `uploadBlob` parse |
-| Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` |
+| Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` (aud may be `did#service`) |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + updateHandle / PLC operation helpers |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
 | CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1 |
-| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete, firehose-diff inversion, p256/k256 commit sign+verify |
+| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete/walk, firehose-diff inversion **and** forward apply, p256/k256 commit sign+verify |
+| Repo sync (TAP-like) | `Repo_sync` | Library-shaped backfill: open/verify repo CAR, walk records, `getRecord` inclusion proof, record-table apply of firehose ops, `#sync` desync, MST-level `apply_commit_tree`. Not a hosted Tap service |
 | TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen, JSON validate |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
 | OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
 | Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) |
-| XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit, service-auth JWT; chat + appview proxies |
+| XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit; service-auth JWT mint/verify (ES256/ES256K, `kid`/`jti`/`iat`/`lxm`, `did#service` aud, replay cache) |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
 | Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video; mention / link / tag |
@@ -72,11 +73,12 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 These are product-level, not missing protocol cores:
 
 - Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
-- A hosted PDS, hosted video transcoder, or live Ozone operator session (client request/response types, video byte-upload + job poll, and proxy headers are implemented)
-- Jetstream Network Replay / HTTP snapshot download against Bluesky's gated archive (plan/segment/block URLs and JSON types are implemented; live download needs an operator token this library does not invent)
+- A hosted PDS, hosted Tap service, hosted video transcoder, or live Ozone operator session (client request/response types, video byte-upload + job poll, TAP-like repo sync helpers, and proxy headers are implemented)
+- Jetstream Network Replay / HTTP snapshot download against Bluesky's gated archive (plan/segment/block URLs, JSON types, and a skippable unauthenticated `try_plan_snapshot` are implemented; a live download still needs an operator token this library does not invent)
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
+- Defined CAR block ordering and collection-subset repo exports (Sync 1.1 leftovers; no stable export layout to implement yet)
 
-Jetstream v2, granular OAuth scopes, Sync v1.1 `getBlocks` (public), live-shaped firehose MST verify, and the video byte-upload pipeline are in this slice. #70–#74 already landed identity/MST/OAuth-core/AppView/Ozone.
+Service-auth JWT mint/verify (`jti`/`kid`/`iat`, `did#service` audience, ES256/ES256K), TAP-like `Repo_sync` (CAR walk, record-table apply, `#sync` resync, MST forward apply), blob CID verify, and skippable Jetstream snapshot HTTP are in this slice. #70–#75 already landed identity/MST/OAuth-core/AppView/Ozone/Jetstream/video.
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -129,6 +131,12 @@ let _js =
         kinds = [ Jetstream.Commit ];
       }
     ()
+
+(* TAP-like local indexer: backfill a CAR, then apply firehose ops *)
+let acct =
+  Repo_sync.create_account ~did:"did:plc:abc123xyz0001112223333"
+    ~collections:[ "app.bsky.feed.post" ] ()
+let _ = acct.Repo_sync.status
 
 (* granular OAuth scopes (atproto remains mandatory) *)
 let scopes = Oauth_scope.parse "atproto repo:app.bsky.feed.post"

--- a/atproto.opam
+++ b/atproto.opam
@@ -48,10 +48,10 @@ OCaml client and protocol library for the AT Protocol (XRPC, lexicons,
 repo sync, identity, AppView, Ozone, and chat).
 
 Public modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video,
-Unspecced, Labeler, Chat, Ozone, Admin, Repo, Server, Identity, Did_plc,
-Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri, Lexicon,
-Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc, Error,
-Syntax, Embed, Facet, Notification, and Moderation.
+Unspecced, Labeler, Chat, Ozone, Admin, Repo, Repo_sync, Server, Identity,
+Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
+Lexicon, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
+Error, Syntax, Embed, Facet, Notification, and Moderation.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -11,6 +11,8 @@ open Atproto.Oauth
 open Atproto.Xrpc
 open Atproto.Jetstream
 open Atproto.Oauth_scope
+open Atproto.Repo_sync
+open Atproto.Cid
 open Atproto.Repo
 open Atproto.Server
 open Atproto.Http_method
@@ -138,4 +140,13 @@ let () =
         ])
   in
   (match ev with `Commit _ -> () | _ -> assert false);
+  let aud = Syntax.parse_did_ref "did:web:video.bsky.app#bsky_transcode" in
+  assert (aud.fragment = Some "bsky_transcode");
+  let blob_cid = Cid.of_blob "clip-bytes" in
+  assert (blob_cid.codec = Cid.Raw);
+  let acct =
+    Repo_sync.create_account ~did:"did:plc:abc123xyz0001112223333"
+      ~collections:[ "app.bsky.feed.post" ] ()
+  in
+  assert (acct.status = Repo_sync.Desynchronized);
   print_endline "examples/offline: public API typechecks and fixtures pass"

--- a/src/cid.ml
+++ b/src/cid.ml
@@ -71,4 +71,30 @@ module Cid = struct
 
   let create ?(codec = Dag_cbor) (data : string) : t =
     of_digest ~codec (sha256 data)
+
+  (* Blobs are raw + SHA-256; repo records / MST nodes are dag-cbor. *)
+  let of_blob (bytes : string) : t = create ~codec:Raw bytes
+
+  let verify_blob ?(expected : t option) (bytes : string) : t =
+    let got = of_blob bytes in
+    match expected with
+    | None -> got
+    | Some cid ->
+        if equal cid got then got
+        else
+          failwith
+            (Printf.sprintf "Cid.verify_blob: expected %s got %s"
+               (to_string cid) (to_string got))
+
+  let verify_block ?(expected : t option) ?(codec = Dag_cbor) (bytes : string) :
+      t =
+    let got = create ~codec bytes in
+    match expected with
+    | None -> got
+    | Some cid ->
+        if equal cid got then got
+        else
+          failwith
+            (Printf.sprintf "Cid.verify_block: expected %s got %s"
+               (to_string cid) (to_string got))
 end

--- a/src/cohttp_client.ml
+++ b/src/cohttp_client.ml
@@ -133,6 +133,21 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  let get_with_status (url : string) headers : (int * string) Lwt.t =
+    let open Lwt.Infix in
+    Cohttp_lwt_unix.Client.get ~headers (Uri.of_string url)
+    >>= fun (resp, body) ->
+    let code = resp |> Response.status |> Code.code_of_status in
+    body |> Cohttp_lwt.Body.to_string >|= fun body -> (code, body)
+
+  let post_with_status (url : string) data headers : (int * string) Lwt.t =
+    let open Lwt.Infix in
+    let body = Cohttp_lwt.Body.of_string data in
+    Cohttp_lwt_unix.Client.post ~headers ~body (Uri.of_string url)
+    >>= fun (resp, body) ->
+    let code = resp |> Response.status |> Code.code_of_status in
+    body |> Cohttp_lwt.Body.to_string >|= fun body -> (code, body)
+
   let post_request_with_headers (url : string) headers =
     let open Lwt.Infix in
     Cohttp_lwt_unix.Client.post ~headers (Uri.of_string url)

--- a/src/did_plc.ml
+++ b/src/did_plc.ml
@@ -144,6 +144,29 @@ module Did_plc = struct
         && String.sub id (String.length id - 8) 8 = "#atproto")
       doc.verification_method
 
+  let did_key_of_method (m : verification_method) : string option =
+    match m.public_key_multibase with
+    | Some mb when String.length mb > 8 && String.sub mb 0 8 = "did:key:" ->
+        Some mb
+    | Some mb when String.length mb > 0 && (mb.[0] = 'z' || mb.[0] = 'Z') ->
+        Some ("did:key:" ^ mb)
+    | _ -> None
+
+  let is_atproto_key_id (id : string) : bool =
+    let n = String.length id in
+    n >= 8 && String.sub id (n - 8) 8 = "#atproto"
+
+  let atproto_signing_keys (doc : did_document) : string list =
+    List.filter_map
+      (fun (m : verification_method) ->
+        if is_atproto_key_id m.id then did_key_of_method m else None)
+      doc.verification_method
+
+  let signing_keys_of_document (doc : did_document) : string list =
+    match atproto_signing_keys doc with
+    | [] -> List.filter_map did_key_of_method doc.verification_method
+    | keys -> keys
+
   let directory_url ?(directory = default_directory) (did : string) : string =
     Printf.sprintf "https://%s/%s" directory did
 

--- a/src/dune
+++ b/src/dune
@@ -66,6 +66,7 @@
   Oauth_scope
   Ozone
   Repo
+  Repo_sync
   Request
   Response
   Server

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -299,6 +299,34 @@ module Firehose = struct
                    (Cid.to_string inverted) (Cid.to_string expected))
         | None -> ())
 
+  let verify_commit_object (c : commit) : Mst.Mst.repo_commit =
+    let signed = repo_commit_of c in
+    if c.repo <> signed.did then
+      failwith
+        (Printf.sprintf "Firehose.verify_commit_object: did %s != repo %s"
+           signed.did c.repo);
+    if c.rev <> signed.rev then
+      failwith
+        (Printf.sprintf "Firehose.verify_commit_object: rev %s != %s" signed.rev
+           c.rev);
+    signed
+
+  let verify_commit_sig ~keys (c : commit) : Mst.Mst.sig_status =
+    Mst.Mst.verify_commit_sig ~keys (repo_commit_of c)
+
+  let apply_commit ~(prev_tree : Mst.Mst.tree) (c : commit) : Mst.Mst.tree =
+    let signed = verify_commit_object c in
+    verify_commit c;
+    let tree = Mst.Mst.apply_ops prev_tree (record_ops c.ops) in
+    let root = Mst.Mst.root_cid tree in
+    if not (Cid.equal root signed.data) then
+      failwith
+        (Printf.sprintf
+           "Firehose.apply_commit: applied MST %s != commit.data %s"
+           (Cid.to_string root)
+           (Cid.to_string signed.data));
+    tree
+
   let subscribe_one ?host ?cursor () : header * message =
     let cell = ref None in
     subscribe ?host ?cursor ~max_messages:1 (fun frame -> cell := Some frame);

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -314,6 +314,29 @@ module Firehose = struct
   let verify_commit_sig ~keys (c : commit) : Mst.Mst.sig_status =
     Mst.Mst.verify_commit_sig ~keys (repo_commit_of c)
 
+  let verify_sync (s : sync) : Mst.Mst.repo_commit =
+    let root =
+      match Car.root s.blocks with
+      | Some c -> c
+      | None -> failwith "Firehose.verify_sync: CAR has no root"
+    in
+    let block =
+      match Car.find_block s.blocks root with
+      | Some b -> b
+      | None -> failwith "Firehose.verify_sync: commit block missing"
+    in
+    let computed = Cid.create block.data in
+    if not (Cid.equal computed root) then
+      failwith "Firehose.verify_sync: commit CID mismatch";
+    let signed = Mst.Mst.parse_repo_commit (Dag_cbor.decode block.data) in
+    if signed.did <> s.did then
+      failwith
+        (Printf.sprintf "Firehose.verify_sync: did %s != %s" signed.did s.did);
+    if signed.rev <> s.rev then
+      failwith
+        (Printf.sprintf "Firehose.verify_sync: rev %s != %s" signed.rev s.rev);
+    signed
+
   let apply_commit ~(prev_tree : Mst.Mst.tree) (c : commit) : Mst.Mst.tree =
     let signed = verify_commit_object c in
     verify_commit c;

--- a/src/jetstream.ml
+++ b/src/jetstream.ml
@@ -422,8 +422,43 @@ module Jetstream = struct
     stats : snapshot_stats;
   }
 
+  (* listSegments row — snapshot-only archive mirror (HTTP + token). *)
+  type archive_segment = {
+    name : string;
+    index : int;
+    checksum : string;
+    size_bytes : int64 option;
+    event_count : int option;
+    min_seq : int64;
+    max_seq : int64;
+    min_witnessed_at : int64 option;
+    max_witnessed_at : int64 option;
+  }
+
+  type list_segments = {
+    cursor : string option;
+    segments : archive_segment list;
+  }
+
+  type download_job =
+    | Segment of { name : string; checksum : string }
+    | Blocks of { name : string; checksum : string; ranges : block_range list }
+
   let plan_snapshot_url ?(host = default_host) () =
     Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.planSnapshot" host
+
+  let plan_backfill_url ?(host = default_host) () =
+    Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.planBackfill" host
+
+  let list_segments_url ?(host = default_host) ?cursor () =
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs
+        (match cursor with Some c -> [ ("cursor", c) ] | None -> [])
+    in
+    let base =
+      Printf.sprintf "https://%s/xrpc/network.bsky.jetstream.listSegments" host
+    in
+    if qs = "" then base else base ^ "?" ^ qs
 
   let get_segment_url ?(host = default_host) ~name () =
     let qs =
@@ -500,27 +535,107 @@ module Jetstream = struct
       stats = parse_snapshot_stats (Yojson.Safe.Util.member "stats" json);
     }
 
+  let parse_archive_segment json : archive_segment =
+    {
+      name = string_member json "name";
+      index =
+        (match Yojson.Safe.Util.member "index" json with `Int n -> n | _ -> 0);
+      checksum = string_member json "checksum";
+      size_bytes =
+        (match Yojson.Safe.Util.member "sizeBytes" json with
+        | `Int n -> Some (Int64.of_int n)
+        | `Intlit s -> Some (Int64.of_string s)
+        | _ -> None);
+      event_count =
+        (match Yojson.Safe.Util.member "eventCount" json with
+        | `Int n -> Some n
+        | _ -> None);
+      min_seq = int64_member json "minSeq";
+      max_seq = int64_member json "maxSeq";
+      min_witnessed_at =
+        (match int64_member json "minWitnessedAt" with
+        | 0L -> None
+        | n -> Some n);
+      max_witnessed_at =
+        (match int64_member json "maxWitnessedAt" with
+        | 0L -> None
+        | n -> Some n);
+    }
+
+  let parse_list_segments json : list_segments =
+    {
+      cursor = string_opt json "cursor";
+      segments =
+        (match Yojson.Safe.Util.member "segments" json with
+        | `List xs -> List.map parse_archive_segment xs
+        | _ -> []);
+    }
+
+  (* Official replay loop: pin sealedTipSeq, page while plannedThroughSeq < S. *)
+  let plan_needs_next (p : snapshot_plan) : bool =
+    Int64.compare p.planned_through_seq p.sealed_tip_seq < 0
+
+  let next_plan_window (p : snapshot_plan) : (int64 * int64) option =
+    if plan_needs_next p then Some (p.planned_through_seq, p.sealed_tip_seq)
+    else None
+
+  let download_jobs (p : snapshot_plan) : download_job list =
+    List.map
+      (fun (s : snapshot_segment) ->
+        if s.mode = "blocks" && s.blocks <> [] then
+          Blocks { name = s.name; checksum = s.checksum; ranges = s.blocks }
+        else Segment { name = s.name; checksum = s.checksum })
+      p.segments
+
+  let cutover_cursor (p : snapshot_plan) : cursor = Seq p.sealed_tip_seq
+
+  let cutover_filter ?(filter = empty_filter) (p : snapshot_plan) : filter =
+    { filter with cursor = Some (cutover_cursor p) }
+
+  let subscribe_url_after_plan ?host ?(filter = empty_filter)
+      (p : snapshot_plan) =
+    subscribe_url ?host ~filter:(cutover_filter ~filter p) ()
+
+  (* Range resume for getSegment after a mid-download 429. *)
+  let range_header ~first ?last () : string * string =
+    let spec =
+      match last with
+      | Some n -> Printf.sprintf "bytes=%d-%d" first n
+      | None -> Printf.sprintf "bytes=%d-" first
+    in
+    ("Range", spec)
+
+  let fold_removes_records (ev : event) : bool =
+    match ev with
+    | `Account a -> (not a.active) && a.status = Some "deleted"
+    | `Sync _ -> true
+    | `Commit c -> c.operation = "delete"
+    | `Identity _ | `Info _ | `Unknown _ -> false
+
   (* Live archive HTTP. Public hosts gate this; pass [token] only if the
      operator already has one. This library never invents a token. Live tail
      ([subscribe]) stays unauthenticated. *)
   exception Snapshot_gated of int * string
   exception Snapshot_http of int * string
+  exception Snapshot_rate_limited of int * string
 
   type snapshot_fetch =
     [ `Plan of snapshot_plan | `Bytes of string | `Gated of int * string ]
 
-  let snapshot_headers ?token () =
+  let snapshot_headers ?token ?range () =
     let pairs =
       Cohttp_client.Cohttp_client.application_json_setting_tuple
       ::
       (match token with
       | Some t when t <> "" -> [ ("Authorization", "Bearer " ^ t) ]
       | _ -> [])
+      @ match range with Some (k, v) -> [ (k, v) ] | None -> []
     in
     Cohttp_client.Cohttp_client.create_headers_from_pairs pairs
 
   let classify_snapshot_status code body =
     if code = 401 || code = 403 then raise (Snapshot_gated (code, body))
+    else if code = 429 then raise (Snapshot_rate_limited (code, body))
     else if code >= 400 then raise (Snapshot_http (code, body))
     else body
 
@@ -539,9 +654,9 @@ module Jetstream = struct
     parse_snapshot_plan
       (Yojson.Safe.from_string (classify_snapshot_status code body))
 
-  let try_get_segment ?host ?token ~name () : string =
+  let try_get_segment ?host ?token ?range ~name () : string =
     let url = get_segment_url ?host ~name () in
-    let headers = snapshot_headers ?token () in
+    let headers = snapshot_headers ?token ?range () in
     let code, body =
       Lwt_main.run (Cohttp_client.Cohttp_client.get_with_status url headers)
     in
@@ -554,4 +669,28 @@ module Jetstream = struct
       Lwt_main.run (Cohttp_client.Cohttp_client.get_with_status url headers)
     in
     classify_snapshot_status code body
+
+  let try_list_segments ?host ?token ?cursor () : list_segments =
+    let url = list_segments_url ?host ?cursor () in
+    let headers = snapshot_headers ?token () in
+    let code, body =
+      Lwt_main.run (Cohttp_client.Cohttp_client.get_with_status url headers)
+    in
+    parse_list_segments
+      (Yojson.Safe.from_string (classify_snapshot_status code body))
+
+  let try_plan_backfill ?host ?token ?kinds ?dids ?collections ?after_seq
+      ?before_seq () : snapshot_plan =
+    let url = plan_backfill_url ?host () in
+    let headers = snapshot_headers ?token () in
+    let data =
+      Yojson.Safe.to_string
+        (plan_snapshot_body ?kinds ?dids ?collections ?after_seq ?before_seq ())
+    in
+    let code, body =
+      Lwt_main.run
+        (Cohttp_client.Cohttp_client.post_with_status url data headers)
+    in
+    parse_snapshot_plan
+      (Yojson.Safe.from_string (classify_snapshot_status code body))
 end

--- a/src/jetstream.ml
+++ b/src/jetstream.ml
@@ -499,4 +499,59 @@ module Jetstream = struct
         | _ -> []);
       stats = parse_snapshot_stats (Yojson.Safe.Util.member "stats" json);
     }
+
+  (* Live archive HTTP. Public hosts gate this; pass [token] only if the
+     operator already has one. This library never invents a token. Live tail
+     ([subscribe]) stays unauthenticated. *)
+  exception Snapshot_gated of int * string
+  exception Snapshot_http of int * string
+
+  type snapshot_fetch =
+    [ `Plan of snapshot_plan | `Bytes of string | `Gated of int * string ]
+
+  let snapshot_headers ?token () =
+    let pairs =
+      Cohttp_client.Cohttp_client.application_json_setting_tuple
+      ::
+      (match token with
+      | Some t when t <> "" -> [ ("Authorization", "Bearer " ^ t) ]
+      | _ -> [])
+    in
+    Cohttp_client.Cohttp_client.create_headers_from_pairs pairs
+
+  let classify_snapshot_status code body =
+    if code = 401 || code = 403 then raise (Snapshot_gated (code, body))
+    else if code >= 400 then raise (Snapshot_http (code, body))
+    else body
+
+  let try_plan_snapshot ?host ?token ?kinds ?dids ?collections ?after_seq
+      ?before_seq () : snapshot_plan =
+    let url = plan_snapshot_url ?host () in
+    let headers = snapshot_headers ?token () in
+    let data =
+      Yojson.Safe.to_string
+        (plan_snapshot_body ?kinds ?dids ?collections ?after_seq ?before_seq ())
+    in
+    let code, body =
+      Lwt_main.run
+        (Cohttp_client.Cohttp_client.post_with_status url data headers)
+    in
+    parse_snapshot_plan
+      (Yojson.Safe.from_string (classify_snapshot_status code body))
+
+  let try_get_segment ?host ?token ~name () : string =
+    let url = get_segment_url ?host ~name () in
+    let headers = snapshot_headers ?token () in
+    let code, body =
+      Lwt_main.run (Cohttp_client.Cohttp_client.get_with_status url headers)
+    in
+    classify_snapshot_status code body
+
+  let try_get_block ?host ?token ~name ~index () : string =
+    let url = get_block_url ?host ~name ~index () in
+    let headers = snapshot_headers ?token () in
+    let code, body =
+      Lwt_main.run (Cohttp_client.Cohttp_client.get_with_status url headers)
+    in
+    classify_snapshot_status code body
 end

--- a/src/label.ml
+++ b/src/label.ml
@@ -382,4 +382,29 @@ module Label = struct
            ])
     in
     header ^ body
+
+  let subscribe ?(host = "bsky.network") ?cursor ?max_messages f =
+    let url = subscribe_url ~host ?cursor () in
+    Websocket.Websocket.with_connection url (fun ws ->
+        let rec loop n =
+          match max_messages with
+          | Some m when n >= m -> ()
+          | _ -> (
+              match Websocket.Websocket.recv_message ws with
+              | Websocket.Websocket.Binary payload
+              | Websocket.Websocket.Text payload ->
+                  f (decode_frame payload);
+                  loop (n + 1)
+              | Websocket.Websocket.Close _ -> ()
+              | Websocket.Websocket.Ping _ | Websocket.Websocket.Pong _ ->
+                  loop n)
+        in
+        loop 0)
+
+  let subscribe_one ?host ?cursor () : header * message =
+    let cell = ref None in
+    subscribe ?host ?cursor ~max_messages:1 (fun frame -> cell := Some frame);
+    match !cell with
+    | Some frame -> frame
+    | None -> failwith "Label.subscribe_one: no frame received"
 end

--- a/src/mst.ml
+++ b/src/mst.ml
@@ -718,6 +718,55 @@ module Mst = struct
   let invert_ops (t : tree) (ops : record_op list) : tree =
     List.fold_left invert_op t (normalize_ops ops)
 
+  let apply_op (t : tree) (op : record_op) : tree =
+    match op.action with
+    | "create" -> (
+        match op.cid with
+        | None -> fail "MST apply: create is missing cid"
+        | Some cid -> (
+            let t, prev = insert t op.path cid in
+            match prev with
+            | None -> t
+            | Some c ->
+                fail
+                  (Printf.sprintf "MST apply create: %s already present as %s"
+                     op.path (Cid.to_string c))))
+    | "update" -> (
+        match op.cid with
+        | None -> fail "MST apply: update is missing cid"
+        | Some cid -> (
+            let t, prev = insert t op.path cid in
+            match (prev, op.prev) with
+            | None, _ -> fail ("MST apply update: missing " ^ op.path)
+            | Some got, Some expected when not (Cid.equal got expected) ->
+                fail
+                  (Printf.sprintf "MST apply update: tree had %s, op.prev is %s"
+                     (Cid.to_string got) (Cid.to_string expected))
+            | Some _, _ -> t))
+    | "delete" -> (
+        let t, prev = remove t op.path in
+        match (prev, op.prev) with
+        | None, _ -> fail ("MST apply delete: missing " ^ op.path)
+        | Some got, Some expected when not (Cid.equal got expected) ->
+            fail
+              (Printf.sprintf "MST apply delete: tree had %s, op.prev is %s"
+                 (Cid.to_string got) (Cid.to_string expected))
+        | Some _, _ -> t)
+    | other -> fail ("MST apply: unknown action " ^ other)
+
+  let apply_ops (t : tree) (ops : record_op list) : tree =
+    List.fold_left apply_op t ops
+
+  let rec collect_entries (t : tree) acc =
+    List.fold_left
+      (fun acc e ->
+        match e with
+        | Value (path, cid) -> (path, cid) :: acc
+        | Child c -> collect_entries c acc)
+      acc (get_entries t)
+
+  let walk (t : tree) : (string * Cid.t) list = List.rev (collect_entries t [])
+
   let check_op (t : tree) (op : record_op) : unit =
     match op.action with
     | "create" | "update" -> (

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -278,6 +278,9 @@ module Repo = struct
     original : Yojson.Safe.t;
   }
 
+  let verify_blob_bytes ?expected (bytes : string) : Cid.Cid.t =
+    Cid.Cid.verify_blob ?expected bytes
+
   let parse_blob_ref json : blob_ref =
     let open Yojson.Safe.Util in
     let blob = match json |> member "blob" with `Null -> json | b -> b in

--- a/src/repo_sync.ml
+++ b/src/repo_sync.ml
@@ -1,0 +1,320 @@
+open Cid
+open Car
+open Dag_cbor
+open Mst
+open Firehose
+open Sync
+open Tid
+
+(** Library-shaped TAP helpers: backfill a repo CAR, walk records, apply
+    firehose ops, and re-sync when the commit chain breaks.
+
+    This is not a hosted Tap service. Spec:
+    https://atproto.com/specs/sync#record-level-synchronization
+    https://atproto.com/blog/introducing-tap *)
+module Repo_sync = struct
+  exception Error of string
+
+  let fail msg = raise (Error msg)
+
+  type status = Desynchronized | In_progress | Synchronized
+
+  type snapshot = {
+    did : string;
+    rev : string;
+    commit_cid : Cid.t;
+    data : Cid.t;
+    commit : Mst.repo_commit;
+    car : Car.t;
+    tree : Mst.tree;
+  }
+
+  type record_change =
+    | Created of { path : string; cid : Cid.t; live : bool }
+    | Updated of { path : string; cid : Cid.t; prev : Cid.t; live : bool }
+    | Deleted of { path : string; prev : Cid.t; live : bool }
+
+  type account = {
+    did : string;
+    mutable rev : string;
+    mutable data : Cid.t option;
+    mutable commit : Cid.t option;
+    mutable status : status;
+    records : (string, Cid.t) Hashtbl.t;
+    pending : Firehose.commit Queue.t;
+    collections : string list;
+  }
+
+  let starts_with s prefix =
+    let n = String.length prefix in
+    String.length s >= n && String.sub s 0 n = prefix
+
+  let path_in_scope collections path =
+    collections = []
+    || List.exists (fun c -> path = c || starts_with path (c ^ "/")) collections
+
+  let split_path path =
+    match String.index_opt path '/' with
+    | None -> (path, "")
+    | Some i ->
+        ( String.sub path 0 i,
+          String.sub path (i + 1) (String.length path - i - 1) )
+
+  let open_car (car : Car.t) : snapshot =
+    let commit_cid =
+      match Car.root car with Some c -> c | None -> fail "CAR has no root"
+    in
+    let block =
+      match Car.find_block car commit_cid with
+      | Some b -> b
+      | None -> fail "commit block missing from CAR"
+    in
+    let computed = Cid.create block.data in
+    if not (Cid.equal computed commit_cid) then
+      fail
+        (Printf.sprintf "commit CID mismatch: root %s block %s"
+           (Cid.to_string commit_cid) (Cid.to_string computed));
+    let commit = Mst.parse_repo_commit (Dag_cbor.decode block.data) in
+    if commit.version <> 3 then
+      fail (Printf.sprintf "unsupported repo commit version %d" commit.version);
+    if not (Tid.is_valid commit.rev) then
+      fail ("commit rev is not a TID: " ^ commit.rev);
+    let store = Mst.store_of_car car in
+    Mst.verify_tree ~get_block:(Mst.store_get store) commit.data;
+    let tree = Mst.tree_of_root store commit.data in
+    {
+      did = commit.did;
+      rev = commit.rev;
+      commit_cid;
+      data = commit.data;
+      commit;
+      car;
+      tree;
+    }
+
+  let open_car_bytes (bytes : string) : snapshot = open_car (Car.parse bytes)
+
+  let verify_snapshot ?(keys : string list option) (snap : snapshot) : unit =
+    Mst.verify_tree
+      ~get_block:(Mst.store_get (Mst.store_of_car snap.car))
+      snap.data;
+    match keys with
+    | None -> ()
+    | Some ks -> (
+        match Mst.verify_commit_sig ~keys:ks snap.commit with
+        | `Valid -> ()
+        | `Missing -> fail "commit is unsigned"
+        | `Invalid -> fail "commit signature is invalid"
+        | `Unsupported_curve c -> fail ("commit uses unsupported curve " ^ c))
+
+  let walk (snap : snapshot) : (string * Cid.t) list = Mst.walk snap.tree
+
+  let record_block (car : Car.t) (cid : Cid.t) : string =
+    match Car.find_block car cid with
+    | None -> fail ("record block missing " ^ Cid.to_string cid)
+    | Some b ->
+        ignore (Cid.verify_block ~expected:cid ~codec:cid.codec b.data);
+        b.data
+
+  let verify_record_proof ~(car : Car.t) ~(path : string) : Cid.t * string =
+    let snap = open_car car in
+    match Mst.get snap.tree path with
+    | None -> fail ("record path not in MST: " ^ path)
+    | Some cid -> (cid, record_block car cid)
+
+  let create_account ?(collections = []) ~did () : account =
+    if not (Syntax.Syntax.is_valid_did did) then fail ("invalid did " ^ did);
+    {
+      did;
+      rev = "";
+      data = None;
+      commit = None;
+      status = Desynchronized;
+      records = Hashtbl.create 64;
+      pending = Queue.create ();
+      collections;
+    }
+
+  let apply_record_op ~live (acct : account) (op : Mst.record_op) :
+      record_change option =
+    if not (path_in_scope acct.collections op.path) then None
+    else
+      match op.action with
+      | "create" -> (
+          match op.cid with
+          | None -> fail "create op missing cid"
+          | Some cid ->
+              Hashtbl.replace acct.records op.path cid;
+              Some (Created { path = op.path; cid; live }))
+      | "update" -> (
+          match op.cid with
+          | None -> fail "update op missing cid"
+          | Some cid -> (
+              match Hashtbl.find_opt acct.records op.path with
+              | Some prev ->
+                  Hashtbl.replace acct.records op.path cid;
+                  Some (Updated { path = op.path; cid; prev; live })
+              | None ->
+                  Hashtbl.replace acct.records op.path cid;
+                  Some (Created { path = op.path; cid; live })))
+      | "delete" -> (
+          match Hashtbl.find_opt acct.records op.path with
+          | Some prev ->
+              Hashtbl.remove acct.records op.path;
+              Some (Deleted { path = op.path; prev; live })
+          | None -> None)
+      | other -> fail ("unknown record op " ^ other)
+
+  let apply_record_ops ~live (acct : account) (ops : Mst.record_op list) :
+      record_change list =
+    List.filter_map (apply_record_op ~live acct) ops
+
+  let diff_walk ~live (acct : account) (walked : (string * Cid.t) list) :
+      record_change list =
+    let seen = Hashtbl.create (List.length walked) in
+    let events = ref [] in
+    List.iter
+      (fun (path, cid) ->
+        if path_in_scope acct.collections path then (
+          Hashtbl.add seen path ();
+          match Hashtbl.find_opt acct.records path with
+          | None ->
+              Hashtbl.replace acct.records path cid;
+              events := Created { path; cid; live } :: !events
+          | Some old when Cid.equal old cid -> ()
+          | Some old ->
+              Hashtbl.replace acct.records path cid;
+              events := Updated { path; cid; prev = old; live } :: !events))
+      walked;
+    let deletes = ref [] in
+    Hashtbl.iter
+      (fun path old ->
+        if path_in_scope acct.collections path && not (Hashtbl.mem seen path)
+        then deletes := (path, old) :: !deletes)
+      acct.records;
+    List.iter
+      (fun (path, prev) ->
+        Hashtbl.remove acct.records path;
+        events := Deleted { path; prev; live } :: !events)
+      !deletes;
+    List.rev !events
+
+  let verify_commit_object (c : Firehose.commit) : Mst.repo_commit =
+    let signed = Firehose.repo_commit_of c in
+    if c.repo <> signed.did then
+      fail (Printf.sprintf "commit.did %s != repo %s" signed.did c.repo);
+    if c.rev <> signed.rev then
+      fail (Printf.sprintf "commit.rev %s != rev %s" signed.rev c.rev);
+    signed
+
+  let verify_commit_sig ~keys (c : Firehose.commit) : unit =
+    let signed = Firehose.repo_commit_of c in
+    match Mst.verify_commit_sig ~keys signed with
+    | `Valid -> ()
+    | `Missing -> fail "firehose commit is unsigned"
+    | `Invalid -> fail "firehose commit signature is invalid"
+    | `Unsupported_curve curve ->
+        fail ("firehose commit uses unsupported curve " ^ curve)
+
+  let apply_commit_tree (prev : snapshot) (c : Firehose.commit) : snapshot =
+    if prev.did <> c.repo then
+      fail
+        (Printf.sprintf "apply_commit_tree: snapshot %s != repo %s" prev.did
+           c.repo);
+    let signed = verify_commit_object c in
+    Firehose.verify_commit c;
+    (match c.prev_data with
+    | Some expected when not (Cid.equal expected prev.data) ->
+        fail "apply_commit_tree: prevData does not match local MST root"
+    | _ -> ());
+    let tree = Mst.apply_ops prev.tree (Firehose.record_ops c.ops) in
+    let root = Mst.root_cid tree in
+    if not (Cid.equal root signed.data) then
+      fail
+        (Printf.sprintf "applied MST root %s != commit.data %s"
+           (Cid.to_string root)
+           (Cid.to_string signed.data));
+    {
+      did = signed.did;
+      rev = signed.rev;
+      commit_cid = c.commit;
+      data = signed.data;
+      commit = signed;
+      car = c.blocks;
+      tree;
+    }
+
+  let process_commit ?keys ?(live = true) (acct : account) (c : Firehose.commit)
+      : record_change list =
+    if c.repo <> acct.did then
+      fail (Printf.sprintf "commit repo %s != account %s" c.repo acct.did);
+    match acct.status with
+    | Desynchronized -> []
+    | In_progress ->
+        Queue.add c acct.pending;
+        []
+    | Synchronized ->
+        if acct.rev <> "" && String.compare c.rev acct.rev <= 0 then []
+        else (
+          (match keys with
+          | Some ks -> verify_commit_sig ~keys:ks c
+          | None -> ());
+          let signed = verify_commit_object c in
+          Firehose.verify_commit c;
+          match (acct.data, c.prev_data) with
+          | Some have, Some want when not (Cid.equal have want) ->
+              acct.status <- Desynchronized;
+              []
+          | _ ->
+              let events =
+                apply_record_ops ~live acct (Firehose.record_ops c.ops)
+              in
+              acct.rev <- c.rev;
+              acct.data <- Some signed.data;
+              acct.commit <- Some c.commit;
+              events)
+
+  let process_sync (acct : account) (s : Firehose.sync) : record_change list =
+    if s.did <> acct.did then
+      fail (Printf.sprintf "sync did %s != account %s" s.did acct.did);
+    (match acct.status with
+    | Synchronized when acct.rev = s.rev -> ()
+    | In_progress -> ()
+    | _ -> acct.status <- Desynchronized);
+    []
+
+  let process_message ?keys (acct : account) (msg : Firehose.message) :
+      record_change list =
+    match msg with
+    | `Commit c -> process_commit ?keys acct c
+    | `Sync s -> process_sync acct s
+    | `Identity _ | `Account _ | `Info _ | `Error _ | `Unknown _ -> []
+
+  let resync_from_car ?keys ?(live = false) (acct : account) (car : Car.t) :
+      record_change list =
+    acct.status <- In_progress;
+    let snap = open_car car in
+    if snap.did <> acct.did then
+      fail (Printf.sprintf "CAR did %s != account %s" snap.did acct.did);
+    verify_snapshot ?keys snap;
+    let events = diff_walk ~live acct (walk snap) in
+    acct.rev <- snap.rev;
+    acct.data <- Some snap.data;
+    acct.commit <- Some snap.commit_cid;
+    let pending = Queue.fold (fun acc c -> c :: acc) [] acct.pending in
+    Queue.clear acct.pending;
+    acct.status <- Synchronized;
+    let rest =
+      List.fold_left
+        (fun acc c -> acc @ process_commit ?keys ~live:true acct c)
+        [] (List.rev pending)
+    in
+    events @ rest
+
+  let fetch_repo ?host ?session (did : string) : snapshot =
+    open_car_bytes (Sync.get_repo ?host ?session did)
+
+  let backfill ?host ?session ?keys (acct : account) : record_change list =
+    let snap = fetch_repo ?host ?session acct.did in
+    resync_from_car ?keys ~live:false acct snap.car
+end

--- a/src/repo_sync.ml
+++ b/src/repo_sync.ml
@@ -314,6 +314,11 @@ module Repo_sync = struct
   let fetch_repo ?host ?session (did : string) : snapshot =
     open_car_bytes (Sync.get_repo ?host ?session did)
 
+  let fetch_record_proof ?host ?session ?commit ~did ~collection ~rkey () :
+      Cid.t * string =
+    let car = Sync.get_record_car ?host ?session ?commit did collection rkey in
+    verify_record_proof ~car ~path:(Sync.record_path ~collection ~rkey)
+
   let backfill ?host ?session ?keys (acct : account) : record_change list =
     let snap = fetch_repo ?host ?session acct.did in
     resync_from_car ?keys ~live:false acct snap.car

--- a/src/sync.ml
+++ b/src/sync.ml
@@ -202,6 +202,12 @@ module Sync = struct
       (("did", did) :: ("collection", collection) :: ("rkey", rkey)
       :: optional_pairs [ ("commit", commit) ])
 
+  let get_record_car ?host ?session ?commit (did : string) (collection : string)
+      (rkey : string) : Car.t =
+    Car.parse (get_record ?host ?session ?commit did collection rkey)
+
+  let record_path ~collection ~rkey = collection ^ "/" ^ rkey
+
   let list_blobs ?host ?session ?since ?cursor ?limit (did : string) :
       list_blobs =
     request_json ?host ?session

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -131,6 +131,50 @@ module Syntax = struct
 
   let ensure_did s = if not (is_valid_did s) then fail ("invalid DID " ^ s)
 
+  (* DID + optional service/key fragment (service-auth aud, atproto-proxy).
+     The fragment is not part of DID syntax; split it before validating. *)
+  type did_ref = { did : string; fragment : string option }
+
+  let split_did_ref (input : string) : string * string option =
+    match String.index_opt input '#' with
+    | None -> (input, None)
+    | Some i ->
+        ( String.sub input 0 i,
+          Some (String.sub input (i + 1) (String.length input - i - 1)) )
+
+  let is_valid_did_fragment (frag : string) : bool =
+    let n = String.length frag in
+    n > 0
+    &&
+    let rec loop i =
+      if i >= n then true
+      else
+        match frag.[i] with
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' -> loop (i + 1)
+        | _ -> false
+    in
+    loop 0
+
+  let is_valid_did_ref (input : string) : bool =
+    let did, frag = split_did_ref input in
+    is_valid_did did
+    && match frag with None -> true | Some f -> is_valid_did_fragment f
+
+  let parse_did_ref (input : string) : did_ref =
+    let did, frag = split_did_ref input in
+    ensure_did did;
+    (match frag with
+    | Some f ->
+        if not (is_valid_did_fragment f) then fail ("invalid DID fragment " ^ f)
+    | None -> ());
+    { did; fragment = frag }
+
+  let did_ref_to_string (r : did_ref) : string =
+    match r.fragment with None -> r.did | Some f -> r.did ^ "#" ^ f
+
+  let ensure_did_ref s =
+    if not (is_valid_did_ref s) then fail ("invalid DID reference " ^ s)
+
   let did_method (input : string) : string option =
     if not (is_valid_did input) then None
     else

--- a/src/xrpc.ml
+++ b/src/xrpc.ml
@@ -1,4 +1,7 @@
 open Base64url
+open Hash
+
+let ensure_rng = lazy (Mirage_crypto_rng_unix.use_default ())
 
 (** XRPC protocol headers and service-auth JWT claims.
     https://atproto.com/specs/xrpc
@@ -142,59 +145,93 @@ module Xrpc = struct
     ("atproto-repo-rev", rev)
 
   (* ---- Service-auth JWT (com.atproto.server.getServiceAuth) ----------- *)
+  (* https://atproto.com/specs/xrpc#inter-service-authentication-jwt *)
 
   type service_auth = {
+    alg : string;
+    typ : string;
+    kid : string;
     iss : string;
     aud : string;
+    aud_did : string;
+    aud_service : string option;
     exp : int64 option;
+    iat : int64 option;
     lxm : string option;
+    jti : string option;
     raw : string;
   }
+
+  let default_kid = "#atproto"
+  let default_typ = "JWT"
+  let recommended_lifetime = 60L
 
   let split_jwt jwt =
     match String.split_on_char '.' jwt with
     | [ h; p; s ] -> (h, p, s)
     | _ -> fail "service-auth JWT must have three base64url parts"
 
+  let json_int64 json field =
+    match Yojson.Safe.Util.member field json with
+    | `Int n -> Some (Int64.of_int n)
+    | `Intlit s -> Some (Int64.of_string s)
+    | _ -> None
+
+  let json_string json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
+  let normalize_kid kid =
+    if kid = "" then default_kid else if kid.[0] = '#' then kid else "#" ^ kid
+
   let parse_service_auth (jwt : string) : service_auth =
-    let _, payload, _ = split_jwt jwt in
-    let json = Yojson.Safe.from_string (Base64url.decode payload) in
-    let open Yojson.Safe.Util in
+    let header_b64, payload_b64, _ = split_jwt jwt in
+    let header = Yojson.Safe.from_string (Base64url.decode header_b64) in
+    let json = Yojson.Safe.from_string (Base64url.decode payload_b64) in
     let iss =
-      match json |> member "iss" with
-      | `String s -> s
-      | _ -> fail "service-auth JWT missing iss"
+      match json_string json "iss" with
+      | Some s -> s
+      | None -> fail "service-auth JWT missing iss"
     in
     let aud =
-      match json |> member "aud" with
-      | `String s -> s
-      | _ -> fail "service-auth JWT missing aud"
+      match json_string json "aud" with
+      | Some s -> s
+      | None -> fail "service-auth JWT missing aud"
     in
     if not (Syntax.Syntax.is_valid_did iss) then
       fail "service-auth iss must be a DID";
-    if not (Syntax.Syntax.is_valid_did aud) then
-      fail "service-auth aud must be a DID";
+    if not (Syntax.Syntax.is_valid_did_ref aud) then
+      fail "service-auth aud must be a DID (optional #service fragment)";
+    let aud_ref = Syntax.Syntax.parse_did_ref aud in
+    let lxm =
+      match json_string json "lxm" with
+      | Some s ->
+          if not (Syntax.Syntax.is_valid_nsid s) then
+            fail "service-auth lxm must be an NSID";
+          Some s
+      | None -> None
+    in
     {
+      alg = Option.value ~default:"" (json_string header "alg");
+      typ = Option.value ~default:default_typ (json_string header "typ");
+      kid =
+        normalize_kid
+          (Option.value ~default:default_kid (json_string header "kid"));
       iss;
       aud;
-      exp =
-        (match json |> member "exp" with
-        | `Int n -> Some (Int64.of_int n)
-        | `Intlit s -> Some (Int64.of_string s)
-        | _ -> None);
-      lxm =
-        (match json |> member "lxm" with
-        | `String s ->
-            if not (Syntax.Syntax.is_valid_nsid s) then
-              fail "service-auth lxm must be an NSID";
-            Some s
-        | _ -> None);
+      aud_did = aud_ref.did;
+      aud_service = aud_ref.fragment;
+      exp = json_int64 json "exp";
+      iat = json_int64 json "iat";
+      lxm;
+      jti = json_string json "jti";
       raw = jwt;
     }
 
   let service_auth_body ~aud ?lxm ?exp () : Yojson.Safe.t =
-    if not (Syntax.Syntax.is_valid_did aud) then
-      fail "getServiceAuth aud must be a DID";
+    if not (Syntax.Syntax.is_valid_did_ref aud) then
+      fail "getServiceAuth aud must be a DID (optional #service fragment)";
     (match lxm with
     | Some n ->
         if not (Syntax.Syntax.is_valid_nsid n) then
@@ -209,4 +246,225 @@ module Xrpc = struct
       | None -> []
     in
     `Assoc fields
+
+  let service_auth_header (jwt : string) : string * string =
+    ("Authorization", "Bearer " ^ jwt)
+
+  let random_jti () : string =
+    Lazy.force ensure_rng;
+    let buf = Bytes.create 16 in
+    for i = 0 to 15 do
+      Bytes.set buf i (Char.chr (Random.int 256))
+    done;
+    Hash.hex_encode (Bytes.to_string buf)
+
+  let b64url_json json = Base64url.encode (Yojson.Safe.to_string json)
+
+  let unsigned_jwt ~alg ~typ ~kid ~iss ~aud ~exp ~iat ?lxm ~jti () : string =
+    let header =
+      `Assoc
+        [ ("alg", `String alg); ("typ", `String typ); ("kid", `String kid) ]
+    in
+    let payload =
+      `Assoc
+        ([
+           ("iss", `String iss);
+           ("aud", `String aud);
+           ("exp", `Intlit (Int64.to_string exp));
+           ("iat", `Intlit (Int64.to_string iat));
+           ("jti", `String jti);
+         ]
+        @ match lxm with Some n -> [ ("lxm", `String n) ] | None -> [])
+    in
+    b64url_json header ^ "." ^ b64url_json payload
+
+  let finish_jwt unsigned signature =
+    unsigned ^ "." ^ Base64url.encode signature
+
+  let sign_service_jwt_p256 ~(priv : Mirage_crypto_ec.P256.Dsa.priv) ~iss ~aud
+      ?lxm ?exp ?iat ?jti ?(kid = default_kid) ?(now = Unix.gettimeofday ()) ()
+      : string =
+    if not (Syntax.Syntax.is_valid_did iss) then
+      fail "service-auth iss must be a DID";
+    if not (Syntax.Syntax.is_valid_did_ref aud) then
+      fail "service-auth aud must be a DID (optional #service fragment)";
+    (match lxm with
+    | Some n ->
+        if not (Syntax.Syntax.is_valid_nsid n) then
+          fail "service-auth lxm must be an NSID"
+    | None -> ());
+    Lazy.force ensure_rng;
+    let iat = Option.value iat ~default:(Int64.of_float now) in
+    let exp = Option.value exp ~default:(Int64.add iat recommended_lifetime) in
+    let jti = Option.value jti ~default:(random_jti ()) in
+    let unsigned =
+      unsigned_jwt ~alg:"ES256" ~typ:default_typ ~kid:(normalize_kid kid) ~iss
+        ~aud ~exp ~iat ?lxm ~jti ()
+    in
+    let digest = Hash.sha256 unsigned in
+    let r, s = Mirage_crypto_ec.P256.Dsa.sign ~key:priv digest in
+    let s =
+      if String.compare s Did_plc.Did_plc.p256_n_half > 0 then
+        Did_plc.Did_plc.sub_be Did_plc.Did_plc.p256_n s
+      else s
+    in
+    finish_jwt unsigned (r ^ s)
+
+  let sign_service_jwt_k256 ~(priv : K256.K256.priv) ~iss ~aud ?lxm ?exp ?iat
+      ?jti ?(kid = default_kid) ?(now = Unix.gettimeofday ()) () : string =
+    if not (Syntax.Syntax.is_valid_did iss) then
+      fail "service-auth iss must be a DID";
+    if not (Syntax.Syntax.is_valid_did_ref aud) then
+      fail "service-auth aud must be a DID (optional #service fragment)";
+    (match lxm with
+    | Some n ->
+        if not (Syntax.Syntax.is_valid_nsid n) then
+          fail "service-auth lxm must be an NSID"
+    | None -> ());
+    let iat = Option.value iat ~default:(Int64.of_float now) in
+    let exp = Option.value exp ~default:(Int64.add iat recommended_lifetime) in
+    let jti = Option.value jti ~default:(random_jti ()) in
+    let unsigned =
+      unsigned_jwt ~alg:"ES256K" ~typ:default_typ ~kid:(normalize_kid kid) ~iss
+        ~aud ~exp ~iat ?lxm ~jti ()
+    in
+    let digest = Hash.sha256 unsigned in
+    let r, s = K256.K256.sign ~key:priv digest in
+    finish_jwt unsigned (r ^ s)
+
+  type sig_status =
+    [ `Valid | `Invalid | `Unsupported_curve of string | `Missing ]
+
+  let verify_service_sig ~(keys : string list) (jwt : string) : sig_status =
+    let header_b64, payload_b64, sig_b64 = split_jwt jwt in
+    if sig_b64 = "" || sig_b64 = "sig" then `Missing
+    else
+      let raw =
+        try Base64url.decode sig_b64
+        with _ -> fail "service-auth signature is not base64url"
+      in
+      if String.length raw <> 64 then `Invalid
+      else
+        let r = String.sub raw 0 32 in
+        let s = String.sub raw 32 32 in
+        let digest = Hash.sha256 (header_b64 ^ "." ^ payload_b64) in
+        let parsed =
+          List.filter_map
+            (fun k -> try Some (Did_key.Did_key.of_string k) with _ -> None)
+            keys
+        in
+        let rec try_keys = function
+          | [] -> (
+              let other =
+                List.find_map
+                  (fun k ->
+                    match k.Did_key.Did_key.curve with
+                    | Did_key.Did_key.Other n -> Some (Printf.sprintf "0x%x" n)
+                    | _ -> None)
+                  parsed
+              in
+              match other with
+              | Some c -> `Unsupported_curve c
+              | None -> `Invalid)
+          | k :: rest -> (
+              match k.Did_key.Did_key.curve with
+              | Did_key.Did_key.P256 -> (
+                  match Did_key.Did_key.p256_pub k with
+                  | Some pub ->
+                      if
+                        Did_plc.Did_plc.is_low_s s
+                        && Mirage_crypto_ec.P256.Dsa.verify ~key:pub (r, s)
+                             digest
+                      then `Valid
+                      else try_keys rest
+                  | None -> try_keys rest)
+              | Did_key.Did_key.K256 -> (
+                  match Did_key.Did_key.k256_pub k with
+                  | Some pub ->
+                      if
+                        K256.K256.is_low_s s
+                        && K256.K256.verify ~key:pub (r, s) digest
+                      then `Valid
+                      else try_keys rest
+                  | None -> try_keys rest)
+              | Did_key.Did_key.Other _ -> try_keys rest)
+        in
+        try_keys parsed
+
+  let audience_matches ~(expected : string) (claims : service_auth) : bool =
+    if claims.aud = expected then true
+    else
+      let want = Syntax.Syntax.parse_did_ref expected in
+      claims.aud_did = want.did
+      &&
+      match want.fragment with
+      | None ->
+          (* expected bare DID: accept legacy bare aud only, not any service *)
+          claims.aud_service = None
+      | Some frag -> claims.aud_service = Some frag
+
+  let is_expired ?(now = Unix.gettimeofday ()) ?(leeway = 5L)
+      (claims : service_auth) : bool =
+    match claims.exp with
+    | None -> true
+    | Some exp ->
+        let now_i = Int64.of_float now in
+        Int64.compare now_i (Int64.add exp leeway) > 0
+
+  let verify_service_jwt ~keys ?aud ?lxm ?now ?(require_lxm = false)
+      ?(require_jti = false) (jwt : string) : service_auth =
+    let claims = parse_service_auth jwt in
+    if claims.typ <> default_typ && ascii_lower claims.typ <> "jwt" then
+      fail ("service-auth typ is not JWT: " ^ claims.typ);
+    (match verify_service_sig ~keys jwt with
+    | `Valid -> ()
+    | `Missing -> fail "service-auth JWT missing signature"
+    | `Invalid -> fail "service-auth JWT signature is invalid"
+    | `Unsupported_curve c ->
+        fail ("service-auth JWT uses unsupported curve " ^ c));
+    (match aud with
+    | Some expected ->
+        if not (audience_matches ~expected claims) then
+          fail
+            (Printf.sprintf "service-auth aud %s does not match %s" claims.aud
+               expected)
+    | None -> ());
+    (match (lxm, claims.lxm) with
+    | Some expected, Some got when got = expected -> ()
+    | Some expected, Some got ->
+        fail
+          (Printf.sprintf "service-auth lxm %s does not match %s" got expected)
+    | Some expected, None ->
+        fail ("service-auth JWT missing lxm (expected " ^ expected ^ ")")
+    | None, None when require_lxm -> fail "service-auth JWT missing lxm"
+    | None, _ -> ());
+    if require_jti && claims.jti = None then fail "service-auth JWT missing jti";
+    if is_expired ?now claims then fail "service-auth JWT is expired";
+    claims
+
+  type jti_cache = {
+    seen : (string, int64) Hashtbl.t;
+    order : string Queue.t;
+    cap : int;
+  }
+
+  let create_jti_cache ?(cap = 4096) () : jti_cache =
+    { seen = Hashtbl.create cap; order = Queue.create (); cap }
+
+  let remember_jti ?(now = Unix.gettimeofday ()) (c : jti_cache)
+      (claims : service_auth) : bool =
+    match claims.jti with
+    | None -> false
+    | Some jti ->
+        let exp = Option.value claims.exp ~default:(Int64.of_float now) in
+        if Hashtbl.mem c.seen jti then true
+        else (
+          Hashtbl.add c.seen jti exp;
+          Queue.add jti c.order;
+          (if Queue.length c.order > c.cap then
+             let old = Queue.take c.order in
+             Hashtbl.remove c.seen old);
+          false)
+
+  let jti_seen (c : jti_cache) (jti : string) : bool = Hashtbl.mem c.seen jti
 end

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
   test_ozone
   test_request
   test_repo
+  test_repo_sync
   test_response
   test_server
   test_session
@@ -112,6 +113,7 @@
   test_ozone
   test_request
   test_repo
+  test_repo_sync
   test_response
   test_server
   test_session

--- a/test/test_cid.ml
+++ b/test/test_cid.ml
@@ -49,6 +49,21 @@ let test_create_sha256 _ =
   OUnit2.assert_bool "different bytes must not collide"
     (not (Cid.equal cid (Cid.create ~codec:Cid.Raw "hello!")))
 
+let test_blob_cid _ =
+  let bytes = "video-bytes" in
+  let cid = Cid.of_blob bytes in
+  OUnit2.assert_equal Cid.Raw cid.codec;
+  OUnit2.assert_bool "verify_blob accepts matching CID"
+    (Cid.equal cid (Cid.verify_blob ~expected:cid bytes));
+  OUnit2.assert_bool "verify_blob rejects wrong CID"
+    (try
+       ignore (Cid.verify_blob ~expected:cid (bytes ^ "!"));
+       false
+     with Failure _ -> true);
+  let dag = Cid.create ~codec:Cid.Dag_cbor "{\"text\":\"hi\"}" in
+  OUnit2.assert_bool "verify_block dag-cbor"
+    (Cid.equal dag (Cid.verify_block ~expected:dag "{\"text\":\"hi\"}"))
+
 let suite =
   "cid"
   >::: [
@@ -59,6 +74,7 @@ let suite =
          "test_bytes_roundtrip" >:: test_bytes_roundtrip;
          "test_base32_roundtrip" >:: test_base32_roundtrip;
          "test_create_sha256" >:: test_create_sha256;
+         "test_blob_cid" >:: test_blob_cid;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_did_plc.ml
+++ b/test/test_did_plc.ml
@@ -49,7 +49,13 @@ let test_parse_document _ =
   OUnit2.assert_equal (Some "https://example2.com") (Did_plc.pds_endpoint doc);
   match Did_plc.signing_key doc with
   | None -> OUnit2.assert_failure "missing #atproto key"
-  | Some key -> OUnit2.assert_equal ~printer:(fun x -> x) "Multikey" key.type_
+  | Some key ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "Multikey" key.type_;
+      let keys = Did_plc.atproto_signing_keys doc in
+      OUnit2.assert_equal 1 (List.length keys);
+      OUnit2.assert_bool "did:key prefix"
+        (String.length (List.hd keys) > 8
+        && String.sub (List.hd keys) 0 8 = "did:key:")
 
 let test_directory_url _ =
   OUnit2.assert_equal

--- a/test/test_firehose.ml
+++ b/test/test_firehose.ml
@@ -254,6 +254,20 @@ let test_verify_live_shaped_cbor_frame _ =
         | None -> false)
   | _ -> OUnit2.assert_failure "expected #commit frame"
 
+let test_apply_commit_matches_invert _ =
+  let commit = synthetic_inverted_commit () in
+  let signed = Firehose.verify_commit_object commit in
+  let store = Mst.store_of_car commit.blocks in
+  let current = Mst.tree_of_root store signed.data in
+  let prev_root = Firehose.invert_commit commit in
+  (* rebuild the previous tree by inverting, then apply forward *)
+  let prev_tree = Mst.invert_ops current (Firehose.record_ops commit.ops) in
+  OUnit2.assert_bool "invert root"
+    (Cid.equal (Mst.root_cid prev_tree) prev_root);
+  let applied = Firehose.apply_commit ~prev_tree commit in
+  OUnit2.assert_bool "apply returns to commit.data"
+    (Cid.equal (Mst.root_cid applied) signed.data)
+
 let test_invert_rejects_wrong_op _ =
   let commit = synthetic_inverted_commit () in
   let bad =
@@ -427,6 +441,7 @@ let suite =
          "test_decode_update_and_delete_ops"
          >:: test_decode_update_and_delete_ops;
          "test_invert_synthetic_commit" >:: test_invert_synthetic_commit;
+         "test_apply_commit_matches_invert" >:: test_apply_commit_matches_invert;
          "test_verify_live_shaped_cbor_frame"
          >:: test_verify_live_shaped_cbor_frame;
          "test_invert_rejects_wrong_op" >:: test_invert_rejects_wrong_op;

--- a/test/test_firehose.ml
+++ b/test/test_firehose.ml
@@ -254,6 +254,22 @@ let test_verify_live_shaped_cbor_frame _ =
         | None -> false)
   | _ -> OUnit2.assert_failure "expected #commit frame"
 
+let test_verify_sync_commit_object _ =
+  let commit = synthetic_inverted_commit () in
+  let sync =
+    {
+      Firehose.seq = 9L;
+      did = commit.repo;
+      blocks = commit.blocks;
+      raw_blocks = commit.raw_blocks;
+      rev = commit.rev;
+      time = commit.time;
+    }
+  in
+  let signed = Firehose.verify_sync sync in
+  OUnit2.assert_equal ~printer:(fun x -> x) commit.repo signed.did;
+  OUnit2.assert_equal ~printer:(fun x -> x) commit.rev signed.rev
+
 let test_apply_commit_matches_invert _ =
   let commit = synthetic_inverted_commit () in
   let signed = Firehose.verify_commit_object commit in
@@ -442,6 +458,7 @@ let suite =
          >:: test_decode_update_and_delete_ops;
          "test_invert_synthetic_commit" >:: test_invert_synthetic_commit;
          "test_apply_commit_matches_invert" >:: test_apply_commit_matches_invert;
+         "test_verify_sync_commit_object" >:: test_verify_sync_commit_object;
          "test_verify_live_shaped_cbor_frame"
          >:: test_verify_live_shaped_cbor_frame;
          "test_invert_rejects_wrong_op" >:: test_invert_rejects_wrong_op;

--- a/test/test_jetstream.ml
+++ b/test/test_jetstream.ml
@@ -251,6 +251,107 @@ let test_plan_snapshot _ =
      in
      contains 0)
 
+let test_replay_planner _ =
+  let page =
+    Jetstream.parse_snapshot_plan
+      (`Assoc
+        [
+          ("plannedThroughSeq", `Int 10);
+          ("sealedTipSeq", `Int 20);
+          ( "segments",
+            `List
+              [
+                `Assoc
+                  [
+                    ("name", `String "seg_0000000000.jss");
+                    ("index", `Int 0);
+                    ("checksum", `String "0c9577a8002d2b24");
+                    ("minSeq", `Int 1);
+                    ("maxSeq", `Int 10);
+                    ("mode", `String "blocks");
+                    ( "blocks",
+                      `List [ `Assoc [ ("first", `Int 7); ("last", `Int 9) ] ]
+                    );
+                  ];
+              ] );
+          ("stats", `Assoc [ ("entries", `Int 1) ]);
+        ])
+  in
+  OUnit2.assert_bool "needs next page" (Jetstream.plan_needs_next page);
+  (match Jetstream.next_plan_window page with
+  | Some (after, before) ->
+      OUnit2.assert_equal ~printer:Int64.to_string 10L after;
+      OUnit2.assert_equal ~printer:Int64.to_string 20L before
+  | None -> OUnit2.assert_failure "expected next window");
+  (match Jetstream.download_jobs page with
+  | [ Jetstream.Blocks { name; ranges; _ } ] ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "seg_0000000000.jss" name;
+      OUnit2.assert_equal 7 (List.hd ranges).first
+  | _ -> OUnit2.assert_failure "expected block-range job");
+  let done_ = { page with planned_through_seq = 20L } in
+  OUnit2.assert_bool "complete" (not (Jetstream.plan_needs_next done_));
+  OUnit2.assert_equal None (Jetstream.next_plan_window done_);
+  let url = Jetstream.subscribe_url_after_plan done_ in
+  OUnit2.assert_bool "cutover cursor"
+    (let needle = "cursor=20" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  let h, v = Jetstream.range_header ~first:1024 () in
+  OUnit2.assert_equal "Range" h;
+  OUnit2.assert_equal ~printer:(fun x -> x) "bytes=1024-" v;
+  let listed =
+    Jetstream.parse_list_segments
+      (`Assoc
+        [
+          ( "segments",
+            `List
+              [
+                `Assoc
+                  [
+                    ("name", `String "seg_0000000000.jss");
+                    ("index", `Int 0);
+                    ("sizeBytes", `Int 193462065);
+                    ("checksum", `String "0c9577a8002d2b24");
+                    ("eventCount", `Int 2569479);
+                    ("minSeq", `Int 1);
+                    ("maxSeq", `Int 2569835);
+                    ("minWitnessedAt", `Intlit "1785262575375952");
+                    ("maxWitnessedAt", `Intlit "1785262678113580");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length listed.segments);
+  OUnit2.assert_equal (Some 2569479) (List.hd listed.segments).event_count;
+  OUnit2.assert_bool "backfill URL"
+    (let u = Jetstream.plan_backfill_url () in
+     let needle = "planBackfill" in
+     let rec contains i =
+       i + String.length needle <= String.length u
+       && (String.sub u i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0);
+  OUnit2.assert_bool "delete folds"
+    (Jetstream.fold_removes_records
+       (Jetstream.parse_event
+          (`Assoc
+            [
+              ("kind", `String "commit");
+              ("did", `String "did:plc:7e6kocyzb77xkncplrkoojej");
+              ("time_us", `Int 1);
+              ( "commit",
+                `Assoc
+                  [
+                    ("operation", `String "delete");
+                    ("collection", `String "app.bsky.feed.post");
+                    ("rkey", `String "3jzfcijpj2z2a");
+                    ("rev", `String "3jzfcijpj2z2a");
+                  ] );
+            ])))
+
 let test_snapshot_gated_live _ =
   let old =
     Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
@@ -313,6 +414,7 @@ let suite =
          "test_dedupe" >:: test_dedupe;
          "test_reconnect_cursor" >:: test_reconnect_cursor;
          "test_plan_snapshot" >:: test_plan_snapshot;
+         "test_replay_planner" >:: test_replay_planner;
          "test_snapshot_gated_live" >:: test_snapshot_gated_live;
          "test_subscribe_live" >:: test_subscribe_live;
        ]

--- a/test/test_jetstream.ml
+++ b/test/test_jetstream.ml
@@ -251,6 +251,27 @@ let test_plan_snapshot _ =
      in
      contains 0)
 
+let test_snapshot_gated_live _ =
+  let old =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
+  in
+  ignore (Unix.alarm 20);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm old)
+    (fun () ->
+      try
+        let _ = Jetstream.try_plan_snapshot () in
+        OUnit2.assert_bool "ungated archive returned a plan" true
+      with
+      | Jetstream.Snapshot_gated (code, _) ->
+          OUnit2.assert_bool "gated without inventing a token"
+            (code = 401 || code = 403)
+      | Jetstream.Snapshot_http (code, _) ->
+          skip_if true (Printf.sprintf "planSnapshot HTTP %d" code)
+      | exn -> skip_if true ("planSnapshot skipped: " ^ Printexc.to_string exn))
+
 let test_subscribe_live _ =
   let old =
     Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
@@ -292,6 +313,7 @@ let suite =
          "test_dedupe" >:: test_dedupe;
          "test_reconnect_cursor" >:: test_reconnect_cursor;
          "test_plan_snapshot" >:: test_plan_snapshot;
+         "test_snapshot_gated_live" >:: test_snapshot_gated_live;
          "test_subscribe_live" >:: test_subscribe_live;
        ]
 

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -115,6 +115,24 @@ let test_subscribe_url _ =
     "wss://mod.example.com/xrpc/com.atproto.label.subscribeLabels?cursor=0"
     (Label.subscribe_url ~host:"mod.example.com" ~cursor:0L ())
 
+let test_subscribe_one_live _ =
+  let old =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
+  in
+  ignore (Unix.alarm 15);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm old)
+    (fun () ->
+      try
+        let _, msg = Label.subscribe_one () in
+        match msg with
+        | `Labels _ | `Info _ | `Error _ | `Unknown _ ->
+            OUnit2.assert_bool "decoded subscribeLabels" true
+      with exn ->
+        skip_if true ("subscribeLabels skipped: " ^ Printexc.to_string exn))
+
 let test_json_sig_roundtrip _ =
   let json =
     `Assoc
@@ -146,6 +164,7 @@ let suite =
          "test_label_sign_verify_k256" >:: test_label_sign_verify_k256;
          "test_subscribe_labels_frame" >:: test_subscribe_labels_frame;
          "test_subscribe_url" >:: test_subscribe_url;
+         "test_subscribe_one_live" >:: test_subscribe_one_live;
          "test_json_sig_roundtrip" >:: test_json_sig_roundtrip;
        ]
 

--- a/test/test_mst.ml
+++ b/test/test_mst.ml
@@ -248,6 +248,84 @@ let test_invert_create_update_delete _ =
   | Some c -> OUnit2.assert_bool "delete inverted to va" (Cid.equal c va)
   | None -> OUnit2.assert_failure "delete invert did not restore key"
 
+let test_apply_create_update_delete _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t0 = Mst.empty_tree store in
+  let va = value_cid "rec-a"
+  and vb = value_cid "rec-b"
+  and vc = value_cid "rec-c" in
+  let t, _ = Mst.insert t0 "app.bsky.feed.post/aaa" va in
+  let before = Mst.root_cid t in
+  let created =
+    Mst.apply_ops t
+      [
+        {
+          Mst.action = "create";
+          path = "app.bsky.feed.post/bbb";
+          cid = Some vb;
+          prev = None;
+        };
+      ]
+  in
+  (match Mst.get created "app.bsky.feed.post/bbb" with
+  | Some c -> OUnit2.assert_bool "create applied" (Cid.equal c vb)
+  | None -> OUnit2.assert_failure "create did not insert");
+  let inverted =
+    Mst.invert_ops created
+      [
+        {
+          Mst.action = "create";
+          path = "app.bsky.feed.post/bbb";
+          cid = Some vb;
+          prev = None;
+        };
+      ]
+  in
+  OUnit2.assert_bool "apply then invert"
+    (Cid.equal (Mst.root_cid inverted) before);
+  let updated =
+    Mst.apply_op created
+      {
+        Mst.action = "update";
+        path = "app.bsky.feed.post/bbb";
+        cid = Some vc;
+        prev = Some vb;
+      }
+  in
+  (match Mst.get updated "app.bsky.feed.post/bbb" with
+  | Some c -> OUnit2.assert_bool "update applied" (Cid.equal c vc)
+  | None -> OUnit2.assert_failure "update dropped key");
+  let deleted =
+    Mst.apply_op updated
+      {
+        Mst.action = "delete";
+        path = "app.bsky.feed.post/aaa";
+        cid = None;
+        prev = Some va;
+      }
+  in
+  OUnit2.assert_equal None (Mst.get deleted "app.bsky.feed.post/aaa");
+  let walked = Mst.walk deleted in
+  OUnit2.assert_equal [ "app.bsky.feed.post/bbb" ] (List.map fst walked)
+
+let test_apply_create_conflict _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = value_cid "rec-a" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  OUnit2.assert_bool "duplicate create accepted"
+    (try
+       ignore
+         (Mst.apply_op t
+            {
+              Mst.action = "create";
+              path = "app.bsky.feed.post/aaa";
+              cid = Some va;
+              prev = None;
+            });
+       false
+     with Mst.Verify_error _ -> true)
+
 let test_invert_create_mismatch _ =
   let store = Mst.store_of_get (fun _ -> None) in
   let t = Mst.empty_tree store in
@@ -383,6 +461,8 @@ let suite =
          "test_insert_lookup_remove" >:: test_insert_lookup_remove;
          "test_insert_replace_returns_prev" >:: test_insert_replace_returns_prev;
          "test_invert_create_update_delete" >:: test_invert_create_update_delete;
+         "test_apply_create_update_delete" >:: test_apply_create_update_delete;
+         "test_apply_create_conflict" >:: test_apply_create_conflict;
          "test_invert_create_mismatch" >:: test_invert_create_mismatch;
          "test_sign_verify_commit_p256" >:: test_sign_verify_commit_p256;
          "test_sign_verify_commit_k256" >:: test_sign_verify_commit_k256;

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -1,0 +1,272 @@
+open OUnit2
+open Atproto.Cid
+open Atproto.Car
+open Atproto.Mst
+open Atproto.Firehose
+open Atproto.Repo_sync
+open Atproto.Did_key
+open Atproto.Hash
+
+let did = "did:plc:7iza6de2dwap2sbkpav7c6c6"
+
+let car_of_tree ~did ~rev ?(records = []) tree =
+  let mst_root = Mst.root_cid tree in
+  let commit_bytes = Mst.encode_repo_commit ~did ~data:mst_root ~rev () in
+  let commit_cid = Cid.create commit_bytes in
+  let mst_blocks =
+    Hashtbl.fold
+      (fun k data acc -> { Car.cid = Cid.of_string k; data } :: acc)
+      tree.store.created []
+  in
+  let record_blocks = List.map (fun (cid, data) -> { Car.cid; data }) records in
+  {
+    Car.roots = [ commit_cid ];
+    blocks =
+      ({ Car.cid = commit_cid; data = commit_bytes } :: mst_blocks)
+      @ record_blocks;
+  }
+
+let firehose_commit ~prev_data ~car ~ops ~rev =
+  let snap = Repo_sync.open_car car in
+  {
+    Firehose.seq = 1L;
+    rebase = false;
+    too_big = false;
+    repo = did;
+    commit = snap.commit_cid;
+    rev;
+    since = None;
+    prev_data;
+    blocks = car;
+    raw_blocks = Car.encode car;
+    ops;
+    blobs = [];
+    time = "2024-01-01T00:00:00.000Z";
+  }
+
+let test_open_car_and_walk _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.feed.like/bbb" vb in
+  let car =
+    car_of_tree ~did ~rev:"3jzfcijpj2z2a"
+      ~records:[ (va, "rec-a"); (vb, "rec-b") ]
+      t
+  in
+  let snap = Repo_sync.open_car car in
+  OUnit2.assert_equal ~printer:(fun x -> x) did snap.did;
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a" snap.rev;
+  Repo_sync.verify_snapshot snap;
+  let walked = Repo_sync.walk snap in
+  OUnit2.assert_equal 2 (List.length walked);
+  OUnit2.assert_equal
+    [ "app.bsky.feed.like/bbb"; "app.bsky.feed.post/aaa" ]
+    (List.sort String.compare (List.map fst walked));
+  let cid, bytes =
+    Repo_sync.verify_record_proof ~car ~path:"app.bsky.feed.post/aaa"
+  in
+  OUnit2.assert_bool "proof cid" (Cid.equal cid va);
+  OUnit2.assert_equal ~printer:(fun x -> x) "rec-a" bytes
+
+let test_record_table_backfill_and_commit _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let prev_data = Mst.root_cid t in
+  let car1 = car_of_tree ~did ~rev:"3jzfcijpj2z2a" t in
+  let acct = Repo_sync.create_account ~did () in
+  OUnit2.assert_equal Repo_sync.Desynchronized acct.status;
+  let created = Repo_sync.resync_from_car ~live:false acct car1 in
+  OUnit2.assert_equal Repo_sync.Synchronized acct.status;
+  OUnit2.assert_equal 1 (List.length created);
+  (match List.hd created with
+  | Repo_sync.Created { path; live; _ } ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post/aaa" path;
+      OUnit2.assert_bool "historical" (not live)
+  | _ -> OUnit2.assert_failure "expected create from backfill");
+  let t, _ = Mst.insert t "app.bsky.feed.post/bbb" vb in
+  let car2 = car_of_tree ~did ~rev:"3jzfcijpj2z2b" t in
+  let commit =
+    firehose_commit ~prev_data:(Some prev_data) ~car:car2 ~rev:"3jzfcijpj2z2b"
+      ~ops:
+        [
+          {
+            Firehose.action = "create";
+            path = "app.bsky.feed.post/bbb";
+            cid = Some vb;
+            prev = None;
+          };
+        ]
+  in
+  let events = Repo_sync.process_commit ~live:true acct commit in
+  OUnit2.assert_equal 1 (List.length events);
+  (match List.hd events with
+  | Repo_sync.Created { path; live; _ } ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post/bbb" path;
+      OUnit2.assert_bool "live" live
+  | _ -> OUnit2.assert_failure "expected live create");
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2b" acct.rev;
+  OUnit2.assert_equal 2 (Hashtbl.length acct.records)
+
+let test_broken_chain_and_sync _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let car = car_of_tree ~did ~rev:"3jzfcijpj2z2a" t in
+  let acct = Repo_sync.create_account ~did () in
+  ignore (Repo_sync.resync_from_car acct car);
+  let other = Cid.create ~codec:Cid.Raw "other-root" in
+  let commit =
+    firehose_commit ~prev_data:(Some other) ~car ~rev:"3jzfcijpj2z2c"
+      ~ops:
+        [
+          {
+            Firehose.action = "create";
+            path = "app.bsky.feed.post/zzz";
+            cid = Some va;
+            prev = None;
+          };
+        ]
+  in
+  (* inversion will fail (wrong op / prevData); treat as broken *)
+  OUnit2.assert_bool "broken invert accepted"
+    (try
+       ignore (Repo_sync.process_commit acct commit);
+       acct.status = Repo_sync.Desynchronized
+     with Repo_sync.Error _ | Failure _ | Mst.Verify_error _ -> true);
+  let sync =
+    {
+      Firehose.seq = 2L;
+      did;
+      blocks = car;
+      raw_blocks = Car.encode car;
+      rev = "3jzfcijpj2z2z";
+      time = "2024-01-01T00:00:00.000Z";
+    }
+  in
+  ignore (Repo_sync.process_sync acct sync);
+  OUnit2.assert_equal Repo_sync.Desynchronized acct.status;
+  let ignored =
+    Repo_sync.process_commit acct
+      (firehose_commit ~prev_data:None ~car ~rev:"3jzfcijpj2z2d" ~ops:[])
+  in
+  OUnit2.assert_equal [] ignored
+
+let test_collection_filter_and_delete _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.feed.like/bbb" vb in
+  let car = car_of_tree ~did ~rev:"3jzfcijpj2z2a" t in
+  let acct =
+    Repo_sync.create_account ~did ~collections:[ "app.bsky.feed.post" ] ()
+  in
+  let events = Repo_sync.resync_from_car acct car in
+  OUnit2.assert_equal 1 (List.length events);
+  OUnit2.assert_equal 1 (Hashtbl.length acct.records);
+  let t, _ = Mst.remove t "app.bsky.feed.post/aaa" in
+  let car2 = car_of_tree ~did ~rev:"3jzfcijpj2z2b" t in
+  let replay = Repo_sync.resync_from_car ~live:false acct car2 in
+  match replay with
+  | [ Repo_sync.Deleted { path; _ } ] ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post/aaa" path
+  | _ -> OUnit2.assert_failure "expected delete of filtered record"
+
+let test_apply_commit_tree _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let prev = Repo_sync.open_car (car_of_tree ~did ~rev:"3jzfcijpj2z2a" t) in
+  let t, _ = Mst.insert t "app.bsky.feed.post/bbb" vb in
+  let car2 = car_of_tree ~did ~rev:"3jzfcijpj2z2b" t in
+  let commit =
+    firehose_commit ~prev_data:(Some prev.data) ~car:car2 ~rev:"3jzfcijpj2z2b"
+      ~ops:
+        [
+          {
+            Firehose.action = "create";
+            path = "app.bsky.feed.post/bbb";
+            cid = Some vb;
+            prev = None;
+          };
+        ]
+  in
+  let next = Repo_sync.apply_commit_tree prev commit in
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2b" next.rev;
+  (match Mst.get next.tree "app.bsky.feed.post/bbb" with
+  | Some c -> OUnit2.assert_bool "forward apply" (Cid.equal c vb)
+  | None -> OUnit2.assert_failure "forward apply missing bbb");
+  let tree = Firehose.apply_commit ~prev_tree:prev.tree commit in
+  OUnit2.assert_bool "firehose apply_commit"
+    (Cid.equal (Mst.root_cid tree) next.data)
+
+let rfc6979_p256_priv =
+  Hash.hex_decode
+    "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"
+
+let test_signed_snapshot _ =
+  match Mirage_crypto_ec.P256.Dsa.priv_of_octets rfc6979_p256_priv with
+  | Error _ -> OUnit2.assert_failure "p256 priv"
+  | Ok priv ->
+      let pub = Mirage_crypto_ec.P256.Dsa.pub_of_priv priv in
+      let key =
+        Did_key.to_string
+          (Did_key.of_p256_octets
+             (Mirage_crypto_ec.P256.Dsa.pub_to_octets ~compress:true pub))
+      in
+      let store = Mst.store_of_get (fun _ -> None) in
+      let t = Mst.empty_tree store in
+      let va = Cid.create ~codec:Cid.Raw "rec-a" in
+      let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+      let data = Mst.root_cid t in
+      let commit_bytes =
+        Mst.sign_p256 ~priv ~did ~data ~rev:"3jzfcijpj2z2a" ()
+      in
+      let commit_cid = Cid.create commit_bytes in
+      let mst_blocks =
+        Hashtbl.fold
+          (fun k d acc -> { Car.cid = Cid.of_string k; data = d } :: acc)
+          t.store.created []
+      in
+      let car =
+        {
+          Car.roots = [ commit_cid ];
+          blocks = { Car.cid = commit_cid; data = commit_bytes } :: mst_blocks;
+        }
+      in
+      let snap = Repo_sync.open_car car in
+      Repo_sync.verify_snapshot ~keys:[ key ] snap;
+      OUnit2.assert_equal `Valid
+        (Mst.verify_commit_sig ~keys:[ key ] snap.commit)
+
+let test_split_path _ =
+  OUnit2.assert_equal
+    ("app.bsky.feed.post", "3jzfcijpj2z2a")
+    (Repo_sync.split_path "app.bsky.feed.post/3jzfcijpj2z2a");
+  OUnit2.assert_equal ("nocollection", "") (Repo_sync.split_path "nocollection")
+
+let suite =
+  "repo_sync"
+  >::: [
+         "test_open_car_and_walk" >:: test_open_car_and_walk;
+         "test_record_table_backfill_and_commit"
+         >:: test_record_table_backfill_and_commit;
+         "test_broken_chain_and_sync" >:: test_broken_chain_and_sync;
+         "test_collection_filter_and_delete"
+         >:: test_collection_filter_and_delete;
+         "test_apply_commit_tree" >:: test_apply_commit_tree;
+         "test_signed_snapshot" >:: test_signed_snapshot;
+         "test_split_path" >:: test_split_path;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -3,6 +3,7 @@ open Atproto.Session
 open Atproto.Auth
 open Atproto.Sync
 open Atproto.Car
+open Atproto.Cid
 open Atproto.Identity
 
 let skip_without_auth () =
@@ -161,6 +162,21 @@ let test_get_blocks_url _ =
      in
      contains 0)
 
+let test_get_record_proof_public _ =
+  try
+    with_public_timeout (fun () ->
+        let ident = public_actor () in
+        let host = public_pds_host ident in
+        let cid, bytes =
+          Atproto.Repo_sync.Repo_sync.fetch_record_proof ~host ~did:ident.did
+            ~collection:"app.bsky.actor.profile" ~rkey:"self" ()
+        in
+        OUnit2.assert_bool "profile proof cid"
+          (String.length (Cid.to_string cid) > 8);
+        OUnit2.assert_bool "profile bytes" (String.length bytes > 0))
+  with exn ->
+    skip_if true ("getRecord proof skipped: " ^ Printexc.to_string exn)
+
 let test_get_repo_status_public _ =
   try
     with_public_timeout (fun () ->
@@ -184,6 +200,7 @@ let suite =
          >:: test_parse_list_repos_by_collection;
          "test_get_blocks_url" >:: test_get_blocks_url;
          "test_get_repo_status_public" >:: test_get_repo_status_public;
+         "test_get_record_proof_public" >:: test_get_record_proof_public;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -89,6 +89,24 @@ let test_did_spec_examples _ =
          (Syntax.is_blessed_did
             "did:key:zQ3shZc2QzApp2oymGvQbzP8eKheVshBHbU4ZYjeXqwSKEn6N"))
 
+let test_did_ref _ =
+  let bare = Syntax.parse_did_ref "did:web:video.bsky.app" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:web:video.bsky.app" bare.did;
+  OUnit2.assert_equal None bare.fragment;
+  let labeled = Syntax.parse_did_ref "did:web:video.bsky.app#bsky_transcode" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "did:web:video.bsky.app" labeled.did;
+  OUnit2.assert_equal (Some "bsky_transcode") labeled.fragment;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:video.bsky.app#bsky_transcode"
+    (Syntax.did_ref_to_string labeled);
+  OUnit2.assert_bool "fragment is not a DID"
+    (not (Syntax.is_valid_did "did:web:video.bsky.app#bsky_transcode"));
+  OUnit2.assert_bool "did-ref accepts service fragment"
+    (Syntax.is_valid_did_ref "did:web:video.bsky.app#bsky_transcode");
+  OUnit2.assert_bool "empty fragment rejected"
+    (not (Syntax.is_valid_did_ref "did:web:video.bsky.app#"))
+
 let test_nsid_spec_examples _ =
   List.iter
     (fun n -> assert_ok n Syntax.is_valid_nsid)
@@ -229,6 +247,7 @@ let suite =
          "test_handle_normalize" >:: test_handle_normalize;
          "test_handle_reserved_tld" >:: test_handle_reserved_tld;
          "test_did_spec_examples" >:: test_did_spec_examples;
+         "test_did_ref" >:: test_did_ref;
          "test_nsid_spec_examples" >:: test_nsid_spec_examples;
          "test_nsid_glob_and_ref" >:: test_nsid_glob_and_ref;
          "test_record_key" >:: test_record_key;

--- a/test/test_xrpc.ml
+++ b/test/test_xrpc.ml
@@ -1,6 +1,9 @@
 open OUnit2
 open Atproto.Xrpc
 open Atproto.Base64url
+open Atproto.Hash
+open Atproto.Did_key
+open Atproto.K256
 
 let test_proxy _ =
   let p = Xrpc.parse_proxy "did:plc:abc123xyz0001112223333#atproto_labeler" in
@@ -97,7 +100,119 @@ let test_service_auth_jwt _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "did:web:mod.example.com"
-    (body |> member "aud" |> to_string)
+    (body |> member "aud" |> to_string);
+  let frag =
+    Xrpc.service_auth_body ~aud:"did:web:video.bsky.app#bsky_transcode"
+      ~lxm:"com.atproto.repo.uploadBlob" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:video.bsky.app#bsky_transcode"
+    (frag |> member "aud" |> to_string)
+
+let rfc6979_p256_priv =
+  Hash.hex_decode
+    "c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721"
+
+let p256_pair () =
+  match Mirage_crypto_ec.P256.Dsa.priv_of_octets rfc6979_p256_priv with
+  | Error _ -> failwith "could not load RFC 6979 P-256 private key"
+  | Ok priv -> (priv, Mirage_crypto_ec.P256.Dsa.pub_of_priv priv)
+
+let p256_did_key pub =
+  Did_key.to_string
+    (Did_key.of_p256_octets
+       (Mirage_crypto_ec.P256.Dsa.pub_to_octets ~compress:true pub))
+
+let test_service_jwt_p256_roundtrip _ =
+  let priv, pub = p256_pair () in
+  let jwt =
+    Xrpc.sign_service_jwt_p256 ~priv ~iss:"did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+      ~aud:"did:web:video.bsky.app#bsky_transcode"
+      ~lxm:"com.atproto.repo.uploadBlob" ~exp:2_000_000_000L ~iat:1_700_000_000L
+      ~jti:"aabbccddeeff00112233445566778899" ~now:1_700_000_000.0 ()
+  in
+  let claims =
+    Xrpc.verify_service_jwt
+      ~keys:[ p256_did_key pub ]
+      ~aud:"did:web:video.bsky.app#bsky_transcode"
+      ~lxm:"com.atproto.repo.uploadBlob" ~now:1_700_000_010.0 jwt
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "ES256" claims.alg;
+  OUnit2.assert_equal ~printer:(fun x -> x) "#atproto" claims.kid;
+  OUnit2.assert_equal (Some "aabbccddeeff00112233445566778899") claims.jti;
+  OUnit2.assert_equal (Some "bsky_transcode") claims.aud_service;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:web:video.bsky.app" claims.aud_did;
+  let h, v = Xrpc.service_auth_header jwt in
+  OUnit2.assert_equal "Authorization" h;
+  OUnit2.assert_bool "bearer"
+    (String.length v > 7 && String.sub v 0 7 = "Bearer ")
+
+let test_service_jwt_k256_roundtrip _ =
+  match K256.priv_of_octets (Hash.hex_decode (String.make 63 '0' ^ "3")) with
+  | Error _ -> OUnit2.assert_failure "k256 priv rejected"
+  | Ok priv ->
+      let pub = K256.pub_of_priv priv in
+      let key =
+        Did_key.to_string
+          (Did_key.of_k256_octets (K256.pub_to_octets ~compress:true pub))
+      in
+      let jwt =
+        Xrpc.sign_service_jwt_k256 ~priv ~iss:"did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+          ~aud:"did:web:api.bsky.app#bsky_appview"
+          ~lxm:"app.bsky.feed.getFeedSkeleton" ~exp:2_000_000_000L
+          ~iat:1_700_000_000L ~jti:"k256nonce" ()
+      in
+      let claims =
+        Xrpc.verify_service_jwt ~keys:[ key ]
+          ~aud:"did:web:api.bsky.app#bsky_appview" ~now:1_700_000_000.0 jwt
+      in
+      OUnit2.assert_equal ~printer:(fun x -> x) "ES256K" claims.alg;
+      OUnit2.assert_equal (Some "k256nonce") claims.jti
+
+let test_service_jwt_rejects _ =
+  let priv, pub = p256_pair () in
+  let key = p256_did_key pub in
+  let jwt =
+    Xrpc.sign_service_jwt_p256 ~priv ~iss:"did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+      ~aud:"did:web:mod.example.com#atproto_labeler"
+      ~lxm:"com.atproto.moderation.createReport" ~exp:1_700_000_060L
+      ~iat:1_700_000_000L ~jti:"once" ()
+  in
+  OUnit2.assert_bool "wrong aud accepted"
+    (try
+       ignore
+         (Xrpc.verify_service_jwt ~keys:[ key ] ~aud:"did:web:other.example"
+            ~now:1_700_000_010.0 jwt);
+       false
+     with Xrpc.Invalid _ -> true);
+  OUnit2.assert_bool "expired accepted"
+    (try
+       ignore (Xrpc.verify_service_jwt ~keys:[ key ] ~now:1_700_000_200.0 jwt);
+       false
+     with Xrpc.Invalid _ -> true);
+  OUnit2.assert_bool "wrong lxm accepted"
+    (try
+       ignore
+         (Xrpc.verify_service_jwt ~keys:[ key ]
+            ~lxm:"com.atproto.server.createSession" ~now:1_700_000_010.0 jwt);
+       false
+     with Xrpc.Invalid _ -> true);
+  OUnit2.assert_bool "bare aud is not a wildcard"
+    (try
+       ignore
+         (Xrpc.verify_service_jwt ~keys:[ key ] ~aud:"did:web:mod.example.com"
+            ~now:1_700_000_010.0 jwt);
+       false
+     with Xrpc.Invalid _ -> true);
+  let cache = Xrpc.create_jti_cache () in
+  let claims = Xrpc.parse_service_auth jwt in
+  OUnit2.assert_bool "first jti is new"
+    (not (Xrpc.remember_jti ~now:1_700_000_010.0 cache claims));
+  OUnit2.assert_bool "replayed jti"
+    (Xrpc.remember_jti ~now:1_700_000_010.0 cache claims)
 
 let suite =
   "xrpc"
@@ -107,6 +222,9 @@ let suite =
          "test_rate_limit" >:: test_rate_limit;
          "test_repo_rev" >:: test_repo_rev;
          "test_service_auth_jwt" >:: test_service_auth_jwt;
+         "test_service_jwt_p256_roundtrip" >:: test_service_jwt_p256_roundtrip;
+         "test_service_jwt_k256_roundtrip" >:: test_service_jwt_k256_roundtrip;
+         "test_service_jwt_rejects" >:: test_service_jwt_rejects;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks the next hard protocol slice on **main** (PR #75 is already merged). Does **not** touch the merged #75 branch.

## What this adds

### Service-auth JWT (`Xrpc`)
`parse_service_auth` treated `aud` as a bare DID, so current `did#service` tokens failed. This implements the current [XRPC inter-service JWT](https://atproto.com/specs/xrpc) surface:

- Parse `alg` / `typ` / `kid` (default `#atproto`) / `iss` / `aud` / `exp` / `iat` / `lxm` / `jti`
- `aud` may be a bare DID or `did#service` (legacy bare-DID match is exact, not a wildcard)
- Local mint: `sign_service_jwt_p256` (ES256) and `sign_service_jwt_k256` (ES256K), low-S
- Verify against `did:key` list: signature, audience, `lxm`, expiry
- `jti` replay cache
- `getServiceAuth` request body accepts `did#service`

No hosted login and no invented credentials.

### TAP-like repo sync (`Repo_sync`)
Library-shaped helpers from the [record-level sync](https://atproto.com/specs/sync#record-level-synchronization) design — **not** a hosted Tap service:

- Open/verify a repo CAR (commit CID, MST tree, optional commit signature)
- Walk records; `getRecord` inclusion proof (MST path + record block CID)
- Record table: backfill from CAR, apply firehose create/update/delete, collection filter
- `#sync` / broken `prevData` → `Desynchronized`; `resync_from_car` diffs and drains queued commits
- MST-level `apply_commit_tree` / `Firehose.apply_commit` (forward apply of invert)
- `fetch_record_proof` against `com.atproto.sync.getRecord` (CAR)

### Jetstream Network Replay (types + skippable HTTP)
Per [bsky.network/docs/jetstream-replay](https://bsky.network/docs/jetstream-replay/):

- `planSnapshot` / `planBackfill` / `listSegments` URLs and JSON types
- Page window (`plannedThroughSeq` < `sealedTipSeq`)
- Download jobs (`segment` vs `blocks`)
- Live cutover `?cursor=sealedTipSeq` (inclusive; dedupe)
- HTTP `Range` resume after 429
- Skippable unauthenticated probe (`Snapshot_gated` on 401/403) — **no invented token**
- Live tail stays unauthenticated

### Other protocol holes
- `Mst.apply_ops` + `Mst.walk`
- `Cid.of_blob` / `verify_blob` (raw + SHA-256)
- `Did_plc.atproto_signing_keys`
- `Label.subscribe` / `subscribe_one` for `com.atproto.label.subscribeLabels`
- `Firehose.verify_sync` (commit-only CAR vs did/rev)

## Tests
`dune build` and `dune runtest` pass. Action majors unchanged.

## Leftovers (product-level / no stable spec)
- Hosted OAuth client-metadata + live browser login
- Hosted PDS / Tap / video transcoder / Ozone operator session
- Jetstream `.jss` columnar decode + live archive download (needs an operator token)
- Permissioned data / spaces / LtHash (no stable public spec)
- Sync 1.1 defined CAR block ordering and collection-subset repo exports

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b3df94b-75da-4604-8a16-23e12d5fd245?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b3df94b-75da-4604-8a16-23e12d5fd245&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

