### PR TITLE
Sync 1.1 pre-order CARs, collection-subset proofs, and JSS v1 decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | AppView feed | `Feed` | Timeline, threads, generators (`getFeed` / `getFeedGenerator` / `getActorFeeds`), `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
-| Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner (`planSnapshot`/`planBackfill`/`listSegments` types, page window, download jobs, live cutover `?cursor=sealedTipSeq`, Range resume) + skippable unauthenticated HTTP (no invented archive token) |
+| Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
@@ -50,9 +50,9 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + updateHandle / PLC operation helpers |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
-| CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1 |
-| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete/walk, firehose-diff inversion **and** forward apply, p256/k256 commit sign+verify |
-| Repo sync (TAP-like) | `Repo_sync` | Library-shaped backfill: open/verify repo CAR, walk records, `getRecord` inclusion proof, record-table apply of firehose ops, `#sync` desync, MST-level `apply_commit_tree`. Not a hosted Tap service |
+| CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1, blessed CID check, Sync 1.1 streamable pre-order |
+| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete/walk, firehose-diff inversion **and** forward apply, p256/k256 commit sign+verify, pre-order blocks, collection-range proofs |
+| Repo sync (TAP-like) | `Repo_sync` | Library-shaped backfill: open/verify repo CAR, walk records, `getRecord` inclusion proof (partial CAR), record-table apply of firehose ops, `#sync` desync, MST-level `apply_commit_tree`, Sync 1.1 pre-order export + collection-subset CAR. Not a hosted Tap service |
 | TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen, JSON validate |
@@ -74,11 +74,11 @@ These are product-level, not missing protocol cores:
 
 - Hosting a public **client-metadata document** and completing a **live browser login** against a PDS (the protocol core — metadata, PAR + DPoP-nonce retry, authorize URL, redirect `code`/`state`/`iss`, token parse — is implemented and tested with fixtures)
 - A hosted PDS, hosted Tap service, hosted video transcoder, or live Ozone operator session (client request/response types, video byte-upload + job poll, TAP-like repo sync helpers, and proxy headers are implemented)
-- Jetstream Network Replay / HTTP snapshot **download** against Bluesky's gated archive (planner, `listSegments` types, cutover cursor, Range resume, and skippable unauthenticated HTTP are implemented; a live archive download still needs an operator token this library does not invent)
+- Jetstream Network Replay / HTTP snapshot **download** against Bluesky's gated archive (planner, `listSegments` types, cutover cursor, Range resume, skippable unauthenticated HTTP, and `.jss` v1 decode are implemented; a live archive download still needs an operator token this library does not invent, and zstd frames need an injected decompressor)
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
-- Defined CAR block ordering and collection-subset repo exports (Sync 1.1 leftovers; no stable export layout to implement yet)
+- Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-Service-auth JWT mint/verify (`jti`/`kid`/`iat`, `did#service` audience, ES256/ES256K), TAP-like `Repo_sync` (CAR walk, record-table apply, `#sync` resync, MST forward apply), blob CID verify, and skippable Jetstream snapshot HTTP are in this slice. #70–#75 already landed identity/MST/OAuth-core/AppView/Ozone/Jetstream/video.
+Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encode/verify + collection-subset proofs, `.jss` v1 columnar decode, blessed CID / repo-path / firehose size+future-rev checks are in this slice. #70–#76 already landed identity/MST/OAuth-core/AppView/Ozone/Jetstream/video/service-auth.
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -149,4 +149,30 @@ let () =
       ~collections:[ "app.bsky.feed.post" ] ()
   in
   assert (acct.status = Repo_sync.Desynchronized);
+  assert (Syntax.is_valid_repo_path "app.bsky.feed.post/3jzfcijpj2z2a");
+  assert (Cid.is_blessed (Cid.create "{\"v\":1}"));
+  let start, finish = Mst.collection_range "app.bsky.feed.post" in
+  assert (start = "app.bsky.feed.post/" && finish = "app.bsky.feed.post0");
+  let jss_hdr =
+    Jetstream.Jss.parse_header
+      (Jetstream.Jss.encode_header
+         {
+           checksum = 0L;
+           version = 1;
+           block_count = 0;
+           event_count = 0;
+           unique_did_count = 0;
+           min_seq = 0L;
+           max_seq = 0L;
+           min_witnessed_at = 0L;
+           max_witnessed_at = 0L;
+           footer_offset = 0L;
+           did_bloom_offset = 0L;
+           block_did_bloom_offset = 0L;
+           collection_index_offset = 0L;
+           block_index_offset = 0L;
+           sealed = false;
+         })
+  in
+  assert (jss_hdr.version = 1);
   print_endline "examples/offline: public API typechecks and fixtures pass"

--- a/src/car.ml
+++ b/src/car.ml
@@ -69,4 +69,53 @@ module Car = struct
 
   let root (car : t) : Cid.t option =
     match car.roots with hd :: _ -> Some hd | [] -> None
+
+  let block_cids (car : t) : Cid.t list =
+    List.map (fun (b : block) -> b.cid) car.blocks
+
+  let first_occurrences (cids : Cid.t list) : Cid.t list =
+    let seen = Hashtbl.create 16 in
+    List.filter
+      (fun c ->
+        let k = Cid.to_string c in
+        if Hashtbl.mem seen k then false
+        else (
+          Hashtbl.add seen k ();
+          true))
+      cids
+
+  (* True when [actual] visits every CID in [expected] in that order. Extra
+     unlinked blocks and later duplicates are tolerated (CARv1 / repo spec). *)
+  let follows_order ~(expected : Cid.t list) (actual : Cid.t list) : bool =
+    let rec loop exp act =
+      match (exp, act) with
+      | [], _ -> true
+      | _ :: _, [] -> false
+      | e :: er, a :: ar -> if Cid.equal e a then loop er ar else loop exp ar
+    in
+    loop expected (first_occurrences actual)
+
+  let reorder ~(expected : Cid.t list) (car : t) : t =
+    let by_cid = Hashtbl.create (List.length car.blocks) in
+    List.iter
+      (fun (b : block) ->
+        let k = Cid.to_string b.cid in
+        if not (Hashtbl.mem by_cid k) then Hashtbl.add by_cid k b)
+      car.blocks;
+    let ordered =
+      List.filter_map
+        (fun c ->
+          match Hashtbl.find_opt by_cid (Cid.to_string c) with
+          | None -> None
+          | Some b ->
+              Hashtbl.remove by_cid (Cid.to_string c);
+              Some b)
+        expected
+    in
+    let extras =
+      List.filter
+        (fun (b : block) -> Hashtbl.mem by_cid (Cid.to_string b.cid))
+        car.blocks
+    in
+    { car with blocks = ordered @ extras }
 end

--- a/src/cid.ml
+++ b/src/cid.ml
@@ -97,4 +97,20 @@ module Cid = struct
           failwith
             (Printf.sprintf "Cid.verify_block: expected %s got %s"
                (to_string cid) (to_string got))
+
+  (* Data-model "blessed" CID: CIDv1 + sha2-256 (32 bytes) + dag-cbor or raw.
+     MST/commit links must be dag-cbor; record leaves may be either. *)
+  let is_blessed ?(codec : codec option) (c : t) : bool =
+    c.version = 1 && c.hash_code = sha2_256
+    && String.length c.digest = 32
+    &&
+    match codec with
+    | Some want -> c.codec = want
+    | None -> ( match c.codec with Dag_cbor | Raw -> true | Other _ -> false)
+
+  let ensure_blessed ?(codec : codec option) (c : t) : unit =
+    if not (is_blessed ?codec c) then
+      failwith
+        (Printf.sprintf "Cid.ensure_blessed: %s is not a blessed atproto CID"
+           (to_string c))
 end

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -67,6 +67,12 @@ module Firehose = struct
 
   let default_relay_host = "bsky.network"
 
+  (* https://atproto.com/specs/sync#commit-events *)
+  let max_frame_bytes = 5_000_000
+  let max_blocks_bytes = 2_000_000
+  let max_record_bytes = 1_000_000
+  let max_ops = 200
+
   let subscribe_url ?(host = default_relay_host) ?cursor () =
     let base =
       Printf.sprintf "wss://%s/xrpc/com.atproto.sync.subscribeRepos" host
@@ -282,7 +288,26 @@ module Firehose = struct
     let inverted = Mst.Mst.invert_ops tree (record_ops c.ops) in
     Mst.Mst.root_cid inverted
 
+  let validate_limits (c : commit) : unit =
+    if String.length c.raw_blocks > max_blocks_bytes then
+      failwith "Firehose.validate_limits: blocks exceed 2,000,000 bytes";
+    if List.length c.ops > max_ops then
+      failwith "Firehose.validate_limits: more than 200 record operations";
+    List.iter
+      (fun (op : repo_op) ->
+        if not (Syntax.Syntax.is_valid_repo_path op.path) then
+          failwith ("Firehose.validate_limits: invalid repo path " ^ op.path))
+      c.ops;
+    if Tid.Tid.is_future c.rev then
+      failwith ("Firehose.validate_limits: rev is in the future " ^ c.rev);
+    List.iter
+      (fun (b : Car.block) ->
+        if String.length b.data > max_record_bytes then
+          failwith "Firehose.validate_limits: block exceeds 1,000,000 bytes")
+      c.blocks.blocks
+
   let verify_commit (c : commit) : unit =
+    validate_limits c;
     match (c.too_big, c.rebase, c.ops) with
     | true, _, _ | _, true, _ -> ()
     | _, _, [] ->
@@ -300,6 +325,10 @@ module Firehose = struct
         | None -> ())
 
   let verify_commit_object (c : commit) : Mst.Mst.repo_commit =
+    (match Car.root c.blocks with
+    | Some root when not (Cid.equal root c.commit) ->
+        failwith "Firehose.verify_commit_object: CAR root is not the commit CID"
+    | _ -> ());
     let signed = repo_commit_of c in
     if c.repo <> signed.did then
       failwith
@@ -309,6 +338,10 @@ module Firehose = struct
       failwith
         (Printf.sprintf "Firehose.verify_commit_object: rev %s != %s" signed.rev
            c.rev);
+    if Tid.Tid.is_future signed.rev then
+      failwith
+        ("Firehose.verify_commit_object: commit rev is in the future "
+       ^ signed.rev);
     signed
 
   let verify_commit_sig ~keys (c : commit) : Mst.Mst.sig_status =

--- a/src/jetstream.ml
+++ b/src/jetstream.ml
@@ -693,4 +693,410 @@ module Jetstream = struct
     in
     parse_snapshot_plan
       (Yojson.Safe.from_string (classify_snapshot_status code body))
+
+  (* Sealed-segment columnar format (.jss v1). Public spec:
+     https://tangled.org/zat.dev/stream/blob/main/docs/jss-format-v1.md
+     (condensed from bluesky-social/jetstream segment/*.go).
+
+     Decode only. No archive token and no invented credentials. zstd frames
+     are accepted through an injected [decompress] callback so this library
+     does not take a compression dependency. *)
+  module Jss = struct
+    exception Error of string
+
+    let fail msg = raise (Error msg)
+    let magic = "jss0"
+    let header_size = 256
+    let block_index_entry_size = 52
+    let default_events_per_block = 4096
+    let max_block_events = 1 lsl 18
+    let max_block_count = 1 lsl 20
+    let max_collection_count = 1 lsl 20
+    let max_decompressed_block = 1 lsl 30
+    let max_did_len = 65535
+    let max_short_len = 255
+
+    type header = {
+      checksum : int64;
+      version : int;
+      block_count : int;
+      event_count : int;
+      unique_did_count : int;
+      min_seq : int64;
+      max_seq : int64;
+      min_witnessed_at : int64;
+      max_witnessed_at : int64;
+      footer_offset : int64;
+      did_bloom_offset : int64;
+      block_did_bloom_offset : int64;
+      collection_index_offset : int64;
+      block_index_offset : int64;
+      sealed : bool;
+    }
+
+    type block_index_entry = {
+      offset : int64;
+      compressed_size : int;
+      uncompressed_size : int;
+      event_count : int;
+      min_seq : int64;
+      max_seq : int64;
+      min_witnessed_at : int64;
+      max_witnessed_at : int64;
+    }
+
+    type row_kind =
+      | Create
+      | Update
+      | Delete
+      | Identity
+      | Account
+      | Sync
+      | Create_resync
+
+    type row = {
+      seq : int64;
+      witnessed_at : int64;
+      indexed_at : int64;
+      kind : row_kind;
+      collection : string;
+      did : string;
+      rkey : string;
+      rev : string;
+      payload : string;
+    }
+
+    let require_len s need what =
+      if String.length s < need then
+        fail
+          (Printf.sprintf "jss %s: need %d bytes, got %d" what need
+             (String.length s))
+
+    let u8 s i = Char.code s.[i]
+
+    let u16_le s i =
+      require_len s (i + 2) "u16";
+      u8 s i lor (u8 s (i + 1) lsl 8)
+
+    let u32_le s i =
+      require_len s (i + 4) "u32";
+      Int64.logor
+        (Int64.of_int (u8 s i))
+        (Int64.logor
+           (Int64.shift_left (Int64.of_int (u8 s (i + 1))) 8)
+           (Int64.logor
+              (Int64.shift_left (Int64.of_int (u8 s (i + 2))) 16)
+              (Int64.shift_left (Int64.of_int (u8 s (i + 3))) 24)))
+
+    let u32_le_int s i = Int64.to_int (u32_le s i)
+
+    let u64_le s i =
+      require_len s (i + 8) "u64";
+      Int64.logor (u32_le s i) (Int64.shift_left (u32_le s (i + 4)) 32)
+
+    let i64_le s i = u64_le s i
+    let put_u8 buf n = Buffer.add_char buf (Char.chr (n land 0xff))
+
+    let put_u16_le buf n =
+      put_u8 buf n;
+      put_u8 buf (n lsr 8)
+
+    let put_u32_le buf n =
+      let n = Int64.to_int (Int64.logand n 0xFFFFFFFFL) in
+      put_u8 buf n;
+      put_u8 buf (n lsr 8);
+      put_u8 buf (n lsr 16);
+      put_u8 buf (n lsr 24)
+
+    let put_u64_le buf n =
+      put_u32_le buf n;
+      put_u32_le buf (Int64.shift_right_logical n 32)
+
+    let kind_of_int = function
+      | 1 -> Create
+      | 2 -> Update
+      | 3 -> Delete
+      | 4 -> Identity
+      | 5 -> Account
+      | 6 -> Sync
+      | 7 -> Create_resync
+      | n -> fail (Printf.sprintf "jss unknown kind %d" n)
+
+    let int_of_kind = function
+      | Create -> 1
+      | Update -> 2
+      | Delete -> 3
+      | Identity -> 4
+      | Account -> 5
+      | Sync -> 6
+      | Create_resync -> 7
+
+    let parse_header (bytes : string) : header =
+      require_len bytes header_size "header";
+      if String.sub bytes 0 4 <> magic then fail "jss magic is not jss0";
+      let checksum = u64_le bytes 4 in
+      let version = u16_le bytes 12 in
+      if version <> 1 then
+        fail (Printf.sprintf "jss unsupported version %d" version);
+      let block_count = u32_le_int bytes 14 in
+      let event_count = u32_le_int bytes 18 in
+      if block_count > max_block_count then
+        fail "jss block_count exceeds sanity cap";
+      {
+        checksum;
+        version;
+        block_count;
+        event_count;
+        unique_did_count = u32_le_int bytes 22;
+        min_seq = u64_le bytes 26;
+        max_seq = u64_le bytes 34;
+        min_witnessed_at = i64_le bytes 42;
+        max_witnessed_at = i64_le bytes 50;
+        footer_offset = u64_le bytes 58;
+        did_bloom_offset = u64_le bytes 66;
+        block_did_bloom_offset = u64_le bytes 74;
+        collection_index_offset = u64_le bytes 82;
+        block_index_offset = u64_le bytes 90;
+        sealed = checksum <> 0L;
+      }
+
+    let encode_header (h : header) : string =
+      let buf = Buffer.create header_size in
+      Buffer.add_string buf magic;
+      put_u64_le buf h.checksum;
+      put_u16_le buf h.version;
+      put_u32_le buf (Int64.of_int h.block_count);
+      put_u32_le buf (Int64.of_int h.event_count);
+      put_u32_le buf (Int64.of_int h.unique_did_count);
+      put_u64_le buf h.min_seq;
+      put_u64_le buf h.max_seq;
+      put_u64_le buf h.min_witnessed_at;
+      put_u64_le buf h.max_witnessed_at;
+      put_u64_le buf h.footer_offset;
+      put_u64_le buf h.did_bloom_offset;
+      put_u64_le buf h.block_did_bloom_offset;
+      put_u64_le buf h.collection_index_offset;
+      put_u64_le buf h.block_index_offset;
+      Buffer.add_bytes buf (Bytes.make 158 '\x00');
+      Buffer.contents buf
+
+    let parse_block_index_entry (bytes : string) (off : int) : block_index_entry
+        =
+      require_len bytes (off + block_index_entry_size) "block index";
+      {
+        offset = u64_le bytes off;
+        compressed_size = u32_le_int bytes (off + 8);
+        uncompressed_size = u32_le_int bytes (off + 12);
+        event_count = u32_le_int bytes (off + 16);
+        min_seq = u64_le bytes (off + 20);
+        max_seq = u64_le bytes (off + 28);
+        min_witnessed_at = i64_le bytes (off + 36);
+        max_witnessed_at = i64_le bytes (off + 44);
+      }
+
+    let parse_block_index (bytes : string) (h : header) : block_index_entry list
+        =
+      if not h.sealed then []
+      else
+        let off = Int64.to_int h.block_index_offset in
+        let rec loop i acc =
+          if i >= h.block_count then List.rev acc
+          else
+            loop (i + 1)
+              (parse_block_index_entry bytes (off + (i * block_index_entry_size))
+              :: acc)
+        in
+        loop 0 []
+
+    let slice_by_lens blob lens max_len what =
+      let rec loop off acc = function
+        | [] ->
+            if off <> String.length blob then
+              fail (Printf.sprintf "jss %s blob trailing bytes" what);
+            List.rev acc
+        | n :: rest ->
+            if n > max_len then
+              fail (Printf.sprintf "jss %s length %d exceeds max" what n);
+            if off + n > String.length blob then
+              fail (Printf.sprintf "jss %s blob truncated" what);
+            loop (off + n) (String.sub blob off n :: acc) rest
+      in
+      loop 0 [] lens
+
+    let decode_columnar (body : string) : row list =
+      require_len body 4 "columnar event_count";
+      let n = u32_le_int body 0 in
+      if n > max_block_events then fail "jss event_count exceeds sanity cap";
+      if n = 0 then
+        if String.length body = 4 then []
+        else fail "jss empty block has trailing bytes"
+      else
+        let off = ref 4 in
+        let take_arr size read =
+          let items = List.init n (fun i -> read body (!off + (i * size))) in
+          off := !off + (n * size);
+          items
+        in
+        let seqs = take_arr 8 u64_le in
+        let witnessed = take_arr 8 i64_le in
+        let indexed = take_arr 8 i64_le in
+        let kinds = take_arr 1 (fun s i -> kind_of_int (u8 s i)) in
+        let coll_lens = take_arr 1 u8 in
+        let did_lens = take_arr 2 u16_le in
+        let rkey_lens = take_arr 1 u8 in
+        let rev_lens = take_arr 1 u8 in
+        let event_lens =
+          take_arr 4 (fun s i ->
+              let n = u32_le_int s i in
+              if n < 0 then fail "jss event_len overflow";
+              n)
+        in
+        let rest = String.sub body !off (String.length body - !off) in
+        let take_blob lens max_len what rem =
+          let total = List.fold_left ( + ) 0 lens in
+          if String.length rem < total then
+            fail (Printf.sprintf "jss %s blob truncated" what);
+          let blob = String.sub rem 0 total in
+          let rem = String.sub rem total (String.length rem - total) in
+          (slice_by_lens blob lens max_len what, rem)
+        in
+        let cols, rest = take_blob coll_lens max_short_len "collection" rest in
+        let dids, rest = take_blob did_lens max_did_len "did" rest in
+        let rkeys, rest = take_blob rkey_lens max_short_len "rkey" rest in
+        let revs, rest = take_blob rev_lens max_short_len "rev" rest in
+        let payloads, rest =
+          take_blob event_lens max_decompressed_block "payload" rest
+        in
+        if rest <> "" then fail "jss columnar trailing bytes";
+        let rec zip acc s w i k c d r v p =
+          match (s, w, i, k, c, d, r, v, p) with
+          | [], [], [], [], [], [], [], [], [] -> List.rev acc
+          | ( s :: ss,
+              w :: ws,
+              i :: is,
+              k :: ks,
+              c :: cs,
+              d :: ds,
+              r :: rs,
+              v :: vs,
+              p :: ps ) ->
+              zip
+                ({
+                   seq = s;
+                   witnessed_at = w;
+                   indexed_at = i;
+                   kind = k;
+                   collection = c;
+                   did = d;
+                   rkey = r;
+                   rev = v;
+                   payload = p;
+                 }
+                :: acc)
+                ss ws is ks cs ds rs vs ps
+          | _ -> fail "jss columnar column length mismatch"
+        in
+        zip [] seqs witnessed indexed kinds cols dids rkeys revs payloads
+
+    let encode_columnar (rows : row list) : string =
+      let n = List.length rows in
+      let buf = Buffer.create 64 in
+      put_u32_le buf (Int64.of_int n);
+      List.iter (fun r -> put_u64_le buf r.seq) rows;
+      List.iter (fun r -> put_u64_le buf r.witnessed_at) rows;
+      List.iter (fun r -> put_u64_le buf r.indexed_at) rows;
+      List.iter (fun r -> put_u8 buf (int_of_kind r.kind)) rows;
+      List.iter (fun r -> put_u8 buf (String.length r.collection)) rows;
+      List.iter (fun r -> put_u16_le buf (String.length r.did)) rows;
+      List.iter (fun r -> put_u8 buf (String.length r.rkey)) rows;
+      List.iter (fun r -> put_u8 buf (String.length r.rev)) rows;
+      List.iter
+        (fun r -> put_u32_le buf (Int64.of_int (String.length r.payload)))
+        rows;
+      List.iter (fun r -> Buffer.add_string buf r.collection) rows;
+      List.iter (fun r -> Buffer.add_string buf r.did) rows;
+      List.iter (fun r -> Buffer.add_string buf r.rkey) rows;
+      List.iter (fun r -> Buffer.add_string buf r.rev) rows;
+      List.iter (fun r -> Buffer.add_string buf r.payload) rows;
+      Buffer.contents buf
+
+    let time_of_us us =
+      let secs = Int64.to_float (Int64.div us 1_000_000L) in
+      match Ptime.of_float_s secs with
+      | None -> Printf.sprintf "%Ld" us
+      | Some t -> Ptime.to_rfc3339 ~frac_s:6 t
+
+    let row_to_event (r : row) : event =
+      match r.kind with
+      | Create | Update | Delete | Create_resync ->
+          let operation =
+            match r.kind with
+            | Update -> "update"
+            | Delete -> "delete"
+            | _ -> "create"
+          in
+          `Commit
+            {
+              did = r.did;
+              seq = r.seq;
+              time = time_of_us r.witnessed_at;
+              operation;
+              collection = r.collection;
+              rkey = r.rkey;
+              rev = r.rev;
+              cid = None;
+              record = None;
+            }
+      | Identity ->
+          `Identity
+            {
+              did = r.did;
+              seq = r.seq;
+              time = time_of_us r.witnessed_at;
+              handle = None;
+            }
+      | Account ->
+          `Account
+            {
+              did = r.did;
+              seq = r.seq;
+              time = time_of_us r.witnessed_at;
+              active = true;
+              status = None;
+            }
+      | Sync ->
+          `Sync
+            {
+              did = r.did;
+              seq = r.seq;
+              time = time_of_us r.witnessed_at;
+              rev = r.rev;
+            }
+
+    (* Sequential frame walk. Each frame is `block_len u64` + `block_len`
+       compressed bytes. Pass [decompress] to unwrap zstd (no dictionary). *)
+    let walk_frames ?(decompress : (string -> string) option) (bytes : string) :
+        row list =
+      let h = parse_header bytes in
+      let rec loop i acc =
+        if i >= String.length bytes then List.rev acc
+        else if
+          h.sealed && Int64.of_int i >= h.footer_offset && h.footer_offset <> 0L
+        then List.rev acc
+        else if i + 8 > String.length bytes then List.rev acc
+        else
+          let len64 = u64_le bytes i in
+          let len = Int64.to_int len64 in
+          if len < 0 || i + 8 + len > String.length bytes then
+            fail "jss truncated block frame";
+          let frame = String.sub bytes (i + 8) len in
+          let body =
+            match decompress with Some f -> f frame | None -> frame
+          in
+          if String.length body > max_decompressed_block then
+            fail "jss decompressed block exceeds 1 GiB";
+          loop (i + 8 + len) (List.rev_append (decode_columnar body) acc)
+      in
+      loop header_size []
+  end
 end

--- a/src/mst.ml
+++ b/src/mst.ml
@@ -20,6 +20,10 @@ module Mst = struct
 
   let fail msg = raise (Verify_error msg)
 
+  (* Spec: limit TreeEntries per node against key-mining DoS. Fanout 4 makes
+     64 statistically extreme (expected ~4). *)
+  let max_entries_per_node = 64
+
   let leading_zeros_on_hash (key : string) : int =
     let digest = Hash.sha256 key in
     let rec loop i acc =
@@ -107,8 +111,24 @@ module Mst = struct
     in
     loop keys
 
+  let ensure_mst_link (cid : Cid.t) : unit =
+    if not (Cid.is_blessed ~codec:Cid.Dag_cbor cid) then
+      fail
+        (Printf.sprintf
+           "MST child link %s is not a blessed dag-cbor SHA-256 CID"
+           (Cid.to_string cid))
+
   let verify_node ?(expected_layer : int option) (n : node) : reconstructed list
       =
+    if List.length n.entries > max_entries_per_node then
+      fail
+        (Printf.sprintf "MST node has %d entries (max %d)"
+           (List.length n.entries) max_entries_per_node);
+    (match n.left with Some c -> ensure_mst_link c | None -> ());
+    List.iter
+      (fun (e : entry) ->
+        match e.right with Some c -> ensure_mst_link c | None -> ())
+      n.entries;
     let items = reconstruct n in
     let keys = List.map (fun r -> r.key) items in
     keys_strictly_increasing keys;
@@ -766,6 +786,213 @@ module Mst = struct
       acc (get_entries t)
 
   let walk (t : tree) : (string * Cid.t) list = List.rev (collect_entries t [])
+
+  let rec collect_available (t : tree) acc =
+    match store_get t.store t.pointer with
+    | None when t.entries = None -> acc
+    | _ -> (
+        try
+          List.fold_left
+            (fun acc e ->
+              match e with
+              | Value (path, cid) -> (path, cid) :: acc
+              | Child c -> collect_available c acc)
+            acc (get_entries t)
+        with Verify_error _ -> acc)
+
+  let walk_available (t : tree) : (string * Cid.t) list =
+    List.rev (collect_available t [])
+
+  let block_of_cid store cid =
+    match store_get store cid with
+    | Some data -> { Car.Car.cid; data }
+    | None -> fail ("MST missing block " ^ Cid.to_string cid)
+
+  (* Streamable CAR pre-order: this MST node, then each entry in node order
+     (left child, then for every leaf: record then right child).
+     https://atproto.com/specs/repository#streamable-car-block-ordering *)
+  let rec preorder_blocks ?(records = true) (t : tree) : Car.Car.block list =
+    let cid = root_cid t in
+    let node_block = block_of_cid t.store cid in
+    node_block
+    :: List.concat
+         (List.map
+            (function
+              | Child c -> preorder_blocks ~records c
+              | Value (_, rec_cid) -> (
+                  if not records then []
+                  else
+                    match store_get t.store rec_cid with
+                    | Some data -> [ { Car.Car.cid = rec_cid; data } ]
+                    | None -> []))
+            (get_entries t))
+
+  let collection_start (collection : string) = collection ^ "/"
+
+  (* Exclusive end of `collection/` — '/' (0x2F) + 1 = '0'. *)
+  let collection_end (collection : string) = collection ^ "0"
+
+  let collection_range (collection : string) : string * string =
+    (collection_start collection, collection_end collection)
+
+  let key_in_range ~start ~end_exclusive key =
+    String.compare key start >= 0 && String.compare key end_exclusive < 0
+
+  let rec subtree_key_bounds (t : tree) : (string * string) option =
+    let rec loop lo hi = function
+      | [] -> ( match (lo, hi) with Some a, Some b -> Some (a, b) | _ -> None)
+      | Value (k, _) :: rest ->
+          let lo = match lo with None -> Some k | Some a -> Some a in
+          loop lo (Some k) rest
+      | Child c :: rest -> (
+          match subtree_key_bounds c with
+          | None -> loop lo hi rest
+          | Some (a, b) ->
+              let lo = match lo with None -> Some a | Some x -> Some x in
+              loop lo (Some b) rest)
+    in
+    loop None None (get_entries t)
+
+  let ranges_overlap (a0, a1) (b0, b1) =
+    String.compare a0 b1 < 0 && String.compare b0 a1 < 0
+
+  let last_opt xs = match List.rev xs with hd :: _ -> Some hd | [] -> None
+
+  (* MST nodes proving every key in [start, end) plus the immediately
+     adjacent keys, plus in-range record blocks. *)
+  let range_blocks ~start ~end_exclusive ?(records = true) (t : tree) :
+      Car.Car.block list =
+    let walked = walk t in
+    let in_range =
+      List.filter (fun (k, _) -> key_in_range ~start ~end_exclusive k) walked
+    in
+    let left_adj =
+      walked
+      |> List.filter (fun (k, _) -> String.compare k start < 0)
+      |> last_opt
+    in
+    let right_adj =
+      List.find_opt (fun (k, _) -> String.compare k end_exclusive >= 0) walked
+    in
+    let needed =
+      List.map fst in_range
+      @ (match left_adj with Some (k, _) -> [ k ] | None -> [])
+      @ match right_adj with Some (k, _) -> [ k ] | None -> []
+    in
+    let rec collect (node : tree) : Car.Car.block list =
+      let this = block_of_cid node.store (root_cid node) in
+      let rec loop acc = function
+        | [] -> List.rev acc
+        | Child c :: rest ->
+            let keep =
+              match subtree_key_bounds c with
+              | None -> false
+              | Some (lo, hi) ->
+                  List.exists
+                    (fun k ->
+                      String.compare lo k <= 0 && String.compare k hi <= 0)
+                    needed
+                  || ranges_overlap (lo, hi ^ "\x00") (start, end_exclusive)
+            in
+            let acc = if keep then List.rev_append (collect c) acc else acc in
+            loop acc rest
+        | Value (k, rec_cid) :: rest ->
+            let acc =
+              if records && key_in_range ~start ~end_exclusive k then
+                match store_get node.store rec_cid with
+                | Some data -> { Car.Car.cid = rec_cid; data } :: acc
+                | None -> acc
+              else acc
+            in
+            loop acc rest
+      in
+      this :: loop [] (get_entries node)
+    in
+    collect t
+
+  let covering_proof (t : tree) (key : string) : Car.Car.block list =
+    range_blocks ~start:key ~end_exclusive:(key ^ "\x00") ~records:true t
+
+  (* Verify included MST nodes; missing children are allowed (partial proof). *)
+  let rec verify_tree_available ~(get_block : Cid.t -> string option)
+      ?(layer : int option) (root : Cid.t) : unit =
+    match get_block root with
+    | None -> ()
+    | Some data ->
+        let expected = Cid.create data in
+        if not (Cid.equal expected root) then
+          fail
+            (Printf.sprintf "MST CID mismatch: got %s expected %s"
+               (Cid.to_string expected) (Cid.to_string root));
+        let node = node_of_bytes data in
+        let items = verify_node ?expected_layer:layer node in
+        let this_layer =
+          match (layer, items) with
+          | Some l, _ -> l
+          | None, hd :: _ -> layer_for_key hd.key
+          | None, [] -> 0
+        in
+        let child_layer = this_layer - 1 in
+        let check_child = function
+          | None -> ()
+          | Some cid ->
+              if child_layer < 0 then fail "MST child below layer 0";
+              verify_tree_available ~get_block ~layer:child_layer cid
+        in
+        check_child node.left;
+        List.iter (fun r -> check_child r.right) items
+
+  type range_status = Complete | Incomplete of string
+
+  let rec range_completeness ~start ~end_exclusive
+      ~(get_block : Cid.t -> string option) ?(layer : int option) (root : Cid.t)
+      : range_status =
+    match get_block root with
+    | None ->
+        Incomplete
+          (Printf.sprintf "missing MST node %s in collection range"
+             (Cid.to_string root))
+    | Some data -> (
+        let node = node_of_bytes data in
+        let items = verify_node ?expected_layer:layer node in
+        let this_layer =
+          match (layer, items) with
+          | Some l, _ -> l
+          | None, hd :: _ -> layer_for_key hd.key
+          | None, [] -> 0
+        in
+        let child_layer = this_layer - 1 in
+        let check_child cid lo hi =
+          if ranges_overlap (lo, hi) (start, end_exclusive) then
+            if child_layer < 0 then Incomplete "MST child below layer 0"
+            else
+              range_completeness ~start ~end_exclusive ~get_block
+                ~layer:child_layer cid
+          else Complete
+        in
+        let left_status =
+          match node.left with
+          | None -> Complete
+          | Some cid ->
+              let first =
+                match items with hd :: _ -> hd.key | [] -> end_exclusive
+              in
+              check_child cid start first
+        in
+        let rec walk = function
+          | [] -> Complete
+          | hd :: rest -> (
+              let next_lo =
+                match rest with r :: _ -> r.key | [] -> end_exclusive
+              in
+              match hd.right with
+              | None -> walk rest
+              | Some cid -> (
+                  match check_child cid hd.key next_lo with
+                  | Incomplete _ as i -> i
+                  | Complete -> walk rest))
+        in
+        match left_status with Incomplete _ as i -> i | Complete -> walk items)
 
   let check_op (t : tree) (op : record_op) : unit =
     match op.action with

--- a/src/repo_sync.ml
+++ b/src/repo_sync.ml
@@ -60,7 +60,7 @@ module Repo_sync = struct
         ( String.sub path 0 i,
           String.sub path (i + 1) (String.length path - i - 1) )
 
-  let open_car (car : Car.t) : snapshot =
+  let open_car ?(complete = true) (car : Car.t) : snapshot =
     let commit_cid =
       match Car.root car with Some c -> c | None -> fail "CAR has no root"
     in
@@ -74,13 +74,19 @@ module Repo_sync = struct
       fail
         (Printf.sprintf "commit CID mismatch: root %s block %s"
            (Cid.to_string commit_cid) (Cid.to_string computed));
+    if not (Cid.is_blessed ~codec:Cid.Dag_cbor commit_cid) then
+      fail "commit CID is not a blessed dag-cbor SHA-256 CID";
     let commit = Mst.parse_repo_commit (Dag_cbor.decode block.data) in
     if commit.version <> 3 then
       fail (Printf.sprintf "unsupported repo commit version %d" commit.version);
     if not (Tid.is_valid commit.rev) then
       fail ("commit rev is not a TID: " ^ commit.rev);
+    if Tid.is_future commit.rev then
+      fail ("commit rev is in the future: " ^ commit.rev);
     let store = Mst.store_of_car car in
-    Mst.verify_tree ~get_block:(Mst.store_get store) commit.data;
+    if complete then
+      Mst.verify_tree ~get_block:(Mst.store_get store) commit.data
+    else Mst.verify_tree_available ~get_block:(Mst.store_get store) commit.data;
     let tree = Mst.tree_of_root store commit.data in
     {
       did = commit.did;
@@ -92,7 +98,8 @@ module Repo_sync = struct
       tree;
     }
 
-  let open_car_bytes (bytes : string) : snapshot = open_car (Car.parse bytes)
+  let open_car_bytes ?complete (bytes : string) : snapshot =
+    open_car ?complete (Car.parse bytes)
 
   let verify_snapshot ?(keys : string list option) (snap : snapshot) : unit =
     Mst.verify_tree
@@ -117,10 +124,176 @@ module Repo_sync = struct
         b.data
 
   let verify_record_proof ~(car : Car.t) ~(path : string) : Cid.t * string =
-    let snap = open_car car in
-    match Mst.get snap.tree path with
+    if not (Syntax.Syntax.is_valid_repo_path path) then
+      fail ("invalid repo path " ^ path);
+    (* getRecord proof CARs are partial (commit + MST path + record). *)
+    let snap = open_car ~complete:false car in
+    let store = Mst.store_of_car car in
+    match Mst.lookup ~get_block:(Mst.store_get store) snap.data path with
     | None -> fail ("record path not in MST: " ^ path)
     | Some cid -> (cid, record_block car cid)
+
+  let preorder_blocks (snap : snapshot) : Car.block list =
+    let commit_block =
+      match Car.find_block snap.car snap.commit_cid with
+      | Some b -> b
+      | None ->
+          {
+            Car.cid = snap.commit_cid;
+            data =
+              Mst.encode_repo_commit ~did:snap.did ~data:snap.data ~rev:snap.rev
+                ?prev:snap.commit.prev ?sig_:snap.commit.sig_ ();
+          }
+    in
+    commit_block :: Mst.preorder_blocks snap.tree
+
+  let is_preorder (snap : snapshot) : bool =
+    Car.follows_order
+      ~expected:(List.map (fun (b : Car.block) -> b.cid) (preorder_blocks snap))
+      (Car.block_cids snap.car)
+
+  let export_car (snap : snapshot) : Car.t =
+    let seen = Hashtbl.create 16 in
+    let blocks =
+      List.filter
+        (fun (b : Car.block) ->
+          let k = Cid.to_string b.cid in
+          if Hashtbl.mem seen k then false
+          else (
+            Hashtbl.add seen k ();
+            true))
+        (preorder_blocks snap)
+    in
+    { Car.roots = [ snap.commit_cid ]; blocks }
+
+  let export_car_bytes (snap : snapshot) : string = Car.encode (export_car snap)
+
+  let export_subset (snap : snapshot) ~(collections : string list) : Car.t =
+    if collections = [] then export_car snap
+    else
+      let commit_block =
+        match Car.find_block snap.car snap.commit_cid with
+        | Some b -> b
+        | None -> fail "commit block missing from snapshot"
+      in
+      let blocks =
+        List.concat
+          (List.map
+             (fun collection ->
+               let start, end_exclusive = Mst.collection_range collection in
+               Mst.range_blocks ~start ~end_exclusive snap.tree)
+             collections)
+      in
+      let all = commit_block :: blocks in
+      let expected =
+        Car.first_occurrences (List.map (fun (b : Car.block) -> b.cid) all)
+      in
+      {
+        Car.roots = [ snap.commit_cid ];
+        blocks =
+          List.filter_map
+            (fun cid ->
+              List.find_opt (fun (b : Car.block) -> Cid.equal b.cid cid) all)
+            expected;
+      }
+
+  let export_subset_bytes snap ~collections =
+    Car.encode (export_subset snap ~collections)
+
+  exception Not_preorder of string
+
+  (* Walk records by consuming blocks in streamable pre-order. Omitted child
+     CIDs (subset proofs) are skipped; an out-of-order present block fails. *)
+  let stream_walk (car : Car.t) : (string * Cid.t) list =
+    let by_cid = Hashtbl.create (List.length car.blocks) in
+    List.iter
+      (fun (b : Car.block) ->
+        let k = Cid.to_string b.cid in
+        if not (Hashtbl.mem by_cid k) then Hashtbl.add by_cid k b)
+      car.blocks;
+    let unused = Queue.create () in
+    List.iter (fun b -> Queue.add b unused) car.blocks;
+    let consumed = Hashtbl.create 16 in
+    let take (cid : Cid.t) : Car.block option =
+      let k = Cid.to_string cid in
+      if Hashtbl.mem consumed k then Hashtbl.find_opt by_cid k
+      else if not (Hashtbl.mem by_cid k) then None
+      else
+        let rec skip () =
+          if Queue.is_empty unused then
+            raise (Not_preorder ("expected " ^ Cid.to_string cid))
+          else
+            let next = Queue.take unused in
+            let nk = Cid.to_string next.cid in
+            if Hashtbl.mem consumed nk then skip ()
+            else if Cid.equal next.cid cid then (
+              Hashtbl.add consumed k ();
+              Some next)
+            else
+              raise
+                (Not_preorder
+                   (Printf.sprintf "pre-order expected %s got %s"
+                      (Cid.to_string cid) (Cid.to_string next.cid)))
+        in
+        skip ()
+    in
+    let commit_cid =
+      match Car.root car with Some c -> c | None -> fail "CAR has no root"
+    in
+    (match take commit_cid with
+    | None -> fail "commit block missing from CAR"
+    | Some _ -> ());
+    let commit_block =
+      match Hashtbl.find_opt by_cid (Cid.to_string commit_cid) with
+      | Some b -> b
+      | None -> fail "commit block missing from CAR"
+    in
+    let commit = Mst.parse_repo_commit (Dag_cbor.decode commit_block.data) in
+    let rec walk_node (cid : Cid.t) : (string * Cid.t) list =
+      match take cid with
+      | None -> []
+      | Some block ->
+          let node = Mst.node_of_bytes block.data in
+          let items = Mst.verify_node node in
+          let left =
+            match node.left with Some c -> walk_node c | None -> []
+          in
+          left
+          @ List.concat
+              (List.map
+                 (fun (r : Mst.reconstructed) ->
+                   (match take r.value with Some _ | None -> ());
+                   (r.key, r.value)
+                   :: (match r.right with Some c -> walk_node c | None -> []))
+                 items)
+    in
+    walk_node commit.data
+
+  let walk_car (car : Car.t) : (string * Cid.t) list =
+    try stream_walk car
+    with Not_preorder _ ->
+      let snap = open_car ~complete:false car in
+      Mst.walk_available snap.tree
+
+  let verify_subset ~(collections : string list) (car : Car.t) : snapshot =
+    let snap = open_car ~complete:false car in
+    let store = Mst.store_of_car car in
+    List.iter
+      (fun collection ->
+        let start, end_exclusive = Mst.collection_range collection in
+        (match
+           Mst.range_completeness ~start ~end_exclusive
+             ~get_block:(Mst.store_get store) snap.data
+         with
+        | Mst.Complete -> ()
+        | Mst.Incomplete msg -> fail ("subset proof incomplete: " ^ msg));
+        List.iter
+          (fun (path, cid) ->
+            if Mst.key_in_range ~start ~end_exclusive path then
+              ignore (record_block car cid))
+          (Mst.walk_available snap.tree))
+      collections;
+    snap
 
   let create_account ?(collections = []) ~did () : account =
     if not (Syntax.Syntax.is_valid_did did) then fail ("invalid did " ^ did);
@@ -313,6 +486,10 @@ module Repo_sync = struct
 
   let fetch_repo ?host ?session (did : string) : snapshot =
     open_car_bytes (Sync.get_repo ?host ?session did)
+
+  let fetch_repo_subset ?host ?session ~did ~collections () : Car.t =
+    let snap = fetch_repo ?host ?session did in
+    export_subset snap ~collections
 
   let fetch_record_proof ?host ?session ?commit ~did ~collection ~rkey () :
       Cid.t * string =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -300,6 +300,25 @@ module Syntax = struct
   let ensure_record_key s =
     if not (is_valid_record_key s) then fail ("invalid record key " ^ s)
 
+  (* Repo paths are exactly `collection/rkey` (no leading slash, two segments).
+     https://atproto.com/specs/repository#repository-paths *)
+  let split_repo_path (input : string) : (string * string) option =
+    match String.index_opt input '/' with
+    | None -> None
+    | Some i ->
+        let collection = String.sub input 0 i in
+        let rkey = String.sub input (i + 1) (String.length input - i - 1) in
+        if String.contains rkey '/' then None else Some (collection, rkey)
+
+  let is_valid_repo_path (input : string) : bool =
+    match split_repo_path input with
+    | None -> false
+    | Some (collection, rkey) ->
+        is_valid_nsid collection && is_valid_record_key rkey
+
+  let ensure_repo_path s =
+    if not (is_valid_repo_path s) then fail ("invalid repo path " ^ s)
+
   (* ---- at-identifier (handle or DID) ----------------------------------- *)
 
   let is_valid_at_identifier s = is_valid_did s || is_valid_handle s

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -76,4 +76,19 @@ module Tid = struct
   let now ?(clock_id = Random.int 1024) () : string =
     let us = Int64.of_float (Unix.gettimeofday () *. 1_000_000.) in
     create ~clock_id us
+
+  (* Sync spec: reject commit revs corresponding to a future timestamp
+     beyond a short clock-drift window (default 5 minutes). *)
+  let default_clock_skew_us = 300_000_000L
+
+  let is_future ?(now_us : int64 option) ?(skew_us = default_clock_skew_us)
+      (s : string) : bool =
+    if not (is_valid s) then false
+    else
+      let now =
+        match now_us with
+        | Some n -> n
+        | None -> Int64.of_float (Unix.gettimeofday () *. 1_000_000.)
+      in
+      Int64.compare (timestamp_us s) (Int64.add now skew_us) > 0
 end

--- a/test/test_car.ml
+++ b/test/test_car.ml
@@ -36,6 +36,29 @@ let test_dag_cbor_map _ =
         (Dag_cbor.as_text (Dag_cbor.require "name" fields))
   | _ -> OUnit2.assert_failure "expected DAG-CBOR map"
 
+let test_follows_order_and_reorder _ =
+  let a = Cid.of_digest ~codec:Cid.Raw (String.make 32 '\x0a') in
+  let b = Cid.of_digest ~codec:Cid.Raw (String.make 32 '\x0b') in
+  let c = Cid.of_digest ~codec:Cid.Raw (String.make 32 '\x0c') in
+  let car =
+    {
+      Car.roots = [ a ];
+      blocks =
+        [
+          { Car.cid = c; data = "c" };
+          { Car.cid = a; data = "a" };
+          { Car.cid = b; data = "b" };
+        ];
+    }
+  in
+  OUnit2.assert_bool "shuffled is not pre-order"
+    (not (Car.follows_order ~expected:[ a; b; c ] (Car.block_cids car)));
+  let ordered = Car.reorder ~expected:[ a; b; c ] car in
+  OUnit2.assert_bool "reorder matches"
+    (Car.follows_order ~expected:[ a; b; c ] (Car.block_cids ordered));
+  OUnit2.assert_equal [ "a"; "b"; "c" ]
+    (List.map (fun (b : Car.block) -> b.data) ordered.blocks)
+
 let test_dag_cbor_cid_tag _ =
   let cid = Cid.of_digest (String.make 32 '\x02') in
   let encoded = Dag_cbor.encode (Dag_cbor.Cid cid) in
@@ -49,6 +72,7 @@ let suite =
   >::: [
          "test_empty_car_roundtrip" >:: test_empty_car_roundtrip;
          "test_car_with_block" >:: test_car_with_block;
+         "test_follows_order_and_reorder" >:: test_follows_order_and_reorder;
          "test_dag_cbor_map" >:: test_dag_cbor_map;
          "test_dag_cbor_cid_tag" >:: test_dag_cbor_cid_tag;
        ]

--- a/test/test_cid.ml
+++ b/test/test_cid.ml
@@ -62,7 +62,16 @@ let test_blob_cid _ =
      with Failure _ -> true);
   let dag = Cid.create ~codec:Cid.Dag_cbor "{\"text\":\"hi\"}" in
   OUnit2.assert_bool "verify_block dag-cbor"
-    (Cid.equal dag (Cid.verify_block ~expected:dag "{\"text\":\"hi\"}"))
+    (Cid.equal dag (Cid.verify_block ~expected:dag "{\"text\":\"hi\"}"));
+  OUnit2.assert_bool "blessed dag-cbor" (Cid.is_blessed ~codec:Cid.Dag_cbor dag);
+  OUnit2.assert_bool "blessed raw blob" (Cid.is_blessed ~codec:Cid.Raw cid);
+  OUnit2.assert_bool "raw is not a dag-cbor link"
+    (not (Cid.is_blessed ~codec:Cid.Dag_cbor cid));
+  let other =
+    Cid.of_digest ~codec:(Cid.Other 0x55) ~hash_code:0x13
+      (String.make 32 '\x00')
+  in
+  OUnit2.assert_bool "unknown hash is not blessed" (not (Cid.is_blessed other))
 
 let suite =
   "cid"

--- a/test/test_firehose.ml
+++ b/test/test_firehose.ml
@@ -5,6 +5,7 @@ open Atproto.Firehose
 open Atproto.Websocket
 open Atproto.Mst
 open Atproto.Car
+open Atproto.Tid
 
 let test_subscribe_url _ =
   OUnit2.assert_equal
@@ -446,6 +447,55 @@ let test_subscribe_invert_live _ =
       with exn ->
         skip_if true ("subscribeRepos invert skipped: " ^ Printexc.to_string exn))
 
+let test_validate_limits _ =
+  let cid = Cid.of_digest (String.make 32 '\x03') in
+  let empty_car = { Car.roots = [ cid ]; blocks = [] } in
+  let base =
+    {
+      Firehose.seq = 1L;
+      rebase = false;
+      too_big = false;
+      repo = "did:plc:7iza6de2dwap2sbkpav7c6c6";
+      commit = cid;
+      rev = "3jzfcijpj2z2a";
+      since = None;
+      prev_data = None;
+      blocks = empty_car;
+      raw_blocks = String.make 16 'x';
+      ops =
+        [
+          {
+            Firehose.action = "create";
+            path = "app.bsky.feed.post/3jzfcijpj2z2a";
+            cid = Some cid;
+            prev = None;
+          };
+        ];
+      blobs = [];
+      time = "2024-01-01T00:00:00.000Z";
+    }
+  in
+  Firehose.validate_limits base;
+  OUnit2.assert_bool "bad path rejected"
+    (try
+       Firehose.validate_limits
+         { base with ops = [ { (List.hd base.ops) with path = "not-a-path" } ] };
+       false
+     with Failure _ -> true);
+  OUnit2.assert_bool "too many ops rejected"
+    (try
+       let op = List.hd base.ops in
+       Firehose.validate_limits
+         { base with ops = List.init (Firehose.max_ops + 1) (fun _ -> op) };
+       false
+     with Failure _ -> true);
+  OUnit2.assert_bool "future rev rejected"
+    (try
+       Firehose.validate_limits
+         { base with rev = Tid.create ~clock_id:0 9_000_000_000_000_000L };
+       false
+     with Failure _ -> true)
+
 let suite =
   "firehose"
   >::: [
@@ -470,6 +520,7 @@ let suite =
          "test_parse_wss_url" >:: test_parse_wss_url;
          "test_subscribe_live" >:: test_subscribe_live;
          "test_subscribe_invert_live" >:: test_subscribe_invert_live;
+         "test_validate_limits" >:: test_validate_limits;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_jetstream.ml
+++ b/test/test_jetstream.ml
@@ -400,6 +400,77 @@ let test_subscribe_live _ =
             OUnit2.assert_bool "decoded a Jetstream frame" true
       with exn -> skip_if true ("jetstream skipped: " ^ Printexc.to_string exn))
 
+let test_jss_header_and_columnar _ =
+  let open Jetstream.Jss in
+  let header =
+    {
+      checksum = 0L;
+      version = 1;
+      block_count = 1;
+      event_count = 1;
+      unique_did_count = 1;
+      min_seq = 1L;
+      max_seq = 1L;
+      min_witnessed_at = 1_700_000_000_000_000L;
+      max_witnessed_at = 1_700_000_000_000_001L;
+      footer_offset = 0L;
+      did_bloom_offset = 0L;
+      block_did_bloom_offset = 0L;
+      collection_index_offset = 0L;
+      block_index_offset = 0L;
+      sealed = false;
+    }
+  in
+  let encoded = encode_header header in
+  OUnit2.assert_equal ~printer:string_of_int 256 (String.length encoded);
+  let parsed = parse_header encoded in
+  OUnit2.assert_equal 1 parsed.version;
+  OUnit2.assert_equal 1 parsed.block_count;
+  OUnit2.assert_equal ~printer:Int64.to_string 1L parsed.min_seq;
+  OUnit2.assert_bool "unsealed" (not parsed.sealed);
+  let row =
+    {
+      seq = 42L;
+      witnessed_at = 1_700_000_000_000_000L;
+      indexed_at = 0L;
+      kind = Create;
+      collection = "app.bsky.feed.post";
+      did = "did:plc:7iza6de2dwap2sbkpav7c6c6";
+      rkey = "3jzfcijpj2z2a";
+      rev = "3jzfcijpj2z2a";
+      payload = "cbor";
+    }
+  in
+  let body = encode_columnar [ row ] in
+  let decoded = decode_columnar body in
+  OUnit2.assert_equal 1 (List.length decoded);
+  let got = List.hd decoded in
+  OUnit2.assert_equal ~printer:Int64.to_string 42L got.seq;
+  OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post" got.collection;
+  OUnit2.assert_equal ~printer:(fun x -> x) "cbor" got.payload;
+  (match row_to_event got with
+  | `Commit c ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "create" c.operation;
+      OUnit2.assert_equal ~printer:(fun x -> x) row.rkey c.rkey
+  | _ -> OUnit2.assert_failure "expected commit event");
+  let empty = decode_columnar (encode_columnar []) in
+  OUnit2.assert_equal 0 (List.length empty);
+  let framed =
+    let buf = Buffer.create 64 in
+    Buffer.add_string buf encoded;
+    let len = String.length body in
+    let len64 = Bytes.create 8 in
+    for i = 0 to 7 do
+      Bytes.set len64 i (Char.chr ((len lsr (8 * i)) land 0xff))
+    done;
+    Buffer.add_bytes buf len64;
+    Buffer.add_string buf body;
+    Buffer.contents buf
+  in
+  let walked = walk_frames framed in
+  OUnit2.assert_equal 1 (List.length walked);
+  OUnit2.assert_equal ~printer:Int64.to_string 42L (List.hd walked).seq
+
 let suite =
   "jetstream"
   >::: [
@@ -417,6 +488,7 @@ let suite =
          "test_replay_planner" >:: test_replay_planner;
          "test_snapshot_gated_live" >:: test_snapshot_gated_live;
          "test_subscribe_live" >:: test_subscribe_live;
+         "test_jss_header_and_columnar" >:: test_jss_header_and_columnar;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_mst.ml
+++ b/test/test_mst.ml
@@ -448,6 +448,26 @@ let test_cid_mismatch _ =
        false
      with Mst.Verify_error _ -> true)
 
+let test_collection_range_and_preorder _ =
+  let start, end_ = Mst.collection_range "app.bsky.feed.post" in
+  OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post/" start;
+  OUnit2.assert_equal ~printer:(fun x -> x) "app.bsky.feed.post0" end_;
+  OUnit2.assert_bool "post in range"
+    (Mst.key_in_range ~start ~end_exclusive:end_ "app.bsky.feed.post/aaa");
+  OUnit2.assert_bool "like out of range"
+    (not (Mst.key_in_range ~start ~end_exclusive:end_ "app.bsky.feed.like/bbb"));
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.feed.like/bbb" vb in
+  ignore (Mst.root_cid t);
+  let pre = Mst.preorder_blocks ~records:false t in
+  OUnit2.assert_bool "preorder starts with MST root"
+    (Cid.equal (List.hd pre).cid (Mst.root_cid t));
+  OUnit2.assert_bool "max entries is documented" (Mst.max_entries_per_node = 64)
+
 let suite =
   "mst"
   >::: [
@@ -469,6 +489,8 @@ let suite =
          "test_commit_sig_wrong_key_and_missing"
          >:: test_commit_sig_wrong_key_and_missing;
          "test_cid_mismatch" >:: test_cid_mismatch;
+         "test_collection_range_and_preorder"
+         >:: test_collection_range_and_preorder;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -249,6 +249,108 @@ let test_signed_snapshot _ =
       OUnit2.assert_equal `Valid
         (Mst.verify_commit_sig ~keys:[ key ] snap.commit)
 
+let test_preorder_export_and_stream _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.feed.like/bbb" vb in
+  let car =
+    car_of_tree ~did ~rev:"3jzfcijpj2z2a"
+      ~records:[ (va, "rec-a"); (vb, "rec-b") ]
+      t
+  in
+  let snap = Repo_sync.open_car car in
+  let exported = Repo_sync.export_car snap in
+  let again = Repo_sync.open_car exported in
+  OUnit2.assert_bool "exported commit"
+    (Cid.equal snap.commit_cid again.commit_cid);
+  OUnit2.assert_bool "exported is pre-order" (Repo_sync.is_preorder again);
+  let streamed = Repo_sync.stream_walk exported in
+  OUnit2.assert_equal
+    (List.sort String.compare (List.map fst (Repo_sync.walk snap)))
+    (List.sort String.compare (List.map fst streamed));
+  let shuffled = { exported with Car.blocks = List.rev exported.Car.blocks } in
+  if List.length shuffled.Car.blocks > 1 then
+    OUnit2.assert_bool "reversed is not pre-order"
+      (not
+         (Car.follows_order
+            ~expected:
+              (List.map
+                 (fun (b : Car.block) -> b.cid)
+                 (Repo_sync.preorder_blocks snap))
+            (Car.block_cids shuffled)));
+  let walked = Repo_sync.walk_car shuffled in
+  OUnit2.assert_equal 2 (List.length walked)
+
+let test_collection_subset_export _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.feed.like/bbb" vb in
+  let car =
+    car_of_tree ~did ~rev:"3jzfcijpj2z2a"
+      ~records:[ (va, "rec-a"); (vb, "rec-b") ]
+      t
+  in
+  let snap = Repo_sync.open_car car in
+  let subset =
+    Repo_sync.export_subset snap ~collections:[ "app.bsky.feed.post" ]
+  in
+  let proven =
+    Repo_sync.verify_subset ~collections:[ "app.bsky.feed.post" ] subset
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) did proven.did;
+  let paths =
+    List.map fst
+      (List.filter
+         (fun (p, _) ->
+           Mst.key_in_range
+             ~start:(Mst.collection_start "app.bsky.feed.post")
+             ~end_exclusive:(Mst.collection_end "app.bsky.feed.post")
+             p)
+         (Mst.walk_available proven.tree))
+  in
+  OUnit2.assert_equal [ "app.bsky.feed.post/aaa" ] paths;
+  let cid, bytes =
+    Repo_sync.verify_record_proof ~car:subset ~path:"app.bsky.feed.post/aaa"
+  in
+  OUnit2.assert_bool "subset proof cid" (Cid.equal cid va);
+  OUnit2.assert_equal ~printer:(fun x -> x) "rec-a" bytes;
+  OUnit2.assert_bool "like record omitted from subset"
+    (match Car.find_block subset vb with None -> true | Some _ -> false)
+
+let test_partial_getrecord_proof _ =
+  let store = Mst.store_of_get (fun _ -> None) in
+  let t = Mst.empty_tree store in
+  let va = Cid.create ~codec:Cid.Raw "rec-a" in
+  let vb = Cid.create ~codec:Cid.Raw "rec-b" in
+  let t, _ = Mst.insert t "app.bsky.feed.post/aaa" va in
+  let t, _ = Mst.insert t "app.bsky.graph.follow/ccc" vb in
+  let full =
+    car_of_tree ~did ~rev:"3jzfcijpj2z2a"
+      ~records:[ (va, "rec-a"); (vb, "rec-b") ]
+      t
+  in
+  let snap = Repo_sync.open_car full in
+  let proof_blocks = Mst.covering_proof snap.tree "app.bsky.feed.post/aaa" in
+  let commit =
+    match Car.find_block full snap.commit_cid with
+    | Some b -> b
+    | None -> OUnit2.assert_failure "commit"
+  in
+  let proof_car =
+    { Car.roots = [ snap.commit_cid ]; blocks = commit :: proof_blocks }
+  in
+  let cid, bytes =
+    Repo_sync.verify_record_proof ~car:proof_car ~path:"app.bsky.feed.post/aaa"
+  in
+  OUnit2.assert_bool "partial proof" (Cid.equal cid va);
+  OUnit2.assert_equal ~printer:(fun x -> x) "rec-a" bytes
+
 let test_split_path _ =
   OUnit2.assert_equal
     ("app.bsky.feed.post", "3jzfcijpj2z2a")
@@ -267,6 +369,9 @@ let suite =
          "test_apply_commit_tree" >:: test_apply_commit_tree;
          "test_signed_snapshot" >:: test_signed_snapshot;
          "test_split_path" >:: test_split_path;
+         "test_preorder_export_and_stream" >:: test_preorder_export_and_stream;
+         "test_collection_subset_export" >:: test_collection_subset_export;
+         "test_partial_getrecord_proof" >:: test_partial_getrecord_proof;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -165,6 +165,23 @@ let test_record_key _ =
       ""; "."; ".."; "alpha/beta"; "#extra"; "@handle"; "any space"; "any+space";
     ]
 
+let test_repo_path _ =
+  OUnit2.assert_bool "valid path"
+    (Syntax.is_valid_repo_path "app.bsky.feed.post/3jzfcijpj2z2a");
+  OUnit2.assert_equal
+    (Some ("app.bsky.feed.post", "3jzfcijpj2z2a"))
+    (Syntax.split_repo_path "app.bsky.feed.post/3jzfcijpj2z2a");
+  List.iter
+    (fun p -> assert_bad p Syntax.is_valid_repo_path)
+    [
+      "nocollection";
+      "/app.bsky.feed.post/self";
+      "app.bsky.feed.post/self/extra";
+      "not-an-nsid/self";
+      "app.bsky.feed.post/";
+      "app.bsky.feed.post/.";
+    ]
+
 let test_at_identifier _ =
   OUnit2.assert_bool "handle" (Syntax.is_valid_at_identifier "jay.bsky.team");
   OUnit2.assert_bool "did"
@@ -251,6 +268,7 @@ let suite =
          "test_nsid_spec_examples" >:: test_nsid_spec_examples;
          "test_nsid_glob_and_ref" >:: test_nsid_glob_and_ref;
          "test_record_key" >:: test_record_key;
+         "test_repo_path" >:: test_repo_path;
          "test_at_identifier" >:: test_at_identifier;
          "test_datetime_spec_examples" >:: test_datetime_spec_examples;
          "test_language" >:: test_language;

--- a/test/test_tid.ml
+++ b/test/test_tid.ml
@@ -61,6 +61,17 @@ let test_now_is_valid _ =
   let tid = Tid.now ~clock_id:1 () in
   OUnit2.assert_bool tid (Tid.is_valid tid)
 
+let test_future_rev _ =
+  OUnit2.assert_bool "past TID is not future"
+    (not (Tid.is_future ~now_us:2_000_000_000_000_000L "3jzfcijpj2z2a"));
+  let future = Tid.create ~clock_id:0 9_000_000_000_000_000L in
+  OUnit2.assert_bool "far-future TID"
+    (Tid.is_future ~now_us:1_700_000_000_000_000L future);
+  OUnit2.assert_bool "within skew is accepted"
+    (not
+       (Tid.is_future ~now_us:1_700_000_000_000_000L ~skew_us:10_000_000L
+          (Tid.create ~clock_id:0 1_700_000_005_000_000L)))
+
 let suite =
   "tid"
   >::: [
@@ -71,6 +82,7 @@ let suite =
          "test_sorts_with_time" >:: test_sorts_with_time;
          "test_rejects_bad_syntax" >:: test_rejects_bad_syntax;
          "test_now_is_valid" >:: test_now_is_valid;
+         "test_future_rev" >:: test_future_rev;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks the next hard protocol slice on **#76** (`cursor/atproto-service-auth-repo-sync-d245`). New branch — does **not** push to PR 76.

## What this adds

### Sync 1.1 streamable CAR order (`Car`, `Mst`, `Repo_sync`)
Per the current [repository spec](https://atproto.com/specs/repository#streamable-car-block-ordering):

- Commit block first, then MST nodes in pre-order with interleaved records
- `Mst.preorder_blocks` / `Repo_sync.export_car` emit that order (deduped)
- `Car.follows_order` / `Repo_sync.is_preorder` detect it
- `Repo_sync.stream_walk` consumes a pre-order CAR; `walk_car` falls back on arbitrary order (parsers must still tolerate that)

The spec still says producers *should* emit this order and parsers *must* accept any order. This library now does both.

### Collection-subset exports
Official `com.atproto.sync.getRepo` lexicon still has only `did` + `since`. The [sync 1.1 proposal](https://github.com/bluesky-social/proposals/blob/main/0006-sync-iteration/README.md) algorithm is implemented locally:

- `Mst.collection_range` / `range_blocks` / `range_completeness` — MST nodes proving `[collection/, collection0)` plus adjacent keys
- `Repo_sync.export_subset` / `verify_subset` — verifiable subset CAR from a full snapshot
- `verify_record_proof` now works on **partial** getRecord proof CARs (commit + path + record), not only full trees
- `fetch_repo_subset` subsets after a full `getRepo` (no invented `collection` query param against current PDS)

### Jetstream `.jss` v1 decode (`Jetstream.Jss`)
Public spec: [jss-format-v1.md](https://tangled.org/zat.dev/stream/blob/main/docs/jss-format-v1.md) (from `bluesky-social/jetstream` segment format).

- Header (magic `jss0`, little-endian fields, sealed vs active)
- Block-index entries (52 bytes)
- Columnar block encode/decode + `row_to_event`
- Sequential frame walk; zstd via an injected `decompress` callback (no new compression dependency, no archive token)

### Other protocol holes vs current specs
- `Cid.is_blessed` — CIDv1 + sha2-256 + dag-cbor/raw
- MST child links must be blessed dag-cbor; `max_entries_per_node = 64`
- `Syntax.is_valid_repo_path` — exactly `collection/rkey`
- `Tid.is_future` — reject commit revs beyond a 5-minute skew
- `Firehose.validate_limits` — 2e6 block bytes, 1e6 per block, 200 ops, repo paths, future rev
- `#commit` CAR root must be the commit CID

## Tests
`dune build` and `dune runtest` pass. Action majors unchanged (`checkout@v4`, `setup-ocaml@v3`, `cache@v4`, `upload-artifact@v4`).

## Leftovers (product-level / no stable wire)
- Hosted OAuth client-metadata + live browser login
- Hosted PDS / Tap / video transcoder / Ozone operator session
- Live Jetstream archive **download** (still gated; no invented token). `.jss` decode is local; zstd is not vendored
- Official lexicon `collection` on `getRepo` (library-side subset exists; sending an unknown query param would break current PDS)
- Permissioned data / spaces / LtHash (no stable public spec)
- JSS xxh3 header checksum + gloom blooms (optional accelerators; not required to iterate events)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6d9f189-1278-4579-9029-7a6d2ec14f0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6d9f189-1278-4579-9029-7a6d2ec14f0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

