### PR TITLE
Current-lexicon embed, record, notification, chat, and ozone clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` with `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
-| Ozone | `Ozone` | `tools.ozone.moderation.*` + `getConfig`; requires `atproto-proxy` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including reactions, requests, leave/accept, log, unread counts, batch send, `updateAllRead`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Ozone | `Ozone` | `tools.ozone.moderation.*` including subjects/repos/records, account timeline, reporter stats, scheduled actions + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
-| Repo writes | `Repo` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; `uploadBlob` parse |
+| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/profile |
 | Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` (aud may be `did#service`) |
-| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + updateHandle / PLC operation helpers |
+| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` DID document + updateHandle / PLC operation helpers |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
 | CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1, blessed CID check, Sync 1.1 streamable pre-order |
@@ -58,12 +58,12 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen, JSON validate |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
 | OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
-| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) |
+| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) + `#selfLabels` |
 | XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit; service-auth JWT mint/verify (ES256/ES256K, `kid`/`jti`/`iat`/`lxm`, `did#service` aud, replay cache) |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
-| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video; mention / link / tag |
-| Notifications | `Notification` | Unread count, list, updateSeen; unknown reasons parse as `` `Other `` |
+| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video, **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
+| Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef) |
 | Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
 | HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST, method enum |
@@ -78,7 +78,17 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encode/verify + collection-subset proofs, `.jss` v1 columnar decode, blessed CID / repo-path / firehose size+future-rev checks are in this slice. #70–#76 already landed identity/MST/OAuth-core/AppView/Ozone/Jetstream/video/service-auth.
+Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encode/verify + collection-subset proofs, `.jss` v1 columnar decode, blessed CID / repo-path / firehose size+future-rev checks landed in #70–#77. This slice adds current-lexicon AppView record/embed parsers (gallery + record views), typed repo reads, Bluesky record builders, notification prefs/push, and remaining chat/ozone XRPC clients.
+
+Still thin vs current lexicons (library leftovers, not product work):
+
+- Feed thread types remain the original (sometimes inaccurate) shapes; `post` / `thread_post` views still omit top-level embed
+- Chat message facets/reactions/attachments stay on `original` JSON; lock/unlock/group-admin convo methods are not wrapped
+- Ozone event/subject payloads remain `Yojson.Safe.t` (query/emit clients exist)
+- `Lexicon.to_ocaml` still emits unions as `Yojson.Safe.t`; no bundled official lexicon JSON
+- `Http_client` H2 stub and unused `Request`/`Response` types
+- `chat.bsky.notification.*` preference endpoints (moved off `app.bsky.notification` in 2026)
+- Graph list/starter-pack **record** builders beyond follow/block/listblock
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -102,6 +112,12 @@ let () = assert (Mst.layer_for_key "blue" = 1)
 
 (* TID used as record keys and commit revs *)
 let () = assert (Tid.is_valid "3jzfcijpj2z2a")
+
+(* typed Bluesky record builders + facet serialize *)
+let post =
+  Records.post ~text:"hello #atproto" ~created_at:"2024-01-01T00:00:00.000Z"
+    ~facets:[ Facet.tag ~byte_start:6 ~byte_end:14 "atproto" ]
+    ()
 
 (* OAuth client metadata + authorize URL (no hosted client required) *)
 let meta =

--- a/atproto.opam
+++ b/atproto.opam
@@ -51,7 +51,7 @@ Public modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video,
 Unspecced, Labeler, Chat, Ozone, Admin, Repo, Repo_sync, Server, Identity,
 Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
-Error, Syntax, Embed, Facet, Notification, and Moderation.
+Error, Syntax, Embed, Facet, Records, Notification, and Moderation.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -4,6 +4,9 @@
 open Atproto.Video
 open Atproto.Embed
 open Atproto.Facet
+open Atproto.Records
+open Atproto.Notification
+open Atproto.Identity
 open Atproto.Lexicon
 open Atproto.Tid
 open Atproto.Mst
@@ -83,6 +86,82 @@ let () =
         ])
   in
   (match facet with `Tag _ -> () | _ -> assert false);
+  let built = Facet.tag ~byte_start:0 ~byte_end:4 "atp" in
+  (match Facet.parse_facet (Facet.facet_to_json built) with
+  | `Tag t -> assert ((List.hd t.features).tag = "atp")
+  | _ -> assert false);
+  (match
+     Embed.parse_embed
+       (`Assoc
+         [
+           ("$type", `String "app.bsky.embed.gallery");
+           ( "items",
+             `List
+               [
+                 `Assoc
+                   [
+                     ("alt", `String "pic");
+                     ( "image",
+                       `Assoc
+                         [
+                           ("$type", `String "blob");
+                           ("ref", `Assoc [ ("$link", `String "bafyimage") ]);
+                           ("mimeType", `String "image/png");
+                           ("size", `Int 4);
+                         ] );
+                   ];
+               ] );
+         ])
+   with
+  | `Gallery g -> assert (List.length g.items = 1)
+  | _ -> assert false);
+  let post =
+    Records.post ~text:"hello" ~created_at:"2024-01-01T00:00:00.000Z"
+      ~tags:[ "atp" ] ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" post with
+    | `String "app.bsky.feed.post" -> true
+    | _ -> false);
+  (match
+     Notification.parse_record
+       (`Assoc
+         [
+           ("$type", `String "app.bsky.feed.post");
+           ("text", `String "quote");
+           ("createdAt", `String "2024-01-01T00:00:00.000Z");
+         ])
+       "quote"
+   with
+  | `Quote q -> assert (q.text = "quote")
+  | _ -> assert false);
+  let did_res =
+    Identity.parse_did_resolution
+      (`Assoc
+        [
+          ( "didDoc",
+            `Assoc
+              [
+                ("id", `String "did:plc:abc123xyz0001112223333");
+                ("alsoKnownAs", `List []);
+                ("verificationMethod", `List []);
+                ("service", `List []);
+              ] );
+        ])
+  in
+  (match did_res.document with
+  | Some doc -> assert (doc.id = "did:plc:abc123xyz0001112223333")
+  | None -> assert false);
+  let rec_get =
+    Repo.parse_record_get
+      (`Assoc
+        [
+          ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3jzfcijpj2z2a");
+          ("cid", `String "bafyreihdummy");
+          ("value", post);
+        ])
+  in
+  assert (String.length rec_get.uri > 8);
   let lex =
     Lexicon.of_string
       {|{"lexicon":1,"id":"com.example.ping","defs":{"main":{"type":"query","parameters":{"type":"params","properties":{}}}}}|}

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -156,7 +156,10 @@ let () =
     Repo.parse_record_get
       (`Assoc
         [
-          ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3jzfcijpj2z2a");
+          ( "uri",
+            `String
+              "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3jzfcijpj2z2a"
+          );
           ("cid", `String "bafyreihdummy");
           ("value", post);
         ])

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -69,30 +69,98 @@ module Embed = struct
     aspect_ratio : aspect_ratio option;
   }
 
-  type media =
+  type gallery_image = {
+    image : image;
+    alt : string;
+    aspect_ratio : aspect_ratio option;
+  }
+
+  type gallery_embed = { embed_type : string; items : gallery_image list }
+
+  type gallery_view_image = {
+    thumbnail : string;
+    fullsize : string;
+    alt : string;
+    aspect_ratio : aspect_ratio option;
+  }
+
+  type gallery_view_embed = {
+    embed_type : string;
+    items : gallery_view_image list;
+  }
+
+  type view_record = {
+    uri : string;
+    cid : string;
+    author_did : string option;
+    author_handle : string option;
+    value : Yojson.Safe.t;
+    labels : string list option;
+    reply_count : int option;
+    repost_count : int option;
+    like_count : int option;
+    quote_count : int option;
+    embeds : embed list;
+    indexed_at : string;
+  }
+
+  and record_view_union =
+    [ `ViewRecord of view_record
+    | `ViewNotFound of { uri : string; not_found : bool }
+    | `ViewBlocked of {
+        uri : string;
+        blocked : bool;
+        author_did : string option;
+      }
+    | `ViewDetached of { uri : string; detached : bool }
+    | `NamedView of {
+        type_ : string;
+        uri : string;
+        cid : string;
+        original : Yojson.Safe.t;
+      }
+    | `Unknown of Yojson.Safe.t ]
+
+  and record_view_embed = {
+    embed_type : string;
+    record : record_view_union;
+  }
+
+  and media =
     [ `Image of image_embed
     | `ImageView of image_view_embed
     | `External of ext_embed
     | `ExternalView of ext_view_embed
     | `Video of video_embed
-    | `VideoView of video_view_embed ]
+    | `VideoView of video_view_embed
+    | `Gallery of gallery_embed
+    | `GalleryView of gallery_view_embed ]
 
-  type record_with_media = {
+  and record_with_media = {
     embed_type : string;
     record : record_embed;
     media : media;
   }
 
-  type embed =
+  and embed =
     [ `Image of image_embed
     | `ImageView of image_view_embed
     | `External of ext_embed
     | `ExternalView of ext_view_embed
     | `Record of record_embed
+    | `RecordView of record_view_embed
     | `RecordWithMedia of record_with_media
     | `Video of video_embed
     | `VideoView of video_view_embed
+    | `Gallery of gallery_embed
+    | `GalleryView of gallery_view_embed
     | `Unknown of Yojson.Safe.t ]
+
+  type embed_external_view = {
+    view : ext_view_embed option;
+    associated_refs : strong_ref list;
+    associated_records : Yojson.Safe.t list;
+  }
 
   let string_member json field =
     match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
@@ -283,6 +351,59 @@ module Embed = struct
       `VideoView (parse_video_view_embed json)
     else `Video (parse_video_embed json)
 
+  let parse_gallery_image json : gallery_image =
+    let open Yojson.Safe.Util in
+    {
+      image = json |> member "image" |> parse_image;
+      alt = string_member json "alt";
+      aspect_ratio = parse_aspect_ratio (json |> member "aspectRatio");
+    }
+
+  let parse_gallery_view_image json : gallery_view_image =
+    let open Yojson.Safe.Util in
+    {
+      thumbnail = string_member json "thumbnail";
+      fullsize = string_member json "fullsize";
+      alt = string_member json "alt";
+      aspect_ratio = parse_aspect_ratio (json |> member "aspectRatio");
+    }
+
+  let parse_gallery_embed json : gallery_embed =
+    let open Yojson.Safe.Util in
+    {
+      embed_type = string_member json "$type";
+      items =
+        (match json |> member "items" with
+        | `List xs -> List.map parse_gallery_image xs
+        | _ -> []);
+    }
+
+  let parse_gallery_view_embed json : gallery_view_embed =
+    let open Yojson.Safe.Util in
+    {
+      embed_type = string_member json "$type";
+      items =
+        (match json |> member "items" with
+        | `List xs -> List.map parse_gallery_view_image xs
+        | _ -> []);
+    }
+
+  let parse_to_correct_gallery_type json =
+    let open Yojson.Safe.Util in
+    match json |> member "items" with
+    | `List (hd :: _) ->
+        if check_for_field "image" hd then `Gallery (parse_gallery_embed json)
+        else `GalleryView (parse_gallery_view_embed json)
+    | _ ->
+        let typ = string_member json "$type" in
+        if typ = "app.bsky.embed.gallery#view" then
+          `GalleryView (parse_gallery_view_embed json)
+        else `Gallery (parse_gallery_embed json)
+
+  let type_suffix suffix typ =
+    let n = String.length suffix in
+    String.length typ >= n && String.sub typ (String.length typ - n) n = suffix
+
   let rec parse_media json : media =
     match parse_embed json with
     | `Image e -> `Image e
@@ -291,6 +412,8 @@ module Embed = struct
     | `ExternalView e -> `ExternalView e
     | `Video e -> `Video e
     | `VideoView e -> `VideoView e
+    | `Gallery e -> `Gallery e
+    | `GalleryView e -> `GalleryView e
     | _ -> `External (parse_ext_embed json)
 
   and parse_record_with_media json : record_with_media =
@@ -299,6 +422,95 @@ module Embed = struct
       embed_type = string_member json "$type";
       record = parse_record_embed json;
       media = parse_media (json |> member "media");
+    }
+
+  and parse_view_record json : view_record =
+    let open Yojson.Safe.Util in
+    let author = json |> member "author" in
+    {
+      uri = string_member json "uri";
+      cid = string_member json "cid";
+      author_did = string_opt author "did";
+      author_handle = string_opt author "handle";
+      value = json |> member "value";
+      labels = Label.Label.parse_label_values (json |> member "labels");
+      reply_count =
+        (match json |> member "replyCount" with `Int n -> Some n | _ -> None);
+      repost_count =
+        (match json |> member "repostCount" with `Int n -> Some n | _ -> None);
+      like_count =
+        (match json |> member "likeCount" with `Int n -> Some n | _ -> None);
+      quote_count =
+        (match json |> member "quoteCount" with `Int n -> Some n | _ -> None);
+      embeds =
+        (match json |> member "embeds" with
+        | `List xs -> List.map parse_embed xs
+        | _ -> []);
+      indexed_at = string_member json "indexedAt";
+    }
+
+  and parse_record_view_union json : record_view_union =
+    let typ = string_member json "$type" in
+    if
+      typ = "app.bsky.embed.record#viewRecord" || type_suffix "#viewRecord" typ
+    then `ViewRecord (parse_view_record json)
+    else if
+      typ = "app.bsky.embed.record#viewNotFound"
+      || type_suffix "#viewNotFound" typ
+    then
+      `ViewNotFound
+        { uri = string_member json "uri"; not_found = true }
+    else if
+      typ = "app.bsky.embed.record#viewBlocked"
+      || type_suffix "#viewBlocked" typ
+    then
+      let author_did =
+        match Yojson.Safe.Util.member "author" json with
+        | `Assoc _ as a -> string_opt a "did"
+        | _ -> None
+      in
+      `ViewBlocked
+        { uri = string_member json "uri"; blocked = true; author_did }
+    else if
+      typ = "app.bsky.embed.record#viewDetached"
+      || type_suffix "#viewDetached" typ
+    then
+      `ViewDetached { uri = string_member json "uri"; detached = true }
+    else if
+      type_suffix "#generatorView" typ
+      || type_suffix "#listView" typ
+      || type_suffix "#labelerView" typ
+      || type_suffix "#starterPackViewBasic" typ
+      || type_suffix "#starterPackView" typ
+    then
+      `NamedView
+        {
+          type_ = typ;
+          uri = string_member json "uri";
+          cid = string_member json "cid";
+          original = json;
+        }
+    else if check_for_field "notFound" json then
+      `ViewNotFound
+        { uri = string_member json "uri"; not_found = true }
+    else if check_for_field "blocked" json then
+      `ViewBlocked
+        {
+          uri = string_member json "uri";
+          blocked = true;
+          author_did = None;
+        }
+    else if check_for_field "detached" json then
+      `ViewDetached { uri = string_member json "uri"; detached = true }
+    else if check_for_field "value" json && check_for_field "uri" json then
+      `ViewRecord (parse_view_record json)
+    else `Unknown json
+
+  and parse_record_view_embed json : record_view_embed =
+    let open Yojson.Safe.Util in
+    {
+      embed_type = string_member json "$type";
+      record = parse_record_view_union (json |> member "record");
     }
 
   and parse_embed json : embed =
@@ -312,6 +524,8 @@ module Embed = struct
       || typ = "app.bsky.embed.recordWithMedia#main"
       || typ = "app.bsky.embed.recordWithMedia#view"
     then `RecordWithMedia (parse_record_with_media json)
+    else if typ = "app.bsky.embed.record#view" then
+      `RecordView (parse_record_view_embed json)
     else if typ = "app.bsky.embed.record" || typ = "app.bsky.embed.record#main"
     then `Record (parse_record_embed json)
     else if typ = "app.bsky.embed.images" || typ = "app.bsky.embed.images#main"
@@ -319,18 +533,32 @@ module Embed = struct
     else if typ = "app.bsky.embed.images#view" then
       `ImageView (parse_image_view_embed json)
     else if
+      typ = "app.bsky.embed.gallery" || typ = "app.bsky.embed.gallery#main"
+    then parse_to_correct_gallery_type json
+    else if typ = "app.bsky.embed.gallery#view" then
+      `GalleryView (parse_gallery_view_embed json)
+    else if
       typ = "app.bsky.embed.external" || typ = "app.bsky.embed.external#main"
     then parse_to_correct_external_type json
     else if typ = "app.bsky.embed.external#view" then
       `ExternalView (parse_ext_view_embed json)
     else if check_for_field "images" json then parse_to_correct_image_type json
+    else if check_for_field "items" json then parse_to_correct_gallery_type json
     else if check_for_field "external" json then
       parse_to_correct_external_type json
     else if check_for_field "video" json || check_for_field "playlist" json then
       parse_to_correct_video_type json
     else if check_for_field "record" json && check_for_field "media" json then
       `RecordWithMedia (parse_record_with_media json)
-    else if check_for_field "record" json then `Record (parse_record_embed json)
+    else if check_for_field "record" json then
+      let inner = Yojson.Safe.Util.member "record" json in
+      if
+        check_for_field "value" inner
+        || check_for_field "notFound" inner
+        || check_for_field "blocked" inner
+        || check_for_field "detached" inner
+      then `RecordView (parse_record_view_embed json)
+      else `Record (parse_record_embed json)
     else `Unknown json
 
   let parse_embed_option json : embed option =
@@ -339,4 +567,301 @@ module Embed = struct
     | `Null -> None
     | `Assoc _ as inner -> ( try Some (parse_embed inner) with _ -> None)
     | _ -> None
+
+  let blob_to_json ?(type_ = "blob") ~cid ~mime_type ~size () : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String type_);
+        ("ref", `Assoc [ ("$link", `String cid) ]);
+        ("mimeType", `String mime_type);
+        ("size", `Int size);
+      ]
+
+  let strong_ref_to_json (r : strong_ref) : Yojson.Safe.t =
+    `Assoc [ ("uri", `String r.uri); ("cid", `String r.cid) ]
+
+  let aspect_ratio_to_json (a : aspect_ratio) : Yojson.Safe.t =
+    `Assoc [ ("width", `Int a.width); ("height", `Int a.height) ]
+
+  let image_to_json (i : image) : Yojson.Safe.t =
+    blob_to_json
+      ~type_:(if i.image_type = "" then "blob" else i.image_type)
+      ~cid:i.ref.ref_link ~mime_type:i.mime_type ~size:i.size ()
+
+  let rec embed_to_json = function
+    | `Image e ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.images"
+                 else e.embed_type) );
+            ( "images",
+              `List
+                (List.map
+                   (fun (d : image_data) ->
+                     `Assoc
+                       [
+                         ("alt", `String d.alt);
+                         ("image", image_to_json d.image);
+                       ])
+                   e.images) );
+          ]
+    | `ImageView e ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.images#view");
+            ( "images",
+              `List
+                (List.map
+                   (fun (v : image_view) ->
+                     `Assoc
+                       [
+                         ("thumb", `String v.thumb);
+                         ("fullsize", `String v.fullsize);
+                         ("alt", `String v.alt);
+                       ])
+                   e.images) );
+          ]
+    | `External e ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.external"
+                 else e.embed_type) );
+            ( "external",
+              `Assoc
+                [
+                  ("uri", `String e.ext.uri);
+                  ("title", `String e.ext.title);
+                  ("description", `String e.ext.description);
+                  ( "thumb",
+                    blob_to_json
+                      ~type_:
+                        (if e.ext.thumb.thumb_type = "" then "blob"
+                         else e.ext.thumb.thumb_type)
+                      ~cid:e.ext.thumb.ref.ref_link
+                      ~mime_type:e.ext.thumb.mime_type ~size:e.ext.thumb.size
+                      () );
+                ] );
+          ]
+    | `ExternalView e ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.external#view");
+            ( "external",
+              `Assoc
+                [
+                  ("uri", `String e.ext.uri);
+                  ("title", `String e.ext.title);
+                  ("description", `String e.ext.description);
+                  ("thumb", `String e.ext.thumb);
+                ] );
+          ]
+    | `Record e ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.record"
+                 else e.embed_type) );
+            ("record", strong_ref_to_json e.record);
+          ]
+    | `RecordView e ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.record#view");
+            ("record", record_view_union_to_json e.record);
+          ]
+    | `RecordWithMedia e ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.recordWithMedia"
+                 else e.embed_type) );
+            ( "record",
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.embed.record");
+                  ("record", strong_ref_to_json e.record.record);
+                ] );
+            ("media", media_to_json e.media);
+          ]
+    | `Video e ->
+        let fields =
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.video"
+                 else e.embed_type) );
+            ( "video",
+              blob_to_json ~cid:e.video.cid ~mime_type:e.video.mime_type
+                ~size:e.video.size () );
+          ]
+          @ (match e.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+          @
+          match e.aspect_ratio with
+          | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+          | None -> []
+        in
+        `Assoc fields
+    | `VideoView e ->
+        let fields =
+          [
+            ("$type", `String "app.bsky.embed.video#view");
+            ("cid", `String e.cid);
+            ("playlist", `String e.playlist);
+          ]
+          @ (match e.thumbnail with
+            | Some t -> [ ("thumbnail", `String t) ]
+            | None -> [])
+          @ (match e.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+          @
+          match e.aspect_ratio with
+          | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+          | None -> []
+        in
+        `Assoc fields
+    | `Gallery e ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "app.bsky.embed.gallery"
+                 else e.embed_type) );
+            ( "items",
+              `List
+                (List.map
+                   (fun (item : gallery_image) ->
+                     let fields =
+                       [
+                         ("image", image_to_json item.image);
+                         ("alt", `String item.alt);
+                       ]
+                       @
+                       match item.aspect_ratio with
+                       | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+                       | None -> []
+                     in
+                     `Assoc fields)
+                   e.items) );
+          ]
+    | `GalleryView e ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.gallery#view");
+            ( "items",
+              `List
+                (List.map
+                   (fun (item : gallery_view_image) ->
+                     let fields =
+                       [
+                         ("thumbnail", `String item.thumbnail);
+                         ("fullsize", `String item.fullsize);
+                         ("alt", `String item.alt);
+                       ]
+                       @
+                       match item.aspect_ratio with
+                       | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+                       | None -> []
+                     in
+                     `Assoc fields)
+                   e.items) );
+          ]
+    | `Unknown json -> json
+
+  and media_to_json (m : media) : Yojson.Safe.t =
+    match m with
+    | `Image e -> embed_to_json (`Image e)
+    | `ImageView e -> embed_to_json (`ImageView e)
+    | `External e -> embed_to_json (`External e)
+    | `ExternalView e -> embed_to_json (`ExternalView e)
+    | `Video e -> embed_to_json (`Video e)
+    | `VideoView e -> embed_to_json (`VideoView e)
+    | `Gallery e -> embed_to_json (`Gallery e)
+    | `GalleryView e -> embed_to_json (`GalleryView e)
+
+  and record_view_union_to_json = function
+    | `ViewRecord v ->
+        let fields =
+          [
+            ("$type", `String "app.bsky.embed.record#viewRecord");
+            ("uri", `String v.uri);
+            ("cid", `String v.cid);
+            ("value", v.value);
+            ("indexedAt", `String v.indexed_at);
+          ]
+          @ (match v.author_did with
+            | Some did ->
+                [
+                  ( "author",
+                    `Assoc
+                      ([ ("did", `String did) ]
+                      @
+                      match v.author_handle with
+                      | Some h -> [ ("handle", `String h) ]
+                      | None -> []) );
+                ]
+            | None -> [])
+          @
+          match v.embeds with
+          | [] -> []
+          | xs -> [ ("embeds", `List (List.map embed_to_json xs)) ]
+        in
+        `Assoc fields
+    | `ViewNotFound { uri; _ } ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.record#viewNotFound");
+            ("uri", `String uri);
+            ("notFound", `Bool true);
+          ]
+    | `ViewBlocked { uri; author_did; _ } ->
+        let fields =
+          [
+            ("$type", `String "app.bsky.embed.record#viewBlocked");
+            ("uri", `String uri);
+            ("blocked", `Bool true);
+          ]
+          @
+          match author_did with
+          | Some did ->
+              [ ("author", `Assoc [ ("did", `String did) ]) ]
+          | None -> []
+        in
+        `Assoc fields
+    | `ViewDetached { uri; _ } ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.embed.record#viewDetached");
+            ("uri", `String uri);
+            ("detached", `Bool true);
+          ]
+    | `NamedView { original; _ } -> original
+    | `Unknown json -> json
+
+  let parse_embed_external_view json : embed_external_view =
+    let open Yojson.Safe.Util in
+    {
+      view =
+        (match json |> member "view" with
+        | `Assoc _ as v -> Some (parse_ext_view_embed v)
+        | _ -> None);
+      associated_refs =
+        (match json |> member "associatedRefs" with
+        | `List xs -> List.map parse_strong_ref xs
+        | _ -> []);
+      associated_records =
+        (match json |> member "associatedRecords" with
+        | `List xs -> xs
+        | _ -> []);
+    }
+
+  let get_embed_external_view ?session ?host ~url ~uris () :
+      embed_external_view =
+    Client.Client.get_json ?session ?host "app.bsky.embed.getEmbedExternalView"
+      (("url", url) :: Client.Client.repeat_param "uris" uris)
+    |> parse_embed_external_view
 end

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -89,6 +89,39 @@ module Embed = struct
     items : gallery_view_image list;
   }
 
+  type view_not_found = { uri : string; not_found : bool }
+
+  type view_blocked = {
+    uri : string;
+    blocked : bool;
+    author_did : string option;
+  }
+
+  type view_detached = { uri : string; detached : bool }
+
+  type named_view = {
+    type_ : string;
+    uri : string;
+    cid : string;
+    original : Yojson.Safe.t;
+  }
+
+  type media =
+    [ `Image of image_embed
+    | `ImageView of image_view_embed
+    | `External of ext_embed
+    | `ExternalView of ext_view_embed
+    | `Video of video_embed
+    | `VideoView of video_view_embed
+    | `Gallery of gallery_embed
+    | `GalleryView of gallery_view_embed ]
+
+  type record_with_media = {
+    embed_type : string;
+    record : record_embed;
+    media : media;
+  }
+
   type view_record = {
     uri : string;
     cid : string;
@@ -106,41 +139,13 @@ module Embed = struct
 
   and record_view_union =
     [ `ViewRecord of view_record
-    | `ViewNotFound of { uri : string; not_found : bool }
-    | `ViewBlocked of {
-        uri : string;
-        blocked : bool;
-        author_did : string option;
-      }
-    | `ViewDetached of { uri : string; detached : bool }
-    | `NamedView of {
-        type_ : string;
-        uri : string;
-        cid : string;
-        original : Yojson.Safe.t;
-      }
+    | `ViewNotFound of view_not_found
+    | `ViewBlocked of view_blocked
+    | `ViewDetached of view_detached
+    | `NamedView of named_view
     | `Unknown of Yojson.Safe.t ]
 
-  and record_view_embed = {
-    embed_type : string;
-    record : record_view_union;
-  }
-
-  and media =
-    [ `Image of image_embed
-    | `ImageView of image_view_embed
-    | `External of ext_embed
-    | `ExternalView of ext_view_embed
-    | `Video of video_embed
-    | `VideoView of video_view_embed
-    | `Gallery of gallery_embed
-    | `GalleryView of gallery_view_embed ]
-
-  and record_with_media = {
-    embed_type : string;
-    record : record_embed;
-    media : media;
-  }
+  and record_view_embed = { embed_type : string; record : record_view_union }
 
   and embed =
     [ `Image of image_embed
@@ -451,15 +456,12 @@ module Embed = struct
 
   and parse_record_view_union json : record_view_union =
     let typ = string_member json "$type" in
-    if
-      typ = "app.bsky.embed.record#viewRecord" || type_suffix "#viewRecord" typ
+    if typ = "app.bsky.embed.record#viewRecord" || type_suffix "#viewRecord" typ
     then `ViewRecord (parse_view_record json)
     else if
       typ = "app.bsky.embed.record#viewNotFound"
       || type_suffix "#viewNotFound" typ
-    then
-      `ViewNotFound
-        { uri = string_member json "uri"; not_found = true }
+    then `ViewNotFound { uri = string_member json "uri"; not_found = true }
     else if
       typ = "app.bsky.embed.record#viewBlocked"
       || type_suffix "#viewBlocked" typ
@@ -474,8 +476,7 @@ module Embed = struct
     else if
       typ = "app.bsky.embed.record#viewDetached"
       || type_suffix "#viewDetached" typ
-    then
-      `ViewDetached { uri = string_member json "uri"; detached = true }
+    then `ViewDetached { uri = string_member json "uri"; detached = true }
     else if
       type_suffix "#generatorView" typ
       || type_suffix "#listView" typ
@@ -491,15 +492,10 @@ module Embed = struct
           original = json;
         }
     else if check_for_field "notFound" json then
-      `ViewNotFound
-        { uri = string_member json "uri"; not_found = true }
+      `ViewNotFound { uri = string_member json "uri"; not_found = true }
     else if check_for_field "blocked" json then
       `ViewBlocked
-        {
-          uri = string_member json "uri";
-          blocked = true;
-          author_did = None;
-        }
+        { uri = string_member json "uri"; blocked = true; author_did = None }
     else if check_for_field "detached" json then
       `ViewDetached { uri = string_member json "uri"; detached = true }
     else if check_for_field "value" json && check_for_field "uri" json then
@@ -589,7 +585,7 @@ module Embed = struct
       ~cid:i.ref.ref_link ~mime_type:i.mime_type ~size:i.size ()
 
   let rec embed_to_json = function
-    | `Image e ->
+    | `Image (e : image_embed) ->
         `Assoc
           [
             ( "$type",
@@ -602,12 +598,11 @@ module Embed = struct
                    (fun (d : image_data) ->
                      `Assoc
                        [
-                         ("alt", `String d.alt);
-                         ("image", image_to_json d.image);
+                         ("alt", `String d.alt); ("image", image_to_json d.image);
                        ])
                    e.images) );
           ]
-    | `ImageView e ->
+    | `ImageView (e : image_view_embed) ->
         `Assoc
           [
             ("$type", `String "app.bsky.embed.images#view");
@@ -623,7 +618,7 @@ module Embed = struct
                        ])
                    e.images) );
           ]
-    | `External e ->
+    | `External (e : ext_embed) ->
         `Assoc
           [
             ( "$type",
@@ -642,11 +637,11 @@ module Embed = struct
                         (if e.ext.thumb.thumb_type = "" then "blob"
                          else e.ext.thumb.thumb_type)
                       ~cid:e.ext.thumb.ref.ref_link
-                      ~mime_type:e.ext.thumb.mime_type ~size:e.ext.thumb.size
-                      () );
+                      ~mime_type:e.ext.thumb.mime_type ~size:e.ext.thumb.size ()
+                  );
                 ] );
           ]
-    | `ExternalView e ->
+    | `ExternalView (e : ext_view_embed) ->
         `Assoc
           [
             ("$type", `String "app.bsky.embed.external#view");
@@ -659,7 +654,7 @@ module Embed = struct
                   ("thumb", `String e.ext.thumb);
                 ] );
           ]
-    | `Record e ->
+    | `Record (e : record_embed) ->
         `Assoc
           [
             ( "$type",
@@ -668,13 +663,13 @@ module Embed = struct
                  else e.embed_type) );
             ("record", strong_ref_to_json e.record);
           ]
-    | `RecordView e ->
+    | `RecordView (e : record_view_embed) ->
         `Assoc
           [
             ("$type", `String "app.bsky.embed.record#view");
             ("record", record_view_union_to_json e.record);
           ]
-    | `RecordWithMedia e ->
+    | `RecordWithMedia (e : record_with_media) ->
         `Assoc
           [
             ( "$type",
@@ -689,7 +684,7 @@ module Embed = struct
                 ] );
             ("media", media_to_json e.media);
           ]
-    | `Video e ->
+    | `Video (e : video_embed) ->
         let fields =
           [
             ( "$type",
@@ -707,7 +702,7 @@ module Embed = struct
           | None -> []
         in
         `Assoc fields
-    | `VideoView e ->
+    | `VideoView (e : video_view_embed) ->
         let fields =
           [
             ("$type", `String "app.bsky.embed.video#view");
@@ -724,7 +719,7 @@ module Embed = struct
           | None -> []
         in
         `Assoc fields
-    | `Gallery e ->
+    | `Gallery (e : gallery_embed) ->
         `Assoc
           [
             ( "$type",
@@ -748,7 +743,7 @@ module Embed = struct
                      `Assoc fields)
                    e.items) );
           ]
-    | `GalleryView e ->
+    | `GalleryView (e : gallery_view_embed) ->
         `Assoc
           [
             ("$type", `String "app.bsky.embed.gallery#view");
@@ -827,8 +822,7 @@ module Embed = struct
           ]
           @
           match author_did with
-          | Some did ->
-              [ ("author", `Assoc [ ("did", `String did) ]) ]
+          | Some did -> [ ("author", `Assoc [ ("did", `String did) ]) ]
           | None -> []
         in
         `Assoc fields
@@ -859,8 +853,8 @@ module Embed = struct
         | _ -> []);
     }
 
-  let get_embed_external_view ?session ?host ~url ~uris () :
-      embed_external_view =
+  let get_embed_external_view ?session ?host ~url ~uris () : embed_external_view
+      =
     Client.Client.get_json ?session ?host "app.bsky.embed.getEmbedExternalView"
       (("url", url) :: Client.Client.repeat_param "uris" uris)
     |> parse_embed_external_view

--- a/src/bsky/facet.ml
+++ b/src/bsky/facet.ml
@@ -103,8 +103,8 @@ module Facet = struct
       [
         ( "$type",
           `String
-            (if f.tag_type = "" then "app.bsky.richtext.facet#tag" else f.tag_type)
-        );
+            (if f.tag_type = "" then "app.bsky.richtext.facet#tag"
+             else f.tag_type) );
         ("tag", `String f.tag);
       ]
 
@@ -115,7 +115,9 @@ module Facet = struct
           [ ("index", index_to_json m.facet_index) ]
           @ (if m.facet_type = "" then []
              else [ ("$type", `String m.facet_type) ])
-          @ [ ("features", `List (List.map mention_feature_to_json m.features)) ]
+          @ [
+              ("features", `List (List.map mention_feature_to_json m.features));
+            ]
         in
         `Assoc fields
     | `Link l ->
@@ -139,8 +141,7 @@ module Facet = struct
       {
         facet_type = "";
         facet_index = { byte_start; byte_end };
-        features =
-          [ { did; mention_type = "app.bsky.richtext.facet#mention" } ];
+        features = [ { did; mention_type = "app.bsky.richtext.facet#mention" } ];
       }
 
   let link ~byte_start ~byte_end uri : facet =

--- a/src/bsky/facet.ml
+++ b/src/bsky/facet.ml
@@ -71,4 +71,90 @@ module Facet = struct
     else
       let features = List.map parse_link_feature features_json in
       `Link { facet_index; features }
+
+  let index_to_json (i : facet_index) : Yojson.Safe.t =
+    `Assoc [ ("byteStart", `Int i.byte_start); ("byteEnd", `Int i.byte_end) ]
+
+  let mention_feature_to_json (f : mention_feature) : Yojson.Safe.t =
+    `Assoc
+      [
+        ( "$type",
+          `String
+            (if f.mention_type = "" then "app.bsky.richtext.facet#mention"
+             else f.mention_type) );
+        ("did", `String f.did);
+      ]
+
+  let link_feature_to_json (f : link_feature) : Yojson.Safe.t =
+    let fields =
+      [
+        ( "$type",
+          `String
+            (if f.link_type = "" then "app.bsky.richtext.facet#link"
+             else f.link_type) );
+        ("uri", `String f.uri);
+      ]
+      @ if f.cid = "" then [] else [ ("cid", `String f.cid) ]
+    in
+    `Assoc fields
+
+  let tag_feature_to_json (f : tag_feature) : Yojson.Safe.t =
+    `Assoc
+      [
+        ( "$type",
+          `String
+            (if f.tag_type = "" then "app.bsky.richtext.facet#tag" else f.tag_type)
+        );
+        ("tag", `String f.tag);
+      ]
+
+  let facet_to_json (f : facet) : Yojson.Safe.t =
+    match f with
+    | `Mention m ->
+        let fields =
+          [ ("index", index_to_json m.facet_index) ]
+          @ (if m.facet_type = "" then []
+             else [ ("$type", `String m.facet_type) ])
+          @ [ ("features", `List (List.map mention_feature_to_json m.features)) ]
+        in
+        `Assoc fields
+    | `Link l ->
+        `Assoc
+          [
+            ("index", index_to_json l.facet_index);
+            ("features", `List (List.map link_feature_to_json l.features));
+          ]
+    | `Tag t ->
+        `Assoc
+          [
+            ("index", index_to_json t.facet_index);
+            ("features", `List (List.map tag_feature_to_json t.features));
+          ]
+
+  let facets_to_json (fs : facet list) : Yojson.Safe.t =
+    `List (List.map facet_to_json fs)
+
+  let mention ~byte_start ~byte_end did : facet =
+    `Mention
+      {
+        facet_type = "";
+        facet_index = { byte_start; byte_end };
+        features =
+          [ { did; mention_type = "app.bsky.richtext.facet#mention" } ];
+      }
+
+  let link ~byte_start ~byte_end uri : facet =
+    `Link
+      {
+        facet_index = { byte_start; byte_end };
+        features =
+          [ { uri; cid = ""; link_type = "app.bsky.richtext.facet#link" } ];
+      }
+
+  let tag ~byte_start ~byte_end tag : facet =
+    `Tag
+      {
+        facet_index = { byte_start; byte_end };
+        features = [ { tag; tag_type = "app.bsky.richtext.facet#tag" } ];
+      }
 end

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -4,6 +4,7 @@ open App
 open Actor
 open Notification
 open Facet
+open Embed
 
 module Feed = struct
   (* Authors feed comes with either "post" "post"+"reply" or "post"+"reason"
@@ -23,6 +24,9 @@ module Feed = struct
     record_type : string;
     langs : string list option;
     facets : Facet.facet list option;
+    embed : Embed.embed option;
+    tags : string list option;
+    self_labels : string list option;
     created_at : string;
   }
 
@@ -158,14 +162,25 @@ module Feed = struct
     try Some (json |> member "facets" |> to_list |> List.map Facet.parse_facet)
     with Type_error _ -> None
 
+  let extract_tags_option json : string list option =
+    let open Yojson.Safe.Util in
+    try Some (json |> member "tags" |> to_list |> List.map to_string)
+    with Type_error _ -> None
+
+  let extract_self_labels_option json : string list option =
+    Label.Label.parse_self_labels (Yojson.Safe.Util.member "labels" json)
+
   let parse_post_record json : post_record =
     let open Yojson.Safe.Util in
     let text = json |> member "text" |> to_string in
     let record_type = json |> member "$type" |> to_string in
     let langs = extract_langs_option json in
     let facets = extract_facets_option json in
+    let embed = Embed.parse_embed_option json in
+    let tags = extract_tags_option json in
+    let self_labels = extract_self_labels_option json in
     let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; langs; facets; created_at }
+    { text; record_type; langs; facets; embed; tags; self_labels; created_at }
 
   let parse_reply_record json : reply_record =
     let open Yojson.Safe.Util in
@@ -659,9 +674,12 @@ module Feed = struct
     author_did : string option;
     author_handle : string option;
     text : string option;
+    embed : Embed.embed option;
+    tags : string list option;
     indexed_at : string;
     reply_count : int option;
     like_count : int option;
+    quote_count : int option;
     original : Yojson.Safe.t;
   }
 
@@ -825,12 +843,19 @@ module Feed = struct
         (match author |> member "handle" with `String s -> Some s | _ -> None);
       text =
         (match record |> member "text" with `String s -> Some s | _ -> None);
+      embed =
+        (match Embed.parse_embed_option json with
+        | Some e -> Some e
+        | None -> Embed.parse_embed_option record);
+      tags = extract_tags_option record;
       indexed_at =
         (match json |> member "indexedAt" with `String s -> s | _ -> "");
       reply_count =
         (match json |> member "replyCount" with `Int n -> Some n | _ -> None);
       like_count =
         (match json |> member "likeCount" with `Int n -> Some n | _ -> None);
+      quote_count =
+        (match json |> member "quoteCount" with `Int n -> Some n | _ -> None);
       original = json;
     }
 

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -37,11 +37,47 @@ module Notification = struct
   type unread_count = { count : int }
   type other_record = { reason : string; raw : Yojson.Safe.t }
 
+  type quote_record = {
+    text : string;
+    record_type : string;
+    langs : string list;
+    embed : Embed.Embed.embed option;
+    created_at : string;
+  }
+
+  type mention_record = {
+    text : string;
+    record_type : string;
+    langs : string list;
+    created_at : string;
+  }
+
+  type starterpack_record = {
+    record_type : string;
+    created_at : string option;
+    raw : Yojson.Safe.t;
+  }
+
+  type verification_record = {
+    record_type : string;
+    created_at : string option;
+    raw : Yojson.Safe.t;
+  }
+
   type record =
     [ `Like of like_record
     | `Follow of follow_record
     | `Repost of repost_record
     | `Reply of reply_record
+    | `Quote of quote_record
+    | `Mention of mention_record
+    | `Starterpack_joined of starterpack_record
+    | `Verified of verification_record
+    | `Unverified of verification_record
+    | `Like_via_repost of like_record
+    | `Repost_via_repost of repost_record
+    | `Subscribed_post of mention_record
+    | `Contact_match of other_record
     | `Other of other_record ]
 
   type notification = {
@@ -54,6 +90,48 @@ module Notification = struct
     is_read : bool;
     indexed_at : string;
     labels : string list option;
+    starter_pack : Yojson.Safe.t option;
+  }
+
+  type notification_page = {
+    cursor : string option;
+    notifications : notification list;
+    priority : bool option;
+    seen_at : string option;
+  }
+
+  type chat_preference = { include_ : string; push : bool }
+
+  type filterable_preference = {
+    include_ : string;
+    list : bool;
+    push : bool;
+  }
+
+  type preference = { list : bool; push : bool }
+
+  type preferences = {
+    chat : chat_preference;
+    follow : filterable_preference;
+    like : filterable_preference;
+    like_via_repost : filterable_preference;
+    mention : filterable_preference;
+    quote : filterable_preference;
+    reply : filterable_preference;
+    repost : filterable_preference;
+    repost_via_repost : filterable_preference;
+    starterpack_joined : preference;
+    subscribed_post : preference;
+    unverified : preference;
+    verified : preference;
+    original : Yojson.Safe.t;
+  }
+
+  type activity_subscription = { post : bool; reply : bool }
+
+  type activity_subscription_page = {
+    cursor : string option;
+    subscriptions : Actor.short_profile list;
   }
 
   (*
@@ -93,35 +171,106 @@ module Notification = struct
     let open Yojson.Safe.Util in
     try Some (json |> member "reply" |> parse_reply) with Type_error _ -> None
 
+  let string_or_empty json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
+
+  let langs_of json =
+    match Yojson.Safe.Util.member "langs" json with
+    | `List items ->
+        List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> []
+
+  let parse_like_body json : like_record =
+    let open Yojson.Safe.Util in
+    {
+      record_type = string_or_empty json "$type";
+      subject = json |> member "subject" |> parse_strong_ref;
+      created_at = string_or_empty json "createdAt";
+    }
+
+  let parse_repost_body json : repost_record =
+    let open Yojson.Safe.Util in
+    {
+      record_type = string_or_empty json "$type";
+      subject = json |> member "subject" |> parse_strong_ref;
+      created_at = string_or_empty json "createdAt";
+    }
+
+  let parse_mention_body json : mention_record =
+    {
+      text = string_or_empty json "text";
+      record_type = string_or_empty json "$type";
+      langs = langs_of json;
+      created_at = string_or_empty json "createdAt";
+    }
+
   let parse_record json reason : record =
     let open Yojson.Safe.Util in
     match reason with
-    | "like" ->
-        let record_type = json |> member "$type" |> to_string in
-        let subject = json |> member "subject" |> parse_strong_ref in
-        let created_at = json |> member "createdAt" |> to_string in
-        `Like { record_type; subject; created_at }
+    | "like" -> `Like (parse_like_body json)
+    | "like-via-repost" -> `Like_via_repost (parse_like_body json)
     | "follow" ->
-        let record_type = json |> member "$type" |> to_string in
-        let subject = json |> member "subject" |> to_string in
-        let created_at = json |> member "createdAt" |> to_string in
-        `Follow { record_type; subject; created_at }
-    | "repost" ->
-        let record_type = json |> member "$type" |> to_string in
-        let subject = json |> member "subject" |> parse_strong_ref in
-        let created_at = json |> member "createdAt" |> to_string in
-        `Repost { record_type; subject; created_at }
+        `Follow
+          {
+            record_type = string_or_empty json "$type";
+            subject = string_or_empty json "subject";
+            created_at = string_or_empty json "createdAt";
+          }
+    | "repost" -> `Repost (parse_repost_body json)
+    | "repost-via-repost" -> `Repost_via_repost (parse_repost_body json)
     | "reply" ->
-        let text = json |> member "text" |> to_string in
-        let record_type = json |> member "$type" |> to_string in
-        let langs =
-          match json |> member "langs" with
-          | `List items -> List.map to_string items
-          | _ -> []
+        let text = string_or_empty json "text" in
+        let record_type = string_or_empty json "$type" in
+        let langs = langs_of json in
+        let reply =
+          try json |> member "reply" |> parse_reply
+          with Type_error _ ->
+            { root = { uri = ""; cid = "" }; parent = { uri = ""; cid = "" } }
         in
-        let reply = json |> member "reply" |> parse_reply in
-        let created_at = json |> member "createdAt" |> to_string in
+        let created_at = string_or_empty json "createdAt" in
         `Reply { text; record_type; langs; reply; created_at }
+    | "quote" ->
+        `Quote
+          {
+            text = string_or_empty json "text";
+            record_type = string_or_empty json "$type";
+            langs = langs_of json;
+            embed = Embed.Embed.parse_embed_option json;
+            created_at = string_or_empty json "createdAt";
+          }
+    | "mention" -> `Mention (parse_mention_body json)
+    | "subscribed-post" -> `Subscribed_post (parse_mention_body json)
+    | "starterpack-joined" ->
+        `Starterpack_joined
+          {
+            record_type = string_or_empty json "$type";
+            created_at =
+              (match json |> member "createdAt" with
+              | `String s -> Some s
+              | _ -> None);
+            raw = json;
+          }
+    | "verified" ->
+        `Verified
+          {
+            record_type = string_or_empty json "$type";
+            created_at =
+              (match json |> member "createdAt" with
+              | `String s -> Some s
+              | _ -> None);
+            raw = json;
+          }
+    | "unverified" ->
+        `Unverified
+          {
+            record_type = string_or_empty json "$type";
+            created_at =
+              (match json |> member "createdAt" with
+              | `String s -> Some s
+              | _ -> None);
+            raw = json;
+          }
+    | "contact-match" -> `Contact_match { reason; raw = json }
     | _ -> `Other { reason; raw = json }
 
   let parse_notification json : notification =
@@ -136,6 +285,11 @@ module Notification = struct
     let is_read = json |> member "isRead" |> to_bool in
     let indexed_at = json |> member "indexedAt" |> to_string in
     let labels = Label.Label.parse_label_values (json |> member "labels") in
+    let starter_pack =
+      match json |> member "starterPack" with
+      | `Null -> None
+      | other -> Some other
+    in
     {
       uri;
       cid;
@@ -146,6 +300,22 @@ module Notification = struct
       is_read;
       indexed_at;
       labels;
+      starter_pack;
+    }
+
+  let parse_notification_page json : notification_page =
+    let open Yojson.Safe.Util in
+    {
+      cursor =
+        (match json |> member "cursor" with `String s -> Some s | _ -> None);
+      notifications =
+        (match json |> member "notifications" with
+        | `List xs -> List.map parse_notification xs
+        | _ -> []);
+      priority =
+        (match json |> member "priority" with `Bool b -> Some b | _ -> None);
+      seen_at =
+        (match json |> member "seenAt" with `String s -> Some s | _ -> None);
     }
 
   let create_notification_endpoint (query_name : string) : string =
@@ -172,32 +342,26 @@ module Notification = struct
     in
     unread_count |> convert_body_to_json |> parse_unread_count
 
-  let list_notifications (s : Session.session) (limit : int) : notification list
-      =
-    let open Yojson.Safe.Util in
-    let bearer_token = Session.bearer_token_from_session s in
-    let application_json = Cohttp_client.application_json_setting_tuple in
-    let headers =
-      Cohttp_client.create_headers_from_pairs [ application_json; bearer_token ]
-    in
-    let base_url = App.create_base_url s in
-    let list_notifications_url =
-      App.create_endpoint_url base_url
-        (create_notification_endpoint "listNotifications")
-    in
-    let body =
-      Cohttp_client.create_body_from_pairs [ ("limit", string_of_int limit) ]
-    in
-    let notifications_req =
-      Lwt_main.run
-        (Cohttp_client.get_request_with_body_and_headers list_notifications_url
-           body headers)
-    in
-    let notification_list =
-      notifications_req |> convert_body_to_json |> member "notifications"
-      |> to_list
-    in
-    notification_list |> List.map parse_notification
+  let list_notifications (s : Session.session) ?reasons ?priority ?cursor
+      ?seen_at (limit : int) : notification list =
+    Client.Client.get_json ~session:s "app.bsky.notification.listNotifications"
+      (("limit", string_of_int limit)
+      :: Client.Client.repeat_param "reasons" (Option.value reasons ~default:[])
+      @ Client.Client.opt_bool "priority" priority
+      @ Client.Client.opt_pair "cursor" cursor
+      @ Client.Client.opt_pair "seenAt" seen_at)
+    |> parse_notification_page
+    |> fun (p : notification_page) -> p.notifications
+
+  let list_notifications_page (s : Session.session) ?reasons ?priority ?cursor
+      ?seen_at ?limit () : notification_page =
+    Client.Client.get_json ~session:s "app.bsky.notification.listNotifications"
+      (Client.Client.opt_int "limit" limit
+      @ Client.Client.repeat_param "reasons" (Option.value reasons ~default:[])
+      @ Client.Client.opt_bool "priority" priority
+      @ Client.Client.opt_pair "cursor" cursor
+      @ Client.Client.opt_pair "seenAt" seen_at)
+    |> parse_notification_page
 
   let update_seen (s : Session.session) (seen_at : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -216,4 +380,244 @@ module Notification = struct
         (Cohttp_client.post_data_with_headers get_update_seen_url data headers)
     in
     updated_seen
+
+  let parse_chat_preference json : chat_preference =
+    {
+      include_ =
+        (match Yojson.Safe.Util.member "include" json with
+        | `String s -> s
+        | _ -> "all");
+      push =
+        (match Yojson.Safe.Util.member "push" json with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let parse_filterable_preference json : filterable_preference =
+    {
+      include_ =
+        (match Yojson.Safe.Util.member "include" json with
+        | `String s -> s
+        | _ -> "all");
+      list =
+        (match Yojson.Safe.Util.member "list" json with
+        | `Bool b -> b
+        | _ -> false);
+      push =
+        (match Yojson.Safe.Util.member "push" json with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let parse_preference json : preference =
+    {
+      list =
+        (match Yojson.Safe.Util.member "list" json with
+        | `Bool b -> b
+        | _ -> false);
+      push =
+        (match Yojson.Safe.Util.member "push" json with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let empty_filterable : filterable_preference =
+    { include_ = "all"; list = false; push = false }
+
+  let empty_preference : preference = { list = false; push = false }
+
+  let parse_preferences json : preferences =
+    let open Yojson.Safe.Util in
+    let prefs =
+      match json |> member "preferences" with `Assoc _ as p -> p | _ -> json
+    in
+    {
+      chat =
+        (match prefs |> member "chat" with
+        | `Assoc _ as c -> parse_chat_preference c
+        | _ -> { include_ = "all"; push = false });
+      follow =
+        (match prefs |> member "follow" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      like =
+        (match prefs |> member "like" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      like_via_repost =
+        (match prefs |> member "likeViaRepost" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      mention =
+        (match prefs |> member "mention" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      quote =
+        (match prefs |> member "quote" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      reply =
+        (match prefs |> member "reply" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      repost =
+        (match prefs |> member "repost" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      repost_via_repost =
+        (match prefs |> member "repostViaRepost" with
+        | `Assoc _ as c -> parse_filterable_preference c
+        | _ -> empty_filterable);
+      starterpack_joined =
+        (match prefs |> member "starterpackJoined" with
+        | `Assoc _ as c -> parse_preference c
+        | _ -> empty_preference);
+      subscribed_post =
+        (match prefs |> member "subscribedPost" with
+        | `Assoc _ as c -> parse_preference c
+        | _ -> empty_preference);
+      unverified =
+        (match prefs |> member "unverified" with
+        | `Assoc _ as c -> parse_preference c
+        | _ -> empty_preference);
+      verified =
+        (match prefs |> member "verified" with
+        | `Assoc _ as c -> parse_preference c
+        | _ -> empty_preference);
+      original = prefs;
+    }
+
+  let filterable_to_json (p : filterable_preference) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("include", `String p.include_);
+        ("list", `Bool p.list);
+        ("push", `Bool p.push);
+      ]
+
+  let preference_to_json (p : preference) : Yojson.Safe.t =
+    `Assoc [ ("list", `Bool p.list); ("push", `Bool p.push) ]
+
+  let chat_preference_to_json (p : chat_preference) : Yojson.Safe.t =
+    `Assoc [ ("include", `String p.include_); ("push", `Bool p.push) ]
+
+  let preferences_to_json (p : preferences) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("chat", chat_preference_to_json p.chat);
+        ("follow", filterable_to_json p.follow);
+        ("like", filterable_to_json p.like);
+        ("likeViaRepost", filterable_to_json p.like_via_repost);
+        ("mention", filterable_to_json p.mention);
+        ("quote", filterable_to_json p.quote);
+        ("reply", filterable_to_json p.reply);
+        ("repost", filterable_to_json p.repost);
+        ("repostViaRepost", filterable_to_json p.repost_via_repost);
+        ("starterpackJoined", preference_to_json p.starterpack_joined);
+        ("subscribedPost", preference_to_json p.subscribed_post);
+        ("unverified", preference_to_json p.unverified);
+        ("verified", preference_to_json p.verified);
+      ]
+
+  let get_preferences (s : Session.session) : preferences =
+    Client.Client.get_json ~session:s "app.bsky.notification.getPreferences" []
+    |> parse_preferences
+
+  let put_preferences (s : Session.session) ~priority () : unit =
+    ignore
+      (Client.Client.post_json ~session:s "app.bsky.notification.putPreferences"
+         (Yojson.Safe.to_string (`Assoc [ ("priority", `Bool priority) ])))
+
+  let put_preferences_v2 (s : Session.session) (prefs : preferences) :
+      preferences =
+    Client.Client.post_json ~session:s "app.bsky.notification.putPreferencesV2"
+      (Yojson.Safe.to_string (preferences_to_json prefs))
+    |> parse_preferences
+
+  let parse_activity_subscription json : activity_subscription =
+    {
+      post =
+        (match Yojson.Safe.Util.member "post" json with
+        | `Bool b -> b
+        | _ -> false);
+      reply =
+        (match Yojson.Safe.Util.member "reply" json with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let activity_subscription_to_json (a : activity_subscription) : Yojson.Safe.t
+      =
+    `Assoc [ ("post", `Bool a.post); ("reply", `Bool a.reply) ]
+
+  let parse_activity_subscription_page json : activity_subscription_page =
+    let open Yojson.Safe.Util in
+    {
+      cursor =
+        (match json |> member "cursor" with `String s -> Some s | _ -> None);
+      subscriptions =
+        (match json |> member "subscriptions" with
+        | `List xs -> List.map Actor.parse_short_profile xs
+        | _ -> []);
+    }
+
+  let list_activity_subscriptions (s : Session.session) ?limit ?cursor () :
+      activity_subscription_page =
+    Client.Client.get_json ~session:s
+      "app.bsky.notification.listActivitySubscriptions"
+      (Client.Client.opt_int "limit" limit
+      @ Client.Client.opt_pair "cursor" cursor)
+    |> parse_activity_subscription_page
+
+  let put_activity_subscription (s : Session.session) ~subject
+      ~(activity_subscription : activity_subscription) () :
+      string * activity_subscription option =
+    let json =
+      Client.Client.post_json ~session:s
+        "app.bsky.notification.putActivitySubscription"
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("subject", `String subject);
+               ( "activitySubscription",
+                 activity_subscription_to_json activity_subscription );
+             ]))
+    in
+    let open Yojson.Safe.Util in
+    ( (match json |> member "subject" with `String s -> s | _ -> subject),
+      match json |> member "activitySubscription" with
+      | `Assoc _ as a -> Some (parse_activity_subscription a)
+      | _ -> None )
+
+  let register_push (s : Session.session) ~service_did ~token ~platform ~app_id
+      ?age_restricted () : unit =
+    let fields =
+      [
+        ("serviceDid", `String service_did);
+        ("token", `String token);
+        ("platform", `String platform);
+        ("appId", `String app_id);
+      ]
+      @
+      match age_restricted with
+      | Some b -> [ ("ageRestricted", `Bool b) ]
+      | None -> []
+    in
+    ignore
+      (Client.Client.post_json ~session:s "app.bsky.notification.registerPush"
+         (Yojson.Safe.to_string (`Assoc fields)))
+
+  let unregister_push (s : Session.session) ~service_did ~token ~platform
+      ~app_id () : unit =
+    ignore
+      (Client.Client.post_json ~session:s
+         "app.bsky.notification.unregisterPush"
+         (Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("serviceDid", `String service_did);
+                ("token", `String token);
+                ("platform", `String platform);
+                ("appId", `String app_id);
+              ])))
 end

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -101,13 +101,7 @@ module Notification = struct
   }
 
   type chat_preference = { include_ : string; push : bool }
-
-  type filterable_preference = {
-    include_ : string;
-    list : bool;
-    push : bool;
-  }
-
+  type filterable_preference = { include_ : string; list : bool; push : bool }
   type preference = { list : bool; push : bool }
 
   type preferences = {
@@ -346,7 +340,8 @@ module Notification = struct
       ?seen_at (limit : int) : notification list =
     Client.Client.get_json ~session:s "app.bsky.notification.listNotifications"
       (("limit", string_of_int limit)
-      :: Client.Client.repeat_param "reasons" (Option.value reasons ~default:[])
+       :: Client.Client.repeat_param "reasons"
+            (Option.value reasons ~default:[])
       @ Client.Client.opt_bool "priority" priority
       @ Client.Client.opt_pair "cursor" cursor
       @ Client.Client.opt_pair "seenAt" seen_at)
@@ -610,8 +605,7 @@ module Notification = struct
   let unregister_push (s : Session.session) ~service_did ~token ~platform
       ~app_id () : unit =
     ignore
-      (Client.Client.post_json ~session:s
-         "app.bsky.notification.unregisterPush"
+      (Client.Client.post_json ~session:s "app.bsky.notification.unregisterPush"
          (Yojson.Safe.to_string
             (`Assoc
               [

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -1,0 +1,183 @@
+open Embed
+open Facet
+open Notification
+
+(** Typed builders and parsers for common Bluesky repo records. *)
+module Records = struct
+  let nsid_post = "app.bsky.feed.post"
+  let nsid_like = "app.bsky.feed.like"
+  let nsid_repost = "app.bsky.feed.repost"
+  let nsid_follow = "app.bsky.graph.follow"
+  let nsid_block = "app.bsky.graph.block"
+  let nsid_listblock = "app.bsky.graph.listblock"
+  let nsid_profile = "app.bsky.actor.profile"
+
+  let strong_ref ~uri ~cid : Yojson.Safe.t =
+    `Assoc [ ("uri", `String uri); ("cid", `String cid) ]
+
+  let parse_strong_ref json : Embed.strong_ref = Embed.parse_strong_ref json
+
+  let via_fields via =
+    match via with Some v -> [ ("via", v) ] | None -> []
+
+  let post ~text ~created_at ?langs ?facets ?embed ?reply ?tags ?self_labels ()
+      : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_post);
+        ("text", `String text);
+        ("createdAt", `String created_at);
+      ]
+      @ (match langs with
+        | Some xs -> [ ("langs", `List (List.map (fun s -> `String s) xs)) ]
+        | None -> [])
+      @ (match facets with
+        | Some fs -> [ ("facets", Facet.facets_to_json fs) ]
+        | None -> [])
+      @ (match embed with
+        | Some e -> [ ("embed", Embed.embed_to_json e) ]
+        | None -> [])
+      @ (match reply with
+        | Some (r : Notification.reply) ->
+            [
+              ( "reply",
+                `Assoc
+                  [
+                    ("root", strong_ref ~uri:r.root.uri ~cid:r.root.cid);
+                    ("parent", strong_ref ~uri:r.parent.uri ~cid:r.parent.cid);
+                  ] );
+            ]
+        | None -> [])
+      @ (match tags with
+        | Some xs -> [ ("tags", `List (List.map (fun s -> `String s) xs)) ]
+        | None -> [])
+      @
+      match self_labels with
+      | Some xs -> [ ("labels", Label.Label.self_labels_to_json xs) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let like ~uri ~cid ~created_at ?via () : Yojson.Safe.t =
+    `Assoc
+      ([
+         ("$type", `String nsid_like);
+         ("subject", strong_ref ~uri ~cid);
+         ("createdAt", `String created_at);
+       ]
+      @ via_fields via)
+
+  let repost ~uri ~cid ~created_at ?via () : Yojson.Safe.t =
+    `Assoc
+      ([
+         ("$type", `String nsid_repost);
+         ("subject", strong_ref ~uri ~cid);
+         ("createdAt", `String created_at);
+       ]
+      @ via_fields via)
+
+  let follow ~subject ~created_at ?via () : Yojson.Safe.t =
+    `Assoc
+      ([
+         ("$type", `String nsid_follow);
+         ("subject", `String subject);
+         ("createdAt", `String created_at);
+       ]
+      @ via_fields via)
+
+  let block ~subject ~created_at () : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String nsid_block);
+        ("subject", `String subject);
+        ("createdAt", `String created_at);
+      ]
+
+  let listblock ~subject ~created_at () : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String nsid_listblock);
+        ("subject", `String subject);
+        ("createdAt", `String created_at);
+      ]
+
+  let profile ?display_name ?description ?pronouns ?website ?avatar ?banner
+      ?self_labels ?pinned_post ?created_at () : Yojson.Safe.t =
+    let fields =
+      [ ("$type", `String nsid_profile) ]
+      @ (match display_name with
+        | Some s -> [ ("displayName", `String s) ]
+        | None -> [])
+      @ (match description with
+        | Some s -> [ ("description", `String s) ]
+        | None -> [])
+      @ (match pronouns with
+        | Some s -> [ ("pronouns", `String s) ]
+        | None -> [])
+      @ (match website with Some s -> [ ("website", `String s) ] | None -> [])
+      @ (match avatar with Some b -> [ ("avatar", b) ] | None -> [])
+      @ (match banner with Some b -> [ ("banner", b) ] | None -> [])
+      @ (match self_labels with
+        | Some xs -> [ ("labels", Label.Label.self_labels_to_json xs) ]
+        | None -> [])
+      @ (match pinned_post with
+        | Some r -> [ ("pinnedPost", r) ]
+        | None -> [])
+      @
+      match created_at with
+      | Some s -> [ ("createdAt", `String s) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  type like_record = {
+    subject : Embed.strong_ref;
+    created_at : string;
+    via : Embed.strong_ref option;
+  }
+
+  type follow_record = {
+    subject : string;
+    created_at : string;
+    via : Embed.strong_ref option;
+  }
+
+  type block_record = { subject : string; created_at : string }
+
+  let parse_via json : Embed.strong_ref option =
+    match Yojson.Safe.Util.member "via" json with
+    | `Assoc _ as v -> Some (parse_strong_ref v)
+    | _ -> None
+
+  let parse_like json : like_record =
+    let open Yojson.Safe.Util in
+    {
+      subject = json |> member "subject" |> parse_strong_ref;
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+      via = parse_via json;
+    }
+
+  let parse_repost json : like_record = parse_like json
+
+  let parse_follow json : follow_record =
+    let open Yojson.Safe.Util in
+    {
+      subject =
+        (match json |> member "subject" with `String s -> s | _ -> "");
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+      via = parse_via json;
+    }
+
+  let parse_block json : block_record =
+    let open Yojson.Safe.Util in
+    {
+      subject =
+        (match json |> member "subject" with `String s -> s | _ -> "");
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+    }
+
+  let parse_listblock json : block_record = parse_block json
+end

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -16,9 +16,7 @@ module Records = struct
     `Assoc [ ("uri", `String uri); ("cid", `String cid) ]
 
   let parse_strong_ref json : Embed.strong_ref = Embed.parse_strong_ref json
-
-  let via_fields via =
-    match via with Some v -> [ ("via", v) ] | None -> []
+  let via_fields via = match via with Some v -> [ ("via", v) ] | None -> []
 
   let post ~text ~created_at ?langs ?facets ?embed ?reply ?tags ?self_labels ()
       : Yojson.Safe.t =
@@ -120,9 +118,7 @@ module Records = struct
       @ (match self_labels with
         | Some xs -> [ ("labels", Label.Label.self_labels_to_json xs) ]
         | None -> [])
-      @ (match pinned_post with
-        | Some r -> [ ("pinnedPost", r) ]
-        | None -> [])
+      @ (match pinned_post with Some r -> [ ("pinnedPost", r) ] | None -> [])
       @
       match created_at with
       | Some s -> [ ("createdAt", `String s) ]
@@ -163,8 +159,7 @@ module Records = struct
   let parse_follow json : follow_record =
     let open Yojson.Safe.Util in
     {
-      subject =
-        (match json |> member "subject" with `String s -> s | _ -> "");
+      subject = (match json |> member "subject" with `String s -> s | _ -> "");
       created_at =
         (match json |> member "createdAt" with `String s -> s | _ -> "");
       via = parse_via json;
@@ -173,8 +168,7 @@ module Records = struct
   let parse_block json : block_record =
     let open Yojson.Safe.Util in
     {
-      subject =
-        (match json |> member "subject" with `String s -> s | _ -> "");
+      subject = (match json |> member "subject" with `String s -> s | _ -> "");
       created_at =
         (match json |> member "createdAt" with `String s -> s | _ -> "");
     }

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -226,11 +226,7 @@ module Chat = struct
   }
 
   type logs = { cursor : string option; logs : log_entry list }
-
-  type unread_counts = {
-    unread_accepted : int;
-    unread_request : int;
-  }
+  type unread_counts = { unread_accepted : int; unread_request : int }
 
   type batch_item = {
     convo_id : string;
@@ -274,8 +270,7 @@ module Chat = struct
       unread_request = Client.int_member json "unreadRequestConvos";
     }
 
-  let parse_accept json : accept_result =
-    { rev = Client.string_opt json "rev" }
+  let parse_accept json : accept_result = { rev = Client.string_opt json "rev" }
 
   let parse_requests json : convos =
     {
@@ -325,16 +320,13 @@ module Chat = struct
            ]))
     |> unwrap_message
 
-  let delete_message_for_self (s : Session.session) ?proxy ~convo_id
-      ~message_id () : message =
+  let delete_message_for_self (s : Session.session) ?proxy ~convo_id ~message_id
+      () : message =
     Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
       "chat.bsky.convo.deleteMessageForSelf"
       (Yojson.Safe.to_string
          (`Assoc
-           [
-             ("convoId", `String convo_id);
-             ("messageId", `String message_id);
-           ]))
+           [ ("convoId", `String convo_id); ("messageId", `String message_id) ]))
     |> unwrap_message
 
   let get_convo_availability (s : Session.session) ?proxy ~members () :
@@ -364,8 +356,7 @@ module Chat = struct
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
     |> parse_requests
 
-  let send_message_batch (s : Session.session) ?proxy ~items () : message list
-      =
+  let send_message_batch (s : Session.session) ?proxy ~items () : message list =
     let payload =
       `Assoc
         [

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -200,4 +200,213 @@ module Chat = struct
     match Yojson.Safe.Util.member "convo" json with
     | `Assoc _ as c -> parse_convo c
     | _ -> parse_convo json
+
+  let convo_id_body convo_id : Yojson.Safe.t =
+    `Assoc [ ("convoId", `String convo_id) ]
+
+  let unwrap_convo json : convo =
+    match Yojson.Safe.Util.member "convo" json with
+    | `Assoc _ as c -> parse_convo c
+    | _ -> parse_convo json
+
+  let unwrap_message json : message =
+    match Yojson.Safe.Util.member "message" json with
+    | `Assoc _ as m -> parse_message m
+    | _ -> parse_message json
+
+  type convo_availability = { can_chat : bool; convo : convo option }
+  type accept_result = { rev : string option }
+  type leave_result = { convo_id : string; rev : string }
+
+  type log_entry = {
+    type_ : string;
+    convo_id : string option;
+    rev : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type logs = { cursor : string option; logs : log_entry list }
+
+  type unread_counts = {
+    unread_accepted : int;
+    unread_request : int;
+  }
+
+  type batch_item = {
+    convo_id : string;
+    text : string;
+    facets : Yojson.Safe.t option;
+    reply_to : string option;
+  }
+
+  let parse_availability json : convo_availability =
+    {
+      can_chat = Client.bool_member json "canChat";
+      convo =
+        (match Yojson.Safe.Util.member "convo" json with
+        | `Assoc _ as c -> Some (parse_convo c)
+        | _ -> None);
+    }
+
+  let parse_leave json : leave_result =
+    {
+      convo_id = Client.string_member json "convoId";
+      rev = Client.string_member json "rev";
+    }
+
+  let parse_log_entry json : log_entry =
+    {
+      type_ = Client.string_member json "$type";
+      convo_id = Client.string_opt json "convoId";
+      rev = Client.string_opt json "rev";
+      original = json;
+    }
+
+  let parse_logs json : logs =
+    {
+      cursor = Client.string_opt json "cursor";
+      logs = List.map parse_log_entry (Client.list_member json "logs");
+    }
+
+  let parse_unread_counts json : unread_counts =
+    {
+      unread_accepted = Client.int_member json "unreadAcceptedConvos";
+      unread_request = Client.int_member json "unreadRequestConvos";
+    }
+
+  let parse_accept json : accept_result =
+    { rev = Client.string_opt json "rev" }
+
+  let parse_requests json : convos =
+    {
+      cursor = Client.string_opt json "cursor";
+      convos =
+        List.map parse_convo
+          (match Yojson.Safe.Util.member "requests" json with
+          | `List xs -> xs
+          | _ -> Client.list_member json "convos");
+    }
+
+  let accept_convo (s : Session.session) ?proxy ~convo_id () : accept_result =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.acceptConvo"
+      (Yojson.Safe.to_string (convo_id_body convo_id))
+    |> parse_accept
+
+  let leave_convo (s : Session.session) ?proxy ~convo_id () : leave_result =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.leaveConvo"
+      (Yojson.Safe.to_string (convo_id_body convo_id))
+    |> parse_leave
+
+  let add_reaction (s : Session.session) ?proxy ~convo_id ~message_id ~value ()
+      : message =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.addReaction"
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("convoId", `String convo_id);
+             ("messageId", `String message_id);
+             ("value", `String value);
+           ]))
+    |> unwrap_message
+
+  let remove_reaction (s : Session.session) ?proxy ~convo_id ~message_id ~value
+      () : message =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.removeReaction"
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("convoId", `String convo_id);
+             ("messageId", `String message_id);
+             ("value", `String value);
+           ]))
+    |> unwrap_message
+
+  let delete_message_for_self (s : Session.session) ?proxy ~convo_id
+      ~message_id () : message =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.deleteMessageForSelf"
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("convoId", `String convo_id);
+             ("messageId", `String message_id);
+           ]))
+    |> unwrap_message
+
+  let get_convo_availability (s : Session.session) ?proxy ~members () :
+      convo_availability =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.getConvoAvailability"
+      (Client.repeat_param "members" members)
+    |> parse_availability
+
+  let get_log (s : Session.session) ?proxy ?cursor () : logs =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.getLog"
+      (Client.opt_pair "cursor" cursor)
+    |> parse_logs
+
+  let get_unread_counts (s : Session.session) ?proxy ?include_group_chats () :
+      unread_counts =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.getUnreadCounts"
+      (Client.opt_bool "includeGroupChats" include_group_chats)
+    |> parse_unread_counts
+
+  let list_convo_requests (s : Session.session) ?proxy ?limit ?cursor () :
+      convos =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.listConvoRequests"
+      (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
+    |> parse_requests
+
+  let send_message_batch (s : Session.session) ?proxy ~items () : message list
+      =
+    let payload =
+      `Assoc
+        [
+          ( "items",
+            `List
+              (List.map
+                 (fun (i : batch_item) ->
+                   `Assoc
+                     [
+                       ("convoId", `String i.convo_id);
+                       ( "message",
+                         message_input ?facets:i.facets ?reply_to:i.reply_to
+                           i.text );
+                     ])
+                 items) );
+        ]
+    in
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.sendMessageBatch"
+      (Yojson.Safe.to_string payload)
+    |> fun json -> List.map parse_message (Client.list_member json "items")
+
+  let update_all_read (s : Session.session) ?proxy ?status () : int =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.updateAllRead"
+      (Yojson.Safe.to_string
+         (`Assoc
+           (match status with
+           | Some s -> [ ("status", `String s) ]
+           | None -> [])))
+    |> fun json ->
+    match Yojson.Safe.Util.member "updatedCount" json with
+    | `Int n -> n
+    | _ -> 0
+
+  let message_input_with_facets ?facets ?reply_to text : Yojson.Safe.t =
+    let facets_json =
+      match facets with
+      | Some (`List _ as f) -> Some f
+      | Some f -> Some f
+      | None -> None
+    in
+    message_input ?facets:facets_json ?reply_to text
 end

--- a/src/dune
+++ b/src/dune
@@ -65,6 +65,7 @@
   Oauth
   Oauth_scope
   Ozone
+  Records
   Repo
   Repo_sync
   Request

--- a/src/identity.ml
+++ b/src/identity.ml
@@ -75,10 +75,30 @@ module Identity = struct
       [ ("handle", handle) ]
     |> parse_resolved_handle
 
+  type did_resolution = {
+    did_doc : Yojson.Safe.t;
+    document : Did_plc.Did_plc.did_document option;
+  }
+
+  let parse_did_resolution json : did_resolution =
+    let open Yojson.Safe.Util in
+    let did_doc =
+      match json |> member "didDoc" with
+      | `Null -> json
+      | other -> other
+    in
+    let document =
+      try Some (Did_plc.Did_plc.parse_document did_doc) with _ -> None
+    in
+    { did_doc; document }
+
   let resolve_did ?host ?session (did : string) : Yojson.Safe.t =
     get_json ?host ?session
       (create_identity_endpoint "resolveDid")
       [ ("did", did) ]
+
+  let resolve_did_parsed ?host ?session (did : string) : did_resolution =
+    resolve_did ?host ?session did |> parse_did_resolution
 
   let resolve ?host ?session (actor : string) : resolved_identity =
     if String.length actor >= 4 && String.sub actor 0 4 = "did:" then

--- a/src/identity.ml
+++ b/src/identity.ml
@@ -83,9 +83,7 @@ module Identity = struct
   let parse_did_resolution json : did_resolution =
     let open Yojson.Safe.Util in
     let did_doc =
-      match json |> member "didDoc" with
-      | `Null -> json
-      | other -> other
+      match json |> member "didDoc" with `Null -> json | other -> other
     in
     let document =
       try Some (Did_plc.Did_plc.parse_document did_doc) with _ -> None

--- a/src/label.ml
+++ b/src/label.ml
@@ -107,6 +107,43 @@ module Label = struct
         if vals = [] then None else Some vals
     | _ -> None
 
+  let self_label_values json : string list =
+    match json with
+    | `List items ->
+        List.filter_map
+          (function
+            | `String s -> Some s
+            | `Assoc _ as obj -> (
+                match Yojson.Safe.Util.member "val" obj with
+                | `String s -> Some s
+                | _ -> None)
+            | _ -> None)
+          items
+    | _ -> []
+
+  (* com.atproto.label.defs#selfLabels — author-applied values on a record. *)
+  let parse_self_labels json : string list option =
+    match json with
+    | `Null -> None
+    | `Assoc _ -> (
+        match Yojson.Safe.Util.member "values" json with
+        | `List _ as values ->
+            let vals = self_label_values values in
+            if vals = [] then None else Some vals
+        | _ -> None)
+    | `List _ as values ->
+        let vals = self_label_values values in
+        if vals = [] then None else Some vals
+    | _ -> None
+
+  let self_labels_to_json (vals : string list) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String "com.atproto.label.defs#selfLabels");
+        ( "values",
+          `List (List.map (fun v -> `Assoc [ ("val", `String v) ]) vals) );
+      ]
+
   let create_label_endpoint (query_name : string) : string =
     "com.atproto.label" ^ "." ^ query_name
 

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -236,4 +236,269 @@ module Ozone = struct
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.server.getConfig" []
     |> parse_server_config
+
+  type subject_view = { subject : string; original : Yojson.Safe.t }
+
+  type subjects = { subjects : subject_view list }
+
+  type reporter_stat = {
+    did : string;
+    account_report_count : int option;
+    record_report_count : int option;
+    reported_account_count : int option;
+    original : Yojson.Safe.t;
+  }
+
+  type reporter_stats = { stats : reporter_stat list }
+
+  type timeline_summary = {
+    event_subject_type : string;
+    event_type : string;
+    count : int;
+  }
+
+  type timeline_item = { day : string; summary : timeline_summary list }
+
+  type account_timeline = { timeline : timeline_item list }
+
+  type scheduled_action = {
+    id : string option;
+    subject : string option;
+    status : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type scheduled_actions = {
+    cursor : string option;
+    actions : scheduled_action list;
+  }
+
+  type failed_item = {
+    subject : string;
+    error : string;
+    error_code : string option;
+  }
+
+  type batch_result = { succeeded : string list; failed : failed_item list }
+
+  type scheduling = {
+    execute_at : string option;
+    execute_after : string option;
+    execute_until : string option;
+  }
+
+  let parse_subject_view json : subject_view =
+    {
+      subject =
+        (match Client.string_opt json "subject" with
+        | Some s -> s
+        | None -> Client.string_member json "did");
+      original = json;
+    }
+
+  let parse_subjects json : subjects =
+    { subjects = List.map parse_subject_view (Client.list_member json "subjects") }
+
+  let parse_reporter_stat json : reporter_stat =
+    {
+      did = Client.string_member json "did";
+      account_report_count = Client.int_opt json "accountReportCount";
+      record_report_count = Client.int_opt json "recordReportCount";
+      reported_account_count = Client.int_opt json "reportedAccountCount";
+      original = json;
+    }
+
+  let parse_reporter_stats json : reporter_stats =
+    { stats = List.map parse_reporter_stat (Client.list_member json "stats") }
+
+  let parse_timeline_summary json : timeline_summary =
+    {
+      event_subject_type = Client.string_member json "eventSubjectType";
+      event_type = Client.string_member json "eventType";
+      count = Client.int_member json "count";
+    }
+
+  let parse_timeline_item json : timeline_item =
+    {
+      day = Client.string_member json "day";
+      summary =
+        List.map parse_timeline_summary (Client.list_member json "summary");
+    }
+
+  let parse_account_timeline json : account_timeline =
+    {
+      timeline =
+        List.map parse_timeline_item (Client.list_member json "timeline");
+    }
+
+  let parse_scheduled_action json : scheduled_action =
+    {
+      id = Client.string_opt json "id";
+      subject =
+        (match Client.string_opt json "subject" with
+        | Some s -> Some s
+        | None -> Client.string_opt json "did");
+      status = Client.string_opt json "status";
+      original = json;
+    }
+
+  let parse_scheduled_actions json : scheduled_actions =
+    {
+      cursor = Client.string_opt json "cursor";
+      actions =
+        List.map parse_scheduled_action (Client.list_member json "actions");
+    }
+
+  let parse_failed_item json : failed_item =
+    {
+      subject =
+        (match Client.string_opt json "subject" with
+        | Some s -> s
+        | None -> Client.string_member json "did");
+      error = Client.string_member json "error";
+      error_code = Client.string_opt json "errorCode";
+    }
+
+  let parse_batch_result json : batch_result =
+    {
+      succeeded =
+        List.filter_map
+          (function `String s -> Some s | _ -> None)
+          (Client.list_member json "succeeded");
+      failed = List.map parse_failed_item (Client.list_member json "failed");
+    }
+
+  let get_records (s : Session.session) ~proxy ~uris () : record_view list =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getRecords"
+      (Client.repeat_param "uris" uris)
+    |> fun json -> List.map parse_record (Client.list_member json "records")
+
+  let get_repos (s : Session.session) ~proxy ~dids () : repo_view list =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getRepos"
+      (Client.repeat_param "dids" dids)
+    |> fun json -> List.map parse_repo (Client.list_member json "repos")
+
+  let get_subjects (s : Session.session) ~proxy ~subjects () : subjects =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getSubjects"
+      (Client.repeat_param "subjects" subjects)
+    |> parse_subjects
+
+  let search_repos (s : Session.session) ~proxy ?q ?term ?limit ?cursor () :
+      repo_view list * string option =
+    let json =
+      Client.get_json ~session:s ~extra:(proxy_headers proxy)
+        "tools.ozone.moderation.searchRepos"
+        (Client.opt_pair "q" q
+        @ Client.opt_pair "term" term
+        @ Client.opt_int "limit" limit
+        @ Client.opt_pair "cursor" cursor)
+    in
+    ( List.map parse_repo (Client.list_member json "repos"),
+      Client.string_opt json "cursor" )
+
+  let get_account_timeline (s : Session.session) ~proxy ~did () :
+      account_timeline =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getAccountTimeline"
+      [ ("did", did) ]
+    |> parse_account_timeline
+
+  let get_reporter_stats (s : Session.session) ~proxy ~dids () : reporter_stats
+      =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getReporterStats"
+      (Client.repeat_param "dids" dids)
+    |> parse_reporter_stats
+
+  let scheduling_to_json (c : scheduling) : Yojson.Safe.t =
+    `Assoc
+      ((match c.execute_at with
+       | Some s -> [ ("executeAt", `String s) ]
+       | None -> [])
+      @ (match c.execute_after with
+        | Some s -> [ ("executeAfter", `String s) ]
+        | None -> [])
+      @
+      match c.execute_until with
+      | Some s -> [ ("executeUntil", `String s) ]
+      | None -> [])
+
+  let takedown_action ?comment ?duration_in_hours
+      ?(acknowledge_account_subjects = false) () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String "tools.ozone.moderation.scheduleAction#takedown");
+        ("acknowledgeAccountSubjects", `Bool acknowledge_account_subjects);
+      ]
+      @ (match comment with Some c -> [ ("comment", `String c) ] | None -> [])
+      @
+      match duration_in_hours with
+      | Some n -> [ ("durationInHours", `Int n) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let schedule_action_body ~action ~subjects ~created_by ~scheduling ?mod_tool
+      () : Yojson.Safe.t =
+    let fields =
+      [
+        ("action", action);
+        ("subjects", `List (List.map (fun s -> `String s) subjects));
+        ("createdBy", `String created_by);
+        ("scheduling", scheduling_to_json scheduling);
+      ]
+      @ match mod_tool with Some t -> [ ("modTool", t) ] | None -> []
+    in
+    `Assoc fields
+
+  let schedule_action (s : Session.session) ~proxy ~action ~subjects ~created_by
+      ~scheduling ?mod_tool () : batch_result =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.scheduleAction"
+      (Yojson.Safe.to_string
+         (schedule_action_body ~action ~subjects ~created_by ~scheduling
+            ?mod_tool ()))
+    |> parse_batch_result
+
+  let list_scheduled_actions (s : Session.session) ~proxy ~statuses
+      ?starts_after ?ends_before ?subjects ?limit ?cursor () : scheduled_actions
+      =
+    let body =
+      `Assoc
+        ([
+           ("statuses", `List (List.map (fun s -> `String s) statuses));
+         ]
+        @ (match starts_after with
+          | Some t -> [ ("startsAfter", `String t) ]
+          | None -> [])
+        @ (match ends_before with
+          | Some t -> [ ("endsBefore", `String t) ]
+          | None -> [])
+        @ (match subjects with
+          | Some xs ->
+              [ ("subjects", `List (List.map (fun s -> `String s) xs)) ]
+          | None -> [])
+        @ (match limit with Some n -> [ ("limit", `Int n) ] | None -> [])
+        @ match cursor with Some c -> [ ("cursor", `String c) ] | None -> [])
+    in
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.listScheduledActions"
+      (Yojson.Safe.to_string body)
+    |> parse_scheduled_actions
+
+  let cancel_scheduled_actions (s : Session.session) ~proxy ~subjects ?comment
+      () : batch_result =
+    let fields =
+      [
+        ("subjects", `List (List.map (fun s -> `String s) subjects));
+      ]
+      @ match comment with Some c -> [ ("comment", `String c) ] | None -> []
+    in
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.cancelScheduledActions"
+      (Yojson.Safe.to_string (`Assoc fields))
+    |> parse_batch_result
 end

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -238,7 +238,6 @@ module Ozone = struct
     |> parse_server_config
 
   type subject_view = { subject : string; original : Yojson.Safe.t }
-
   type subjects = { subjects : subject_view list }
 
   type reporter_stat = {
@@ -258,7 +257,6 @@ module Ozone = struct
   }
 
   type timeline_item = { day : string; summary : timeline_summary list }
-
   type account_timeline = { timeline : timeline_item list }
 
   type scheduled_action = {
@@ -297,7 +295,10 @@ module Ozone = struct
     }
 
   let parse_subjects json : subjects =
-    { subjects = List.map parse_subject_view (Client.list_member json "subjects") }
+    {
+      subjects =
+        List.map parse_subject_view (Client.list_member json "subjects");
+    }
 
   let parse_reporter_stat json : reporter_stat =
     {
@@ -468,9 +469,7 @@ module Ozone = struct
       =
     let body =
       `Assoc
-        ([
-           ("statuses", `List (List.map (fun s -> `String s) statuses));
-         ]
+        ([ ("statuses", `List (List.map (fun s -> `String s) statuses)) ]
         @ (match starts_after with
           | Some t -> [ ("startsAfter", `String t) ]
           | None -> [])
@@ -492,9 +491,7 @@ module Ozone = struct
   let cancel_scheduled_actions (s : Session.session) ~proxy ~subjects ?comment
       () : batch_result =
     let fields =
-      [
-        ("subjects", `List (List.map (fun s -> `String s) subjects));
-      ]
+      [ ("subjects", `List (List.map (fun s -> `String s) subjects)) ]
       @ match comment with Some c -> [ ("comment", `String c) ] | None -> []
     in
     Client.post_json ~session:s ~extra:(proxy_headers proxy)

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -43,23 +43,9 @@ module Repo = struct
     }
 
   type commit_meta = { cid : string; rev : string }
-
-  type record_get = {
-    uri : string;
-    cid : string option;
-    value : Yojson.Safe.t;
-  }
-
-  type listed_record = {
-    uri : string;
-    cid : string;
-    value : Yojson.Safe.t;
-  }
-
-  type listed_records = {
-    cursor : string option;
-    records : listed_record list;
-  }
+  type record_get = { uri : string; cid : string option; value : Yojson.Safe.t }
+  type listed_record = { uri : string; cid : string; value : Yojson.Safe.t }
+  type listed_records = { cursor : string option; records : listed_record list }
 
   type repo_description = {
     handle : string;
@@ -160,8 +146,7 @@ module Repo = struct
     let open Yojson.Safe.Util in
     {
       commit = parse_commit_meta (json |> member "commit");
-      results =
-        (match json |> member "results" with `List xs -> xs | _ -> []);
+      results = (match json |> member "results" with `List xs -> xs | _ -> []);
     }
 
   let describe_repo_parsed ?session ?host ~repo () : repo_description =

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -14,6 +14,8 @@ module Repo = struct
     facets : Facet.facet list option;
     langs : string list option;
     reply : Notification.reply option;
+    tags : string list option;
+    self_labels : string list option;
     created_at : string;
   }
 
@@ -25,8 +27,163 @@ module Repo = struct
     let facets = Feed.extract_facets_option json in
     let langs = Feed.extract_langs_option json in
     let reply = Notification.parse_reply_option json in
+    let tags = Feed.extract_tags_option json in
+    let self_labels = Feed.extract_self_labels_option json in
     let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; embed; facets; langs; reply; created_at }
+    {
+      text;
+      record_type;
+      embed;
+      facets;
+      langs;
+      reply;
+      tags;
+      self_labels;
+      created_at;
+    }
+
+  type commit_meta = { cid : string; rev : string }
+
+  type record_get = {
+    uri : string;
+    cid : string option;
+    value : Yojson.Safe.t;
+  }
+
+  type listed_record = {
+    uri : string;
+    cid : string;
+    value : Yojson.Safe.t;
+  }
+
+  type listed_records = {
+    cursor : string option;
+    records : listed_record list;
+  }
+
+  type repo_description = {
+    handle : string;
+    did : string;
+    did_doc : Yojson.Safe.t option;
+    collections : string list;
+    handle_is_correct : bool;
+  }
+
+  type write_result = {
+    uri : string;
+    cid : string;
+    commit : commit_meta option;
+    validation_status : string option;
+  }
+
+  type apply_writes_result = {
+    commit : commit_meta option;
+    results : Yojson.Safe.t list;
+  }
+
+  let parse_commit_meta json : commit_meta option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            cid =
+              (match Yojson.Safe.Util.member "cid" json with
+              | `String s -> s
+              | _ -> "");
+            rev =
+              (match Yojson.Safe.Util.member "rev" json with
+              | `String s -> s
+              | _ -> "");
+          }
+    | _ -> None
+
+  let parse_record_get json : record_get =
+    let open Yojson.Safe.Util in
+    {
+      uri = (match json |> member "uri" with `String s -> s | _ -> "");
+      cid = (match json |> member "cid" with `String s -> Some s | _ -> None);
+      value = json |> member "value";
+    }
+
+  let parse_listed_record json : listed_record =
+    let open Yojson.Safe.Util in
+    {
+      uri = (match json |> member "uri" with `String s -> s | _ -> "");
+      cid = (match json |> member "cid" with `String s -> s | _ -> "");
+      value = json |> member "value";
+    }
+
+  let parse_listed_records json : listed_records =
+    let open Yojson.Safe.Util in
+    {
+      cursor =
+        (match json |> member "cursor" with `String s -> Some s | _ -> None);
+      records =
+        (match json |> member "records" with
+        | `List xs -> List.map parse_listed_record xs
+        | _ -> []);
+    }
+
+  let parse_repo_description json : repo_description =
+    let open Yojson.Safe.Util in
+    {
+      handle = (match json |> member "handle" with `String s -> s | _ -> "");
+      did = (match json |> member "did" with `String s -> s | _ -> "");
+      did_doc =
+        (match json |> member "didDoc" with
+        | `Null -> None
+        | other -> Some other);
+      collections =
+        (match json |> member "collections" with
+        | `List xs ->
+            List.filter_map (function `String s -> Some s | _ -> None) xs
+        | _ -> []);
+      handle_is_correct =
+        (match json |> member "handleIsCorrect" with
+        | `Bool b -> b
+        | _ -> false);
+    }
+
+  let parse_write_result json : write_result =
+    let open Yojson.Safe.Util in
+    {
+      uri = (match json |> member "uri" with `String s -> s | _ -> "");
+      cid = (match json |> member "cid" with `String s -> s | _ -> "");
+      commit = parse_commit_meta (json |> member "commit");
+      validation_status =
+        (match json |> member "validationStatus" with
+        | `String s -> Some s
+        | _ -> None);
+    }
+
+  let parse_apply_writes_result json : apply_writes_result =
+    let open Yojson.Safe.Util in
+    {
+      commit = parse_commit_meta (json |> member "commit");
+      results =
+        (match json |> member "results" with `List xs -> xs | _ -> []);
+    }
+
+  let describe_repo_parsed ?session ?host ~repo () : repo_description =
+    Client.Client.get_json ?session ?host "com.atproto.repo.describeRepo"
+      [ ("repo", repo) ]
+    |> parse_repo_description
+
+  let get_record_parsed ?session ?host ~repo ~collection ~rkey ?cid () :
+      record_get =
+    Client.Client.get_json ?session ?host "com.atproto.repo.getRecord"
+      ([ ("repo", repo); ("collection", collection); ("rkey", rkey) ]
+      @ Client.Client.opt_pair "cid" cid)
+    |> parse_record_get
+
+  let list_records_parsed ?session ?host ~repo ~collection ?limit ?cursor
+      ?reverse () : listed_records =
+    Client.Client.get_json ?session ?host "com.atproto.repo.listRecords"
+      ([ ("repo", repo); ("collection", collection) ]
+      @ Client.Client.opt_int "limit" limit
+      @ Client.Client.opt_pair "cursor" cursor
+      @ Client.Client.opt_bool "reverse" reverse)
+    |> parse_listed_records
 
   let create_repo_endpoint (query_name : string) : string =
     "com.atproto.repo" ^ "." ^ query_name

--- a/test/dune
+++ b/test/dune
@@ -36,6 +36,7 @@
   test_oauth_scope
   test_ozone
   test_request
+  test_records
   test_repo
   test_repo_sync
   test_response
@@ -112,6 +113,7 @@
   test_oauth_scope
   test_ozone
   test_request
+  test_records
   test_repo
   test_repo_sync
   test_response

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -74,10 +74,7 @@ let test_parse_unread_and_logs _ =
   let counts =
     Chat.parse_unread_counts
       (`Assoc
-        [
-          ("unreadAcceptedConvos", `Int 3);
-          ("unreadRequestConvos", `Int 1);
-        ])
+        [ ("unreadAcceptedConvos", `Int 3); ("unreadRequestConvos", `Int 1) ])
   in
   OUnit2.assert_equal 3 counts.unread_accepted;
   OUnit2.assert_equal 1 counts.unread_request;

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -70,6 +70,54 @@ let test_send_message_body _ =
     "hi"
     (body |> member "message" |> member "text" |> to_string)
 
+let test_parse_unread_and_logs _ =
+  let counts =
+    Chat.parse_unread_counts
+      (`Assoc
+        [
+          ("unreadAcceptedConvos", `Int 3);
+          ("unreadRequestConvos", `Int 1);
+        ])
+  in
+  OUnit2.assert_equal 3 counts.unread_accepted;
+  OUnit2.assert_equal 1 counts.unread_request;
+  let logs =
+    Chat.parse_logs
+      (`Assoc
+        [
+          ( "logs",
+            `List
+              [
+                `Assoc
+                  [
+                    ("$type", `String "chat.bsky.convo.defs#logCreateMessage");
+                    ("convoId", `String "c1");
+                    ("rev", `String "r2");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length logs.logs);
+  let accept = Chat.parse_accept (`Assoc [ ("rev", `String "r9") ]) in
+  OUnit2.assert_equal (Some "r9") accept.rev;
+  let avail =
+    Chat.parse_availability
+      (`Assoc
+        [
+          ("canChat", `Bool true);
+          ( "convo",
+            `Assoc
+              [
+                ("id", `String "c2");
+                ("rev", `String "r0");
+                ("muted", `Bool false);
+                ("unreadCount", `Int 0);
+                ("members", `List []);
+              ] );
+        ])
+  in
+  OUnit2.assert_equal true avail.can_chat
+
 let test_list_convos_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -87,6 +135,7 @@ let suite =
          "test_default_proxy" >:: test_default_proxy;
          "test_parse_convos" >:: test_parse_convos;
          "test_send_message_body" >:: test_send_message_body;
+         "test_parse_unread_and_logs" >:: test_parse_unread_and_logs;
          "test_list_convos_auth_skipped" >:: test_list_convos_auth_skipped;
        ]
 

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -199,7 +199,8 @@ let test_parse_gallery _ =
                         ("mimeType", `String "image/jpeg");
                         ("size", `Int 12);
                       ] );
-                  ("aspectRatio", `Assoc [ ("width", `Int 4); ("height", `Int 3) ]);
+                  ( "aspectRatio",
+                    `Assoc [ ("width", `Int 4); ("height", `Int 3) ] );
                 ];
             ] );
       ]
@@ -277,8 +278,7 @@ let test_parse_record_view_not_found _ =
           `Assoc
             [
               ("$type", `String "app.bsky.embed.record#viewNotFound");
-              ( "uri",
-                `String "at://did:plc:alice/app.bsky.feed.post/missing" );
+              ("uri", `String "at://did:plc:alice/app.bsky.feed.post/missing");
               ("notFound", `Bool true);
             ] );
       ]
@@ -313,9 +313,7 @@ let test_embed_to_json_roundtrip _ =
           OUnit2.assert_equal
             ~printer:(fun x -> x)
             "app.bsky.embed.record"
-            (match List.assoc "$type" fields with
-            | `String s -> s
-            | _ -> "");
+            (match List.assoc "$type" fields with `String s -> s | _ -> "");
           OUnit2.assert_equal
             ~printer:(fun x -> x)
             e.record.uri
@@ -353,7 +351,8 @@ let test_parse_embed_external_view _ =
               `Assoc
                 [
                   ("uri", `String "at://did:plc:alice/site.standard.document/1");
-                  ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+                  ( "cid",
+                    `String "bafyreihdummy000000000000000000000000000000000" );
                 ];
             ] );
       ]

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -173,6 +173,198 @@ let test_unknown_is_not_fail _ =
   | `Unknown _ -> ()
   | _ -> OUnit2.assert_failure "expected unknown embed"
 
+let test_parse_gallery _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.gallery");
+        ( "items",
+          `List
+            [
+              `Assoc
+                [
+                  ("alt", `String "one");
+                  ( "image",
+                    `Assoc
+                      [
+                        ("$type", `String "blob");
+                        ( "ref",
+                          `Assoc
+                            [
+                              ( "$link",
+                                `String
+                                  "bafyimage0000000000000000000000000000000000"
+                              );
+                            ] );
+                        ("mimeType", `String "image/jpeg");
+                        ("size", `Int 12);
+                      ] );
+                  ("aspectRatio", `Assoc [ ("width", `Int 4); ("height", `Int 3) ]);
+                ];
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `Gallery e ->
+      OUnit2.assert_equal 1 (List.length e.items);
+      OUnit2.assert_equal ~printer:(fun x -> x) "one" (List.hd e.items).alt;
+      OUnit2.assert_equal
+        (Some { Embed.width = 4; height = 3 })
+        (List.hd e.items).aspect_ratio
+  | _ -> OUnit2.assert_failure "expected gallery embed"
+
+let test_parse_gallery_view _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.gallery#view");
+        ( "items",
+          `List
+            [
+              `Assoc
+                [
+                  ("thumbnail", `String "https://cdn.example/thumb.jpg");
+                  ("fullsize", `String "https://cdn.example/full.jpg");
+                  ("alt", `String "wide");
+                ];
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `GalleryView e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "wide" (List.hd e.items).alt
+  | _ -> OUnit2.assert_failure "expected gallery view"
+
+let test_parse_record_view _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.record#view");
+        ( "record",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.record#viewRecord");
+              ( "uri",
+                `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+              ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+              ( "author",
+                `Assoc
+                  [
+                    ("did", `String "did:plc:alice000111222333444555666");
+                    ("handle", `String "alice.test");
+                  ] );
+              ("value", `Assoc [ ("text", `String "quoted") ]);
+              ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+              ("likeCount", `Int 4);
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `RecordView e -> (
+      match e.record with
+      | `ViewRecord v ->
+          OUnit2.assert_equal (Some 4) v.like_count;
+          OUnit2.assert_equal (Some "alice.test") v.author_handle
+      | _ -> OUnit2.assert_failure "expected viewRecord")
+  | _ -> OUnit2.assert_failure "expected record view"
+
+let test_parse_record_view_not_found _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.record#view");
+        ( "record",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.record#viewNotFound");
+              ( "uri",
+                `String "at://did:plc:alice/app.bsky.feed.post/missing" );
+              ("notFound", `Bool true);
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `RecordView e -> (
+      match e.record with
+      | `ViewNotFound { uri; not_found } ->
+          OUnit2.assert_bool "notFound" not_found;
+          OUnit2.assert_bool "uri" (String.length uri > 8)
+      | _ -> OUnit2.assert_failure "expected viewNotFound")
+  | _ -> OUnit2.assert_failure "expected record view"
+
+let test_embed_to_json_roundtrip _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.record");
+        ( "record",
+          `Assoc
+            [
+              ( "uri",
+                `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+              ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `Record e as parsed -> (
+      match Embed.embed_to_json parsed with
+      | `Assoc fields ->
+          OUnit2.assert_equal
+            ~printer:(fun x -> x)
+            "app.bsky.embed.record"
+            (match List.assoc "$type" fields with
+            | `String s -> s
+            | _ -> "");
+          OUnit2.assert_equal
+            ~printer:(fun x -> x)
+            e.record.uri
+            (match
+               Yojson.Safe.Util.member "record" (Embed.embed_to_json parsed)
+             with
+            | `Assoc _ as r -> (
+                match Yojson.Safe.Util.member "uri" r with
+                | `String s -> s
+                | _ -> "")
+            | _ -> "")
+      | _ -> OUnit2.assert_failure "expected assoc")
+  | _ -> OUnit2.assert_failure "expected record embed"
+
+let test_parse_embed_external_view _ =
+  let json =
+    `Assoc
+      [
+        ( "view",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.external#view");
+              ( "external",
+                `Assoc
+                  [
+                    ("uri", `String "https://atproto.com");
+                    ("title", `String "AT Protocol");
+                    ("description", `String "specs");
+                    ("thumb", `String "https://cdn.example/t.jpg");
+                  ] );
+            ] );
+        ( "associatedRefs",
+          `List
+            [
+              `Assoc
+                [
+                  ("uri", `String "at://did:plc:alice/site.standard.document/1");
+                  ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+                ];
+            ] );
+      ]
+  in
+  let v = Embed.parse_embed_external_view json in
+  OUnit2.assert_equal 1 (List.length v.associated_refs);
+  match v.view with
+  | Some e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri
+  | None -> OUnit2.assert_failure "expected view"
+
 let suite =
   "embed"
   >::: [
@@ -182,6 +374,12 @@ let suite =
          "test_parse_record" >:: test_parse_record;
          "test_parse_record_with_media" >:: test_parse_record_with_media;
          "test_unknown_is_not_fail" >:: test_unknown_is_not_fail;
+         "test_parse_gallery" >:: test_parse_gallery;
+         "test_parse_gallery_view" >:: test_parse_gallery_view;
+         "test_parse_record_view" >:: test_parse_record_view;
+         "test_parse_record_view_not_found" >:: test_parse_record_view_not_found;
+         "test_embed_to_json_roundtrip" >:: test_embed_to_json_roundtrip;
+         "test_parse_embed_external_view" >:: test_parse_embed_external_view;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_facet.ml
+++ b/test/test_facet.ml
@@ -72,7 +72,9 @@ let test_parse_tag _ =
   | _ -> OUnit2.assert_failure "expected tag"
 
 let test_builders_and_serialize _ =
-  let mention = Facet.mention ~byte_start:0 ~byte_end:5 "did:plc:abc123xyz0001112223333" in
+  let mention =
+    Facet.mention ~byte_start:0 ~byte_end:5 "did:plc:abc123xyz0001112223333"
+  in
   let link = Facet.link ~byte_start:6 ~byte_end:20 "https://atproto.com" in
   let tag = Facet.tag ~byte_start:21 ~byte_end:29 "atproto" in
   (match mention with
@@ -83,9 +85,9 @@ let test_builders_and_serialize _ =
   | _ -> OUnit2.assert_failure "expected mention builder");
   let json = Facet.facets_to_json [ mention; link; tag ] in
   match json with
-  | `List xs ->
+  | `List xs -> (
       OUnit2.assert_equal 3 (List.length xs);
-      (match Facet.parse_facet (List.hd xs) with
+      match Facet.parse_facet (List.hd xs) with
       | `Mention _ -> ()
       | _ -> OUnit2.assert_failure "roundtrip mention")
   | _ -> OUnit2.assert_failure "expected list"

--- a/test/test_facet.ml
+++ b/test/test_facet.ml
@@ -71,12 +71,32 @@ let test_parse_tag _ =
         "atproto" (List.hd t.features).tag
   | _ -> OUnit2.assert_failure "expected tag"
 
+let test_builders_and_serialize _ =
+  let mention = Facet.mention ~byte_start:0 ~byte_end:5 "did:plc:abc123xyz0001112223333" in
+  let link = Facet.link ~byte_start:6 ~byte_end:20 "https://atproto.com" in
+  let tag = Facet.tag ~byte_start:21 ~byte_end:29 "atproto" in
+  (match mention with
+  | `Mention m ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:abc123xyz0001112223333" (List.hd m.features).did
+  | _ -> OUnit2.assert_failure "expected mention builder");
+  let json = Facet.facets_to_json [ mention; link; tag ] in
+  match json with
+  | `List xs ->
+      OUnit2.assert_equal 3 (List.length xs);
+      (match Facet.parse_facet (List.hd xs) with
+      | `Mention _ -> ()
+      | _ -> OUnit2.assert_failure "roundtrip mention")
+  | _ -> OUnit2.assert_failure "expected list"
+
 let suite =
   "facet"
   >::: [
          "test_parse_mention" >:: test_parse_mention;
          "test_parse_link" >:: test_parse_link;
          "test_parse_tag" >:: test_parse_tag;
+         "test_builders_and_serialize" >:: test_builders_and_serialize;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -158,6 +158,96 @@ let test_parse_search_posts _ =
   OUnit2.assert_equal 1 (List.length page.posts);
   OUnit2.assert_equal (Some "hello atproto") (List.hd page.posts).text
 
+let test_parse_post_record_embed_and_tags _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.feed.post");
+        ("text", `String "gallery post");
+        ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ("langs", `List [ `String "en" ]);
+        ("tags", `List [ `String "art" ]);
+        ( "labels",
+          `Assoc
+            [
+              ("$type", `String "com.atproto.label.defs#selfLabels");
+              ("values", `List [ `Assoc [ ("val", `String "nudity") ] ]);
+            ] );
+        ( "embed",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.gallery");
+              ( "items",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ("alt", `String "pic");
+                        ( "image",
+                          `Assoc
+                            [
+                              ("$type", `String "blob");
+                              ( "ref",
+                                `Assoc
+                                  [
+                                    ( "$link",
+                                      `String
+                                        "bafyimage0000000000000000000000000000000000"
+                                    );
+                                  ] );
+                              ("mimeType", `String "image/png");
+                              ("size", `Int 4);
+                            ] );
+                      ];
+                  ] );
+            ] );
+      ]
+  in
+  let rec_ = Feed.parse_post_record json in
+  OUnit2.assert_equal (Some [ "art" ]) rec_.tags;
+  OUnit2.assert_equal (Some [ "nudity" ]) rec_.self_labels;
+  match rec_.embed with
+  | Some (`Gallery g) -> OUnit2.assert_equal 1 (List.length g.items)
+  | _ -> OUnit2.assert_failure "expected gallery embed on post record"
+
+let test_parse_post_view_embed _ =
+  let json =
+    `Assoc
+      [
+        ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k");
+        ("cid", `String "bafyreiabc");
+        ( "author",
+          `Assoc
+            [
+              ("did", `String "did:plc:abc123xyz0001112223333");
+              ("handle", `String "alice.test");
+            ] );
+        ("record", `Assoc [ ("text", `String "hello atproto") ]);
+        ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+        ("likeCount", `Int 3);
+        ("quoteCount", `Int 1);
+        ( "embed",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.external#view");
+              ( "external",
+                `Assoc
+                  [
+                    ("uri", `String "https://atproto.com");
+                    ("title", `String "AT Protocol");
+                    ("description", `String "docs");
+                    ("thumb", `String "https://cdn.example/t.jpg");
+                  ] );
+            ] );
+      ]
+  in
+  let view = Feed.parse_post_view json in
+  OUnit2.assert_equal (Some 1) view.quote_count;
+  match view.embed with
+  | Some (`ExternalView e) ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri
+  | _ -> OUnit2.assert_failure "expected external view embed"
+
 let test_send_interactions_body _ =
   let body =
     Feed.send_interactions_body ~feed:discover_feed
@@ -205,6 +295,9 @@ let suite =
          "test_get_timeline" >:: test_get_timeline;
          "test_parse_generator" >:: test_parse_generator;
          "test_parse_search_posts" >:: test_parse_search_posts;
+         "test_parse_post_record_embed_and_tags"
+         >:: test_parse_post_record_embed_and_tags;
+         "test_parse_post_view_embed" >:: test_parse_post_view_embed;
          "test_send_interactions_body" >:: test_send_interactions_body;
          "test_get_feed_generator_live" >:: test_get_feed_generator_live;
          "test_search_posts_live" >:: test_search_posts_live;

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -214,7 +214,8 @@ let test_parse_post_view_embed _ =
   let json =
     `Assoc
       [
-        ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k");
+        ( "uri",
+          `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
         ("cid", `String "bafyreiabc");
         ( "author",
           `Assoc

--- a/test/test_identity.ml
+++ b/test/test_identity.ml
@@ -110,6 +110,28 @@ let test_update_handle_body _ =
     "alice.test"
     (body |> member "handle" |> to_string)
 
+let test_parse_did_resolution _ =
+  let json =
+    `Assoc
+      [
+        ( "didDoc",
+          `Assoc
+            [
+              ("id", `String "did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+              ("alsoKnownAs", `List [ `String "at://jay.bsky.team" ]);
+              ("verificationMethod", `List []);
+              ("service", `List []);
+            ] );
+      ]
+  in
+  let resolved = Identity.parse_did_resolution json in
+  match resolved.document with
+  | Some doc ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:ewvi7nxzyoun6zhxrhs64oiz" doc.id
+  | None -> OUnit2.assert_failure "expected parsed DID document"
+
 let test_handle_txt_helpers _ =
   OUnit2.assert_equal (Some "did:plc:ewvi7nxzyoun6zhxrhs64oiz")
     (Identity.parse_txt_did "did=did:plc:ewvi7nxzyoun6zhxrhs64oiz");
@@ -127,6 +149,7 @@ let suite =
          "test_resolve_handle_live" >:: test_resolve_handle_live;
          "test_resolve_actor_live" >:: test_resolve_actor_live;
          "test_parse_identity_info" >:: test_parse_identity_info;
+         "test_parse_did_resolution" >:: test_parse_did_resolution;
          "test_plc_operation_bodies" >:: test_plc_operation_bodies;
          "test_recommended_did_credentials" >:: test_recommended_did_credentials;
          "test_handle_txt_helpers" >:: test_handle_txt_helpers;

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -155,10 +155,23 @@ let test_json_sig_roundtrip _ =
   let again = Label.parse_label back in
   OUnit2.assert_equal again.sig_ l.sig_
 
+let test_self_labels _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "com.atproto.label.defs#selfLabels");
+        ("values", `List [ `Assoc [ ("val", `String "porn") ] ]);
+      ]
+  in
+  OUnit2.assert_equal (Some [ "porn" ]) (Label.parse_self_labels json);
+  let encoded = Label.self_labels_to_json [ "nudity" ] in
+  OUnit2.assert_equal (Some [ "nudity" ]) (Label.parse_self_labels encoded)
+
 let suite =
   "suite"
   >::: [
          "test_query_labels" >:: test_query_labels;
+         "test_self_labels" >:: test_self_labels;
          "test_parse_query_labels" >:: test_parse_query_labels;
          "test_label_sign_verify_p256" >:: test_label_sign_verify_p256;
          "test_label_sign_verify_k256" >:: test_label_sign_verify_k256;

--- a/test/test_notification.ml
+++ b/test/test_notification.ml
@@ -34,10 +34,142 @@ let test_parse_unread_and_like _ =
         "app.bsky.feed.like" r.record_type
   | _ -> OUnit2.assert_failure "expected like");
   match
-    Notification.parse_record (`Assoc [ ("text", `String "hi") ]) "quote"
+    Notification.parse_record
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.feed.post");
+          ("text", `String "hi");
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ])
+      "quote"
   with
-  | `Other o -> OUnit2.assert_equal ~printer:(fun x -> x) "quote" o.reason
-  | _ -> OUnit2.assert_failure "expected other record for quote"
+  | `Quote q ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "hi" q.text
+  | _ -> OUnit2.assert_failure "expected quote record"
+
+let test_parse_mention_and_via_repost _ =
+  (match
+     Notification.parse_record
+       (`Assoc
+         [
+           ("$type", `String "app.bsky.feed.post");
+           ("text", `String "@alice hello");
+           ("createdAt", `String "2024-01-01T00:00:00.000Z");
+         ])
+       "mention"
+   with
+  | `Mention m ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "@alice hello" m.text
+  | _ -> OUnit2.assert_failure "expected mention");
+  (match
+     Notification.parse_record
+       (`Assoc
+         [
+           ("$type", `String "app.bsky.feed.like");
+           ( "subject",
+             `Assoc
+               [
+                 ( "uri",
+                   `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+                 );
+                 ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+               ] );
+           ("createdAt", `String "2024-01-01T00:00:00.000Z");
+         ])
+       "like-via-repost"
+   with
+  | `Like_via_repost _ -> ()
+  | _ -> OUnit2.assert_failure "expected like-via-repost");
+  match Notification.parse_record (`Assoc []) "unknown-reason" with
+  | `Other o ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "unknown-reason" o.reason
+  | _ -> OUnit2.assert_failure "expected other"
+
+let test_parse_preferences _ =
+  let json =
+    `Assoc
+      [
+        ( "preferences",
+          `Assoc
+            [
+              ( "chat",
+                `Assoc [ ("include", `String "all"); ("push", `Bool true) ] );
+              ( "follow",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool true);
+                    ("push", `Bool false);
+                  ] );
+              ( "like",
+                `Assoc
+                  [
+                    ("include", `String "follows");
+                    ("list", `Bool true);
+                    ("push", `Bool true);
+                  ] );
+              ( "likeViaRepost",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool false);
+                    ("push", `Bool false);
+                  ] );
+              ( "mention",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool true);
+                    ("push", `Bool true);
+                  ] );
+              ( "quote",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool true);
+                    ("push", `Bool true);
+                  ] );
+              ( "reply",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool true);
+                    ("push", `Bool true);
+                  ] );
+              ( "repost",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool true);
+                    ("push", `Bool false);
+                  ] );
+              ( "repostViaRepost",
+                `Assoc
+                  [
+                    ("include", `String "all");
+                    ("list", `Bool false);
+                    ("push", `Bool false);
+                  ] );
+              ( "starterpackJoined",
+                `Assoc [ ("list", `Bool true); ("push", `Bool false) ] );
+              ( "subscribedPost",
+                `Assoc [ ("list", `Bool true); ("push", `Bool true) ] );
+              ( "unverified",
+                `Assoc [ ("list", `Bool true); ("push", `Bool false) ] );
+              ( "verified",
+                `Assoc [ ("list", `Bool true); ("push", `Bool true) ] );
+            ] );
+      ]
+  in
+  let prefs = Notification.parse_preferences json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "follows" prefs.like.include_;
+  OUnit2.assert_equal true prefs.verified.push;
+  let encoded = Notification.preferences_to_json prefs in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "follows"
+    (encoded |> member "like" |> member "include" |> to_string)
 
 let test_get_unread_count _ =
   skip_if
@@ -78,6 +210,8 @@ let suite =
   "suite"
   >::: [
          "test_parse_unread_and_like" >:: test_parse_unread_and_like;
+         "test_parse_mention_and_via_repost" >:: test_parse_mention_and_via_repost;
+         "test_parse_preferences" >:: test_parse_preferences;
          "test_get_unread_count" >:: test_get_unread_count;
          "test_list_notifications" >:: test_list_notifications;
          "test_update_seen" >:: test_update_seen;

--- a/test/test_notification.ml
+++ b/test/test_notification.ml
@@ -43,8 +43,7 @@ let test_parse_unread_and_like _ =
         ])
       "quote"
   with
-  | `Quote q ->
-      OUnit2.assert_equal ~printer:(fun x -> x) "hi" q.text
+  | `Quote q -> OUnit2.assert_equal ~printer:(fun x -> x) "hi" q.text
   | _ -> OUnit2.assert_failure "expected quote record"
 
 let test_parse_mention_and_via_repost _ =
@@ -72,7 +71,8 @@ let test_parse_mention_and_via_repost _ =
                  ( "uri",
                    `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
                  );
-                 ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+                 ( "cid",
+                   `String "bafyreihdummy000000000000000000000000000000000" );
                ] );
            ("createdAt", `String "2024-01-01T00:00:00.000Z");
          ])
@@ -156,8 +156,7 @@ let test_parse_preferences _ =
                 `Assoc [ ("list", `Bool true); ("push", `Bool true) ] );
               ( "unverified",
                 `Assoc [ ("list", `Bool true); ("push", `Bool false) ] );
-              ( "verified",
-                `Assoc [ ("list", `Bool true); ("push", `Bool true) ] );
+              ("verified", `Assoc [ ("list", `Bool true); ("push", `Bool true) ]);
             ] );
       ]
   in
@@ -210,7 +209,8 @@ let suite =
   "suite"
   >::: [
          "test_parse_unread_and_like" >:: test_parse_unread_and_like;
-         "test_parse_mention_and_via_repost" >:: test_parse_mention_and_via_repost;
+         "test_parse_mention_and_via_repost"
+         >:: test_parse_mention_and_via_repost;
          "test_parse_preferences" >:: test_parse_preferences;
          "test_get_unread_count" >:: test_get_unread_count;
          "test_list_notifications" >:: test_list_notifications;

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -62,6 +62,69 @@ let test_takedown_event _ =
     "tools.ozone.moderation.defs#modEventTakedown"
     (ev |> member "$type" |> to_string)
 
+let test_parse_timeline_and_schedule _ =
+  let timeline =
+    Ozone.parse_account_timeline
+      (`Assoc
+        [
+          ( "timeline",
+            `List
+              [
+                `Assoc
+                  [
+                    ("day", `String "2024-01-01");
+                    ( "summary",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("eventSubjectType", `String "account");
+                              ( "eventType",
+                                `String
+                                  "tools.ozone.moderation.defs#modEventTakedown"
+                              );
+                              ("count", `Int 2);
+                            ];
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length timeline.timeline);
+  OUnit2.assert_equal 2 (List.hd (List.hd timeline.timeline).summary).count;
+  let result =
+    Ozone.parse_batch_result
+      (`Assoc
+        [
+          ("succeeded", `List [ `String "did:plc:abc123xyz0001112223333" ]);
+          ( "failed",
+            `List
+              [
+                `Assoc
+                  [
+                    ("did", `String "did:plc:fail000111222333444555666");
+                    ("error", `String "busy");
+                    ("errorCode", `String "Conflict");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length result.succeeded);
+  OUnit2.assert_equal ~printer:(fun x -> x) "busy" (List.hd result.failed).error;
+  let body =
+    Ozone.schedule_action_body
+      ~action:(Ozone.takedown_action ~comment:"spam" ())
+      ~subjects:[ "did:plc:abc123xyz0001112223333" ]
+      ~created_by:"did:plc:mod000111222333444555666"
+      ~scheduling:{ execute_at = Some "2024-02-01T00:00:00.000Z"; execute_after = None; execute_until = None }
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "tools.ozone.moderation.scheduleAction#takedown"
+    (body |> member "action" |> member "$type" |> to_string)
+
 let test_query_statuses_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -81,6 +144,7 @@ let suite =
          "test_parse_statuses" >:: test_parse_statuses;
          "test_emit_event_body" >:: test_emit_event_body;
          "test_takedown_event" >:: test_takedown_event;
+         "test_parse_timeline_and_schedule" >:: test_parse_timeline_and_schedule;
          "test_query_statuses_auth_skipped" >:: test_query_statuses_auth_skipped;
        ]
 

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -116,7 +116,12 @@ let test_parse_timeline_and_schedule _ =
       ~action:(Ozone.takedown_action ~comment:"spam" ())
       ~subjects:[ "did:plc:abc123xyz0001112223333" ]
       ~created_by:"did:plc:mod000111222333444555666"
-      ~scheduling:{ execute_at = Some "2024-02-01T00:00:00.000Z"; execute_after = None; execute_until = None }
+      ~scheduling:
+        {
+          execute_at = Some "2024-02-01T00:00:00.000Z";
+          execute_after = None;
+          execute_until = None;
+        }
       ()
   in
   let open Yojson.Safe.Util in

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -1,0 +1,113 @@
+open OUnit2
+open Atproto.Records
+open Atproto.Facet
+open Atproto.Embed
+
+let test_post_builder _ =
+  let facets = [ Facet.tag ~byte_start:0 ~byte_end:8 "atproto" ] in
+  let embed =
+    `Record
+      {
+        Embed.embed_type = "app.bsky.embed.record";
+        record =
+          {
+            uri = "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a";
+            cid = "bafyreihdummy000000000000000000000000000000000";
+          };
+      }
+  in
+  let json =
+    Records.post ~text:"#atproto quote" ~created_at:"2024-01-01T00:00:00.000Z"
+      ~langs:[ "en" ] ~facets ~embed ~tags:[ "dev" ] ~self_labels:[ "graphic-media" ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.feed.post"
+    (json |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.embed.record"
+    (json |> member "embed" |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "graphic-media"
+    (json |> member "labels" |> member "values" |> to_list |> List.hd
+   |> member "val" |> to_string)
+
+let test_graph_and_like_builders _ =
+  let like =
+    Records.like ~uri:"at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+      ~cid:"bafyreihdummy000000000000000000000000000000000"
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  let follow =
+    Records.follow ~subject:"did:plc:alice000111222333444555666"
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  let block =
+    Records.block ~subject:"did:plc:bob000111222333444555666777"
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  let profile =
+    Records.profile ~display_name:"Ada" ~pronouns:"she/her"
+      ~website:"https://atproto.com" ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.feed.like" (like |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:alice000111222333444555666"
+    (follow |> member "subject" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.graph.block" (block |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "Ada"
+    (profile |> member "displayName" |> to_string)
+
+let test_parse_like_and_follow _ =
+  let like =
+    Records.parse_like
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.feed.like");
+          ( "subject",
+            `Assoc
+              [
+                ( "uri",
+                  `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+                );
+                ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+              ] );
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ])
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" like.subject.uri;
+  let follow =
+    Records.parse_follow
+      (`Assoc
+        [
+          ("subject", `String "did:plc:alice000111222333444555666");
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ])
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:alice000111222333444555666" follow.subject
+
+let suite =
+  "records"
+  >::: [
+         "test_post_builder" >:: test_post_builder;
+         "test_graph_and_like_builders" >:: test_graph_and_like_builders;
+         "test_parse_like_and_follow" >:: test_parse_like_and_follow;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -6,20 +6,24 @@ open Atproto.Embed
 let test_post_builder _ =
   let facets = [ Facet.tag ~byte_start:0 ~byte_end:8 "atproto" ] in
   let embed =
-    `Record
-      {
-        Embed.embed_type = "app.bsky.embed.record";
-        record =
-          {
-            uri = "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a";
-            cid = "bafyreihdummy000000000000000000000000000000000";
-          };
-      }
+    Embed.parse_embed
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.embed.record");
+          ( "record",
+            `Assoc
+              [
+                ( "uri",
+                  `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a"
+                );
+                ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+              ] );
+        ])
   in
   let json =
     Records.post ~text:"#atproto quote" ~created_at:"2024-01-01T00:00:00.000Z"
-      ~langs:[ "en" ] ~facets ~embed ~tags:[ "dev" ] ~self_labels:[ "graphic-media" ]
-      ()
+      ~langs:[ "en" ] ~facets ~embed ~tags:[ "dev" ]
+      ~self_labels:[ "graphic-media" ] ()
   in
   let open Yojson.Safe.Util in
   OUnit2.assert_equal
@@ -57,14 +61,16 @@ let test_graph_and_like_builders _ =
   let open Yojson.Safe.Util in
   OUnit2.assert_equal
     ~printer:(fun x -> x)
-    "app.bsky.feed.like" (like |> member "$type" |> to_string);
+    "app.bsky.feed.like"
+    (like |> member "$type" |> to_string);
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "did:plc:alice000111222333444555666"
     (follow |> member "subject" |> to_string);
   OUnit2.assert_equal
     ~printer:(fun x -> x)
-    "app.bsky.graph.block" (block |> member "$type" |> to_string);
+    "app.bsky.graph.block"
+    (block |> member "$type" |> to_string);
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "Ada"

--- a/test/test_repo.ml
+++ b/test/test_repo.ml
@@ -139,6 +139,90 @@ let test_parse_list_missing_blobs _ =
     "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
     (List.hd missing.blobs).cid
 
+let test_parse_record_get_and_describe _ =
+  let rec_ =
+    Repo.parse_record_get
+      (`Assoc
+        [
+          ( "uri",
+            `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+          ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+          ( "value",
+            `Assoc
+              [
+                ("$type", `String "app.bsky.feed.post");
+                ("text", `String "hello");
+                ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                ("tags", `List [ `String "atp" ]);
+                ( "labels",
+                  `Assoc
+                    [
+                      ("$type", `String "com.atproto.label.defs#selfLabels");
+                      ( "values",
+                        `List [ `Assoc [ ("val", `String "nudity") ] ] );
+                    ] );
+              ] );
+        ])
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" rec_.uri;
+  let post = Repo.parse_post_record rec_.value in
+  OUnit2.assert_equal (Some [ "atp" ]) post.tags;
+  OUnit2.assert_equal (Some [ "nudity" ]) post.self_labels;
+  let desc =
+    Repo.parse_repo_description
+      (`Assoc
+        [
+          ("handle", `String "alice.test");
+          ("did", `String "did:plc:alice000111222333444555666");
+          ("didDoc", `Assoc [ ("id", `String "did:plc:alice000111222333444555666") ]);
+          ("collections", `List [ `String "app.bsky.feed.post" ]);
+          ("handleIsCorrect", `Bool true);
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "alice.test" desc.handle;
+  OUnit2.assert_equal true desc.handle_is_correct;
+  let listed =
+    Repo.parse_listed_records
+      (`Assoc
+        [
+          ("cursor", `String "next");
+          ( "records",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+                    ( "cid",
+                      `String "bafyreihdummy000000000000000000000000000000000"
+                    );
+                    ("value", `Assoc [ ("text", `String "hello") ]);
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length listed.records);
+  let write =
+    Repo.parse_write_result
+      (`Assoc
+        [
+          ( "uri",
+            `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+          ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+          ( "commit",
+            `Assoc
+              [
+                ("cid", `String "bafyreihdummy000000000000000000000000000000000");
+                ("rev", `String "3jzfcijpj2z2a");
+              ] );
+          ("validationStatus", `String "valid");
+        ])
+  in
+  OUnit2.assert_equal (Some "valid") write.validation_status
+
 let test_import_repo_url _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -156,6 +240,7 @@ let suite =
          "test_apply_writes_body" >:: test_apply_writes_body;
          "test_parse_blob_ref" >:: test_parse_blob_ref;
          "test_parse_list_missing_blobs" >:: test_parse_list_missing_blobs;
+         "test_parse_record_get_and_describe" >:: test_parse_record_get_and_describe;
          "test_import_repo_url" >:: test_import_repo_url;
        ]
 

--- a/test/test_repo.ml
+++ b/test/test_repo.ml
@@ -144,8 +144,7 @@ let test_parse_record_get_and_describe _ =
     Repo.parse_record_get
       (`Assoc
         [
-          ( "uri",
-            `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+          ("uri", `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a");
           ("cid", `String "bafyreihdummy000000000000000000000000000000000");
           ( "value",
             `Assoc
@@ -158,8 +157,7 @@ let test_parse_record_get_and_describe _ =
                   `Assoc
                     [
                       ("$type", `String "com.atproto.label.defs#selfLabels");
-                      ( "values",
-                        `List [ `Assoc [ ("val", `String "nudity") ] ] );
+                      ("values", `List [ `Assoc [ ("val", `String "nudity") ] ]);
                     ] );
               ] );
         ])
@@ -176,7 +174,8 @@ let test_parse_record_get_and_describe _ =
         [
           ("handle", `String "alice.test");
           ("did", `String "did:plc:alice000111222333444555666");
-          ("didDoc", `Assoc [ ("id", `String "did:plc:alice000111222333444555666") ]);
+          ( "didDoc",
+            `Assoc [ ("id", `String "did:plc:alice000111222333444555666") ] );
           ("collections", `List [ `String "app.bsky.feed.post" ]);
           ("handleIsCorrect", `Bool true);
         ])
@@ -209,8 +208,7 @@ let test_parse_record_get_and_describe _ =
     Repo.parse_write_result
       (`Assoc
         [
-          ( "uri",
-            `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a" );
+          ("uri", `String "at://did:plc:alice/app.bsky.feed.post/3jzfcijpj2z2a");
           ("cid", `String "bafyreihdummy000000000000000000000000000000000");
           ( "commit",
             `Assoc
@@ -240,7 +238,8 @@ let suite =
          "test_apply_writes_body" >:: test_apply_writes_body;
          "test_parse_blob_ref" >:: test_parse_blob_ref;
          "test_parse_list_missing_blobs" >:: test_parse_list_missing_blobs;
-         "test_parse_record_get_and_describe" >:: test_parse_record_get_and_describe;
+         "test_parse_record_get_and_describe"
+         >:: test_parse_record_get_and_describe;
          "test_import_repo_url" >:: test_import_repo_url;
        ]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the next highest-leverage library work after #70–#77: current Bluesky/AT Protocol lexicon alignment for AppView records and the remaining chat/ozone/notification XRPC surfaces.

## What landed

- **`Embed`**: `app.bsky.embed.gallery` (+ `#view`), `app.bsky.embed.record#view` union (`viewRecord` / `viewNotFound` / `viewBlocked` / `viewDetached` / named generator/list/labeler/starter-pack views), `embed_to_json`, and `getEmbedExternalView` parse/client
- **`Facet`**: `facet_to_json` / `facets_to_json` plus `mention` / `link` / `tag` builders
- **`Feed` / `Repo`**: post records carry `embed`, `tags`, and `#selfLabels`; `post_view` parses embed + `quoteCount`; typed `describeRepo` / `getRecord` / `listRecords` / write-result parsers (legacy string APIs kept)
- **`Records`**: builders + parsers for post, like, repost, follow, block, listblock, profile
- **`Notification`**: all `listNotifications` known reasons (`quote`, `mention`, `*-via-repost`, starterpack, verified, subscribed-post, contact-match); prefs / prefs-v2 / activity subscriptions / register+unregister push
- **`Chat`**: accept, leave, reactions, delete-for-self, availability, log, unread counts, requests, batch send, `updateAllRead`
- **`Ozone`**: getRecords/getRepos/getSubjects, searchRepos, account timeline, reporter stats, schedule/list/cancel scheduled actions
- **`Identity`**: typed `resolveDid` DID-document parse
- Fixture tests (no invented Bluesky credentials; live auth suites still skip without real `ATP_AUTH`)
- README / `examples/offline.ml` updated to the current public API

GitHub Action majors are unchanged (`checkout@v4`, `setup-ocaml@v3`, `cache@v4`, `upload-artifact@v4`).

## Leftovers (explicit)

- Feed thread types remain the original (sometimes inaccurate) shapes; `post` / `thread_post` views still omit top-level embed
- Chat message facets/reactions/attachments stay on `original` JSON; lock/unlock/group-admin convo methods are not wrapped
- Ozone event/subject payloads remain `Yojson.Safe.t`
- `Lexicon.to_ocaml` still emits unions as `Yojson.Safe.t`; no bundled official lexicon JSON
- `Http_client` H2 stub and unused `Request`/`Response` types
- `chat.bsky.notification.*` preference endpoints (moved off `app.bsky.notification` in 2026)
- Graph list/starter-pack **record** builders beyond follow/block/listblock
- Product/hosted work skipped per brief (public OAuth client-metadata URL, browser login, hosted PDS/Tap/transcoder/Ozone session, Jetstream archive operator token, permissioned data/LtHash)

## Test plan

- `dune build` and `dune runtest` (fixture tests; live Bluesky auth tests skip without `ATP_AUTH`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10430e07-2500-4708-b7ae-bdcbe598d32d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10430e07-2500-4708-b7ae-bdcbe598d32d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

