### PR TITLE
Lexicon-accurate threads, typed chat/ozone payloads, and graph record builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | --- | --- | --- |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
 | AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences |
-| AppView feed | `Feed` | Timeline, threads, generators (`getFeed` / `getFeedGenerator` / `getActorFeeds`), `searchPosts`, quotes, list feed, interactions |
+| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts), generators, `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including reactions, requests, leave/accept, log, unread counts, batch send, `updateAllRead`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
-| Ozone | `Ozone` | `tools.ozone.moderation.*` including subjects/repos/records, account timeline, reporter stats, scheduled actions + `getConfig`; requires `atproto-proxy` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `chat.bsky.group` add/remove/edit, `chat.bsky.notification.getPreferences` / `putPreferences`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions (repoRef / strongRef / messageRef / convoRef), subjects/repos/records, account timeline, reporter stats, scheduled actions + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
-| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/profile |
+| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile |
 | Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` (aud may be `did#service`) |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` DID document + updateHandle / PLC operation helpers |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
@@ -55,7 +55,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Repo sync (TAP-like) | `Repo_sync` | Library-shaped backfill: open/verify repo CAR, walk records, `getRecord` inclusion proof (partial CAR), record-table apply of firehose ops, `#sync` desync, MST-level `apply_commit_tree`, Sync 1.1 pre-order export + collection-subset CAR. Not a hosted Tap service |
 | TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
-| Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen, JSON validate |
+| Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen (unions emit polymorphic variants), JSON validate, small bundled official lexicon documents |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
 | OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
 | Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) + `#selfLabels` |

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -6,6 +6,9 @@ open Atproto.Embed
 open Atproto.Facet
 open Atproto.Records
 open Atproto.Notification
+open Atproto.Feed
+open Atproto.Chat
+open Atproto.Ozone
 open Atproto.Identity
 open Atproto.Lexicon
 open Atproto.Tid
@@ -119,6 +122,63 @@ let () =
     Records.post ~text:"hello" ~created_at:"2024-01-01T00:00:00.000Z"
       ~tags:[ "atp" ] ()
   in
+  let list =
+    Records.list ~name:"Friends" ~purpose:Records.purpose_curatelist
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" list with
+    | `String "app.bsky.graph.list" -> true
+    | _ -> false);
+  let pack =
+    Records.starterpack ~name:"Start"
+      ~list:"at://did:plc:abc123xyz0001112223333/app.bsky.graph.list/3k"
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" pack with
+    | `String "app.bsky.graph.starterpack" -> true
+    | _ -> false);
+  (match
+     Feed.parse_thread_feed
+       (`Assoc
+         [
+           ( "thread",
+             `Assoc
+               [
+                 ("$type", `String "app.bsky.feed.defs#notFoundPost");
+                 ( "uri",
+                   `String
+                     "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+                 );
+                 ("notFound", `Bool true);
+               ] );
+         ])
+   with
+  | { thread = `NotFound n; _ } -> assert n.not_found
+  | _ -> assert false);
+  let chat_prefs =
+    Chat.parse_notification_preferences
+      (`Assoc
+        [
+          ("chat", `Assoc [ ("include", `String "all"); ("push", `Bool true) ]);
+          ( "chatRequest",
+            `Assoc [ ("include", `String "follows"); ("push", `Bool false) ] );
+        ])
+  in
+  assert chat_prefs.chat.push;
+  (match
+     Ozone.parse_subject
+       (`Assoc
+         [
+           ("$type", `String "com.atproto.admin.defs#repoRef");
+           ("did", `String "did:plc:abc123xyz0001112223333");
+         ])
+   with
+  | `Repo_ref r -> assert (r.did <> "")
+  | _ -> assert false);
+  let lex_docs = Lexicon.official_documents () in
+  assert (List.length lex_docs >= 5);
   assert (
     match Yojson.Safe.Util.member "$type" post with
     | `String "app.bsky.feed.post" -> true

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -12,13 +12,6 @@ module Feed = struct
    * combination ie. type feed_post, type feed_reply, feed_repost, feed_like?, feed_follow?
    * *)
 
-  type thread_record = {
-    text : string;
-    record_type : string;
-    reply : Notification.reply;
-    created_at : string;
-  }
-
   type post_record = {
     text : string;
     record_type : string;
@@ -27,23 +20,13 @@ module Feed = struct
     embed : Embed.embed option;
     tags : string list option;
     self_labels : string list option;
+    reply : Notification.reply option;
     created_at : string;
   }
 
-  type reply_record = {
-    text : string;
-    record_type : string;
-    langs : string list option;
-    reply : Notification.reply;
-    created_at : string;
-  }
-
-  type repost_record = {
-    text : string;
-    record_type : string;
-    created_at : string;
-  }
-
+  type thread_record = post_record
+  type reply_record = post_record
+  type repost_record = post_record
   type like_viewer = { like : string }
   type repost_viewer = { repost : string; like : string }
 
@@ -74,54 +57,30 @@ module Feed = struct
     reply_count : int;
     repost_count : int;
     like_count : int;
+    quote_count : int option;
+    bookmark_count : int option;
     indexed_at : string;
     viewer : feed_viewer;
     labels : string list option;
+    embed : Embed.embed option;
   }
 
-  type reply_post = {
+  type reply_post = post
+  type repost_post = post
+  type thread_post = post
+  type not_found_post = { uri : string; not_found : bool }
+
+  type blocked_post = {
     uri : string;
-    cid : string;
-    author : Actor.typeahead_profile;
-    record : reply_record;
-    reply_count : int;
-    repost_count : int;
-    like_count : int;
-    indexed_at : string;
-    viewer : feed_viewer;
-    labels : string list option;
+    blocked : bool;
+    author_did : string option;
   }
 
-  type repost_post = {
-    uri : string;
-    cid : string;
-    author : Actor.typeahead_profile;
-    record : repost_record;
-    reply_count : int;
-    repost_count : int;
-    like_count : int;
-    indexed_at : string;
-    viewer : feed_viewer;
-    labels : string list option;
-  }
+  type reply_ref_item =
+    [ `Post of post | `NotFound of not_found_post | `Blocked of blocked_post ]
 
-  type thread_post = {
-    uri : string;
-    cid : string;
-    author : Actor.typeahead_profile;
-    record : thread_record;
-    reply_count : int;
-    repost_count : int;
-    like_count : int;
-    indexed_at : string;
-    viewer : feed_viewer;
-    labels : string list option;
-  }
-
-  (* lies *)
-  type reply = { root : repost_post; parent : repost_post }
+  type reply = { root : reply_ref_item; parent : reply_ref_item }
   type reply_feed = { post : reply_post; reply : reply }
-  type replies = { replies_type : string; post : reply_post }
 
   type reason = {
     reason_type : string;
@@ -170,42 +129,53 @@ module Feed = struct
   let extract_self_labels_option json : string list option =
     Label.Label.parse_self_labels (Yojson.Safe.Util.member "labels" json)
 
+  let string_or_empty json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
+
+  let int_or_zero json field =
+    match Yojson.Safe.Util.member field json with `Int n -> n | _ -> 0
+
+  let int_opt json field =
+    match Yojson.Safe.Util.member field json with `Int n -> Some n | _ -> None
+
+  let type_name json =
+    match Yojson.Safe.Util.member "$type" json with `String s -> s | _ -> ""
+
+  let ends_with suffix s =
+    let n = String.length suffix in
+    let m = String.length s in
+    m >= n && String.sub s (m - n) n = suffix
+
+  let parse_reply_ref json : Notification.reply option =
+    match Yojson.Safe.Util.member "reply" json with
+    | `Assoc _ as r -> ( try Some (Notification.parse_reply r) with _ -> None)
+    | _ -> None
+
   let parse_post_record json : post_record =
-    let open Yojson.Safe.Util in
-    let text = json |> member "text" |> to_string in
-    let record_type = json |> member "$type" |> to_string in
+    let text = string_or_empty json "text" in
+    let record_type = string_or_empty json "$type" in
     let langs = extract_langs_option json in
     let facets = extract_facets_option json in
     let embed = Embed.parse_embed_option json in
     let tags = extract_tags_option json in
     let self_labels = extract_self_labels_option json in
-    let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; langs; facets; embed; tags; self_labels; created_at }
+    let reply = parse_reply_ref json in
+    let created_at = string_or_empty json "createdAt" in
+    {
+      text;
+      record_type;
+      langs;
+      facets;
+      embed;
+      tags;
+      self_labels;
+      reply;
+      created_at;
+    }
 
-  let parse_reply_record json : reply_record =
-    let open Yojson.Safe.Util in
-    let text = json |> member "text" |> to_string in
-    let record_type = json |> member "$type" |> to_string in
-    let langs = extract_langs_option json in
-    let reply = json |> member "reply" |> Notification.parse_reply in
-    let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; langs; reply; created_at }
-
-  let parse_thread_record json : thread_record =
-    let open Yojson.Safe.Util in
-    let text = json |> member "text" |> to_string in
-    let record_type = json |> member "$type" |> to_string in
-    (* MAYBE REPLY NOW ALWAYS HERE *)
-    let reply = json |> member "reply" |> Notification.parse_reply in
-    let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; reply; created_at }
-
-  let parse_repost_record json : repost_record =
-    let open Yojson.Safe.Util in
-    let text = json |> member "text" |> to_string in
-    let record_type = json |> member "$type" |> to_string in
-    let created_at = json |> member "createdAt" |> to_string in
-    { text; record_type; created_at }
+  let parse_reply_record json : reply_record = parse_post_record json
+  let parse_thread_record json : thread_record = parse_post_record json
+  let parse_repost_record json : repost_record = parse_post_record json
 
   let parse_like_viewer json : like_viewer =
     let open Yojson.Safe.Util in
@@ -234,16 +204,19 @@ module Feed = struct
 
   let parse_post json : post =
     let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
-    let cid = json |> member "cid" |> to_string in
+    let uri = string_or_empty json "uri" in
+    let cid = string_or_empty json "cid" in
     let author = json |> member "author" |> Actor.parse_typeahead_profile in
     let record = json |> member "record" |> parse_post_record in
-    let reply_count = json |> member "replyCount" |> to_int in
-    let repost_count = json |> member "repostCount" |> to_int in
-    let like_count = json |> member "likeCount" |> to_int in
-    let indexed_at = json |> member "indexedAt" |> to_string in
+    let reply_count = int_or_zero json "replyCount" in
+    let repost_count = int_or_zero json "repostCount" in
+    let like_count = int_or_zero json "likeCount" in
+    let quote_count = int_opt json "quoteCount" in
+    let bookmark_count = int_opt json "bookmarkCount" in
+    let indexed_at = string_or_empty json "indexedAt" in
     let viewer = json |> member "viewer" |> parse_feed_viewer in
     let labels = Label.Label.parse_label_values (json |> member "labels") in
+    let embed = Embed.parse_embed_option json in
     {
       uri;
       cid;
@@ -252,60 +225,16 @@ module Feed = struct
       reply_count;
       repost_count;
       like_count;
+      quote_count;
+      bookmark_count;
       indexed_at;
       viewer;
       labels;
+      embed;
     }
 
-  let parse_reply_post json : reply_post =
-    let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
-    let cid = json |> member "cid" |> to_string in
-    let author = json |> member "author" |> Actor.parse_typeahead_profile in
-    let record = json |> member "record" |> parse_reply_record in
-    let reply_count = json |> member "replyCount" |> to_int in
-    let repost_count = json |> member "repostCount" |> to_int in
-    let like_count = json |> member "likeCount" |> to_int in
-    let indexed_at = json |> member "indexedAt" |> to_string in
-    let viewer = json |> member "viewer" |> parse_feed_viewer in
-    let labels = Label.Label.parse_label_values (json |> member "labels") in
-    {
-      uri;
-      cid;
-      author;
-      record;
-      reply_count;
-      repost_count;
-      like_count;
-      indexed_at;
-      viewer;
-      labels;
-    }
-
-  let parse_thread_post json : thread_post =
-    let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
-    let cid = json |> member "cid" |> to_string in
-    let author = json |> member "author" |> Actor.parse_typeahead_profile in
-    let record = json |> member "record" |> parse_thread_record in
-    let reply_count = json |> member "replyCount" |> to_int in
-    let repost_count = json |> member "repostCount" |> to_int in
-    let like_count = json |> member "likeCount" |> to_int in
-    let indexed_at = json |> member "indexedAt" |> to_string in
-    let viewer = json |> member "viewer" |> parse_feed_viewer in
-    let labels = Label.Label.parse_label_values (json |> member "labels") in
-    {
-      uri;
-      cid;
-      author;
-      record;
-      reply_count;
-      repost_count;
-      like_count;
-      indexed_at;
-      viewer;
-      labels;
-    }
+  let parse_reply_post json : reply_post = parse_post json
+  let parse_thread_post json : thread_post = parse_post json
 
   let parse_like json : like =
     let open Yojson.Safe.Util in
@@ -329,35 +258,56 @@ module Feed = struct
     let indexed_at = json |> member "indexedAt" |> to_string in
     { reason_type; by; indexed_at }
 
-  let parse_repost_post json : repost_post =
-    let open Yojson.Safe.Util in
-    let uri = json |> member "uri" |> to_string in
-    let cid = json |> member "cid" |> to_string in
-    let author = json |> member "author" |> Actor.parse_typeahead_profile in
-    let record = json |> member "record" |> parse_repost_record in
-    let reply_count = json |> member "replyCount" |> to_int in
-    let repost_count = json |> member "repostCount" |> to_int in
-    let like_count = json |> member "likeCount" |> to_int in
-    let indexed_at = json |> member "indexedAt" |> to_string in
-    let viewer = json |> member "viewer" |> parse_feed_viewer in
-    let labels = Label.Label.parse_label_values (json |> member "labels") in
+  let parse_repost_post json : repost_post = parse_post json
+
+  let parse_not_found_post json : not_found_post =
     {
-      uri;
-      cid;
-      author;
-      record;
-      reply_count;
-      repost_count;
-      like_count;
-      indexed_at;
-      viewer;
-      labels;
+      uri = string_or_empty json "uri";
+      not_found =
+        (match Yojson.Safe.Util.member "notFound" json with
+        | `Bool b -> b
+        | _ -> true);
     }
+
+  let parse_blocked_post json : blocked_post =
+    let author = Yojson.Safe.Util.member "author" json in
+    {
+      uri = string_or_empty json "uri";
+      blocked =
+        (match Yojson.Safe.Util.member "blocked" json with
+        | `Bool b -> b
+        | _ -> true);
+      author_did =
+        (match author with
+        | `Assoc _ -> (
+            match Yojson.Safe.Util.member "did" author with
+            | `String s -> Some s
+            | _ -> None)
+        | _ -> None);
+    }
+
+  let parse_reply_ref_item json : reply_ref_item =
+    let t = type_name json in
+    if
+      ends_with "notFoundPost" t
+      ||
+      match Yojson.Safe.Util.member "notFound" json with
+      | `Bool true -> true
+      | _ -> false
+    then `NotFound (parse_not_found_post json)
+    else if
+      ends_with "blockedPost" t
+      ||
+      match Yojson.Safe.Util.member "blocked" json with
+      | `Bool true -> true
+      | _ -> false
+    then `Blocked (parse_blocked_post json)
+    else `Post (parse_post json)
 
   let parse_reply json : reply =
     let open Yojson.Safe.Util in
-    let root = json |> member "root" |> parse_repost_post in
-    let parent = json |> member "parent" |> parse_repost_post in
+    let root = json |> member "root" |> parse_reply_ref_item in
+    let parent = json |> member "parent" |> parse_reply_ref_item in
     { root; parent }
 
   let parse_repost_feed json : repost_feed =
@@ -404,50 +354,84 @@ module Feed = struct
     in
     { cursor; feed }
 
-  let parse_replies json : replies =
-    let open Yojson.Safe.Util in
-    let replies_type = json |> member "$type" |> to_string in
-    let post = json |> member "post" |> parse_reply_post in
-    { replies_type; post }
-
-  type thread_parent = {
-    thread_type : string;
-    post : repost_post;
-    replies : replies list;
-  }
+  type thread_context = { root_author_like : string option }
 
   type thread = {
     thread_type : string;
     post : thread_post;
-    parent : thread_parent;
-    replies : replies list;
+    parent : thread_item option;
+    replies : thread_item list;
+    thread_context : thread_context option;
   }
 
-  type thread_feed = { thread : thread }
+  and thread_item =
+    [ `Thread of thread
+    | `NotFound of not_found_post
+    | `Blocked of blocked_post ]
 
-  let parse_thread_parent json : thread_parent =
-    let open Yojson.Safe.Util in
-    let thread_type = json |> member "$type" |> to_string in
-    let post = json |> member "post" |> parse_repost_post in
-    let replies =
-      json |> member "replies" |> to_list |> List.map parse_replies
-    in
-    { thread_type; post; replies }
+  type replies = thread_item
+  type thread_parent = thread
+  type thread_feed = { thread : thread_item; threadgate : Yojson.Safe.t option }
 
-  let parse_thread json : thread =
+  let parse_thread_context json : thread_context =
+    {
+      root_author_like =
+        (match Yojson.Safe.Util.member "rootAuthorLike" json with
+        | `String s -> Some s
+        | _ -> None);
+    }
+
+  let rec parse_thread_item json : thread_item =
+    let t = type_name json in
+    if
+      ends_with "notFoundPost" t
+      ||
+      match Yojson.Safe.Util.member "notFound" json with
+      | `Bool true -> true
+      | _ -> false
+    then `NotFound (parse_not_found_post json)
+    else if
+      ends_with "blockedPost" t
+      ||
+      match Yojson.Safe.Util.member "blocked" json with
+      | `Bool true -> true
+      | _ -> false
+    then `Blocked (parse_blocked_post json)
+    else `Thread (parse_thread json)
+
+  and parse_thread json : thread =
     let open Yojson.Safe.Util in
-    let thread_type = json |> member "$type" |> to_string in
+    let thread_type = type_name json in
     let post = json |> member "post" |> parse_thread_post in
-    let parent = json |> member "parent" |> parse_thread_parent in
-    let replies =
-      json |> member "replies" |> to_list |> List.map parse_replies
+    let parent =
+      match json |> member "parent" with
+      | `Assoc _ as p -> Some (parse_thread_item p)
+      | _ -> None
     in
-    { thread_type; post; parent; replies }
+    let replies =
+      match json |> member "replies" with
+      | `List xs -> List.map parse_thread_item xs
+      | _ -> []
+    in
+    let thread_context =
+      match json |> member "threadContext" with
+      | `Assoc _ as c -> Some (parse_thread_context c)
+      | _ -> None
+    in
+    { thread_type; post; parent; replies; thread_context }
+
+  let parse_replies json : replies = parse_thread_item json
+  let parse_thread_parent json : thread_parent = parse_thread json
 
   let parse_thread_feed json : thread_feed =
     let open Yojson.Safe.Util in
-    let thread = json |> member "thread" |> parse_thread in
-    { thread }
+    {
+      thread = json |> member "thread" |> parse_thread_item;
+      threadgate =
+        (match json |> member "threadgate" with
+        | `Assoc _ as g -> Some g
+        | _ -> None);
+    }
 
   let parse_posts_feed json : posts_feed =
     let open Yojson.Safe.Util in
@@ -678,8 +662,10 @@ module Feed = struct
     tags : string list option;
     indexed_at : string;
     reply_count : int option;
+    repost_count : int option;
     like_count : int option;
     quote_count : int option;
+    bookmark_count : int option;
     original : Yojson.Safe.t;
   }
 
@@ -852,10 +838,16 @@ module Feed = struct
         (match json |> member "indexedAt" with `String s -> s | _ -> "");
       reply_count =
         (match json |> member "replyCount" with `Int n -> Some n | _ -> None);
+      repost_count =
+        (match json |> member "repostCount" with `Int n -> Some n | _ -> None);
       like_count =
         (match json |> member "likeCount" with `Int n -> Some n | _ -> None);
       quote_count =
         (match json |> member "quoteCount" with `Int n -> Some n | _ -> None);
+      bookmark_count =
+        (match json |> member "bookmarkCount" with
+        | `Int n -> Some n
+        | _ -> None);
       original = json;
     }
 

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -10,7 +10,13 @@ module Records = struct
   let nsid_follow = "app.bsky.graph.follow"
   let nsid_block = "app.bsky.graph.block"
   let nsid_listblock = "app.bsky.graph.listblock"
+  let nsid_list = "app.bsky.graph.list"
+  let nsid_listitem = "app.bsky.graph.listitem"
+  let nsid_starterpack = "app.bsky.graph.starterpack"
   let nsid_profile = "app.bsky.actor.profile"
+  let purpose_modlist = "app.bsky.graph.defs#modlist"
+  let purpose_curatelist = "app.bsky.graph.defs#curatelist"
+  let purpose_referencelist = "app.bsky.graph.defs#referencelist"
 
   let strong_ref ~uri ~cid : Yojson.Safe.t =
     `Assoc [ ("uri", `String uri); ("cid", `String cid) ]
@@ -99,6 +105,65 @@ module Records = struct
         ("createdAt", `String created_at);
       ]
 
+  let list ~name ~purpose ~created_at ?description ?description_facets ?avatar
+      ?self_labels () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_list);
+        ("name", `String name);
+        ("purpose", `String purpose);
+        ("createdAt", `String created_at);
+      ]
+      @ (match description with
+        | Some s -> [ ("description", `String s) ]
+        | None -> [])
+      @ (match description_facets with
+        | Some fs -> [ ("descriptionFacets", Facet.facets_to_json fs) ]
+        | None -> [])
+      @ (match avatar with Some b -> [ ("avatar", b) ] | None -> [])
+      @
+      match self_labels with
+      | Some xs -> [ ("labels", Label.Label.self_labels_to_json xs) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let listitem ~subject ~list ~created_at () : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String nsid_listitem);
+        ("subject", `String subject);
+        ("list", `String list);
+        ("createdAt", `String created_at);
+      ]
+
+  let starterpack ~name ~list ~created_at ?description ?description_facets
+      ?feeds () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_starterpack);
+        ("name", `String name);
+        ("list", `String list);
+        ("createdAt", `String created_at);
+      ]
+      @ (match description with
+        | Some s -> [ ("description", `String s) ]
+        | None -> [])
+      @ (match description_facets with
+        | Some fs -> [ ("descriptionFacets", Facet.facets_to_json fs) ]
+        | None -> [])
+      @
+      match feeds with
+      | Some uris ->
+          [
+            ( "feeds",
+              `List (List.map (fun uri -> `Assoc [ ("uri", `String uri) ]) uris)
+            );
+          ]
+      | None -> []
+    in
+    `Assoc fields
+
   let profile ?display_name ?description ?pronouns ?website ?avatar ?banner
       ?self_labels ?pinned_post ?created_at () : Yojson.Safe.t =
     let fields =
@@ -140,6 +205,30 @@ module Records = struct
 
   type block_record = { subject : string; created_at : string }
 
+  type list_record = {
+    name : string;
+    purpose : string;
+    description : string option;
+    description_facets : Facet.facet list option;
+    created_at : string;
+    self_labels : string list option;
+  }
+
+  type listitem_record = {
+    subject : string;
+    list : string;
+    created_at : string;
+  }
+
+  type starterpack_record = {
+    name : string;
+    list : string;
+    description : string option;
+    description_facets : Facet.facet list option;
+    feeds : string list;
+    created_at : string;
+  }
+
   let parse_via json : Embed.strong_ref option =
     match Yojson.Safe.Util.member "via" json with
     | `Assoc _ as v -> Some (parse_strong_ref v)
@@ -174,4 +263,57 @@ module Records = struct
     }
 
   let parse_listblock json : block_record = parse_block json
+
+  let parse_facets_option json field : Facet.facet list option =
+    match Yojson.Safe.Util.member field json with
+    | `List xs -> Some (List.map Facet.parse_facet xs)
+    | _ -> None
+
+  let parse_list json : list_record =
+    let open Yojson.Safe.Util in
+    {
+      name = (match json |> member "name" with `String s -> s | _ -> "");
+      purpose = (match json |> member "purpose" with `String s -> s | _ -> "");
+      description =
+        (match json |> member "description" with
+        | `String s -> Some s
+        | _ -> None);
+      description_facets = parse_facets_option json "descriptionFacets";
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+      self_labels = Label.Label.parse_self_labels (json |> member "labels");
+    }
+
+  let parse_listitem json : listitem_record =
+    let open Yojson.Safe.Util in
+    {
+      subject = (match json |> member "subject" with `String s -> s | _ -> "");
+      list = (match json |> member "list" with `String s -> s | _ -> "");
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+    }
+
+  let parse_starterpack json : starterpack_record =
+    let open Yojson.Safe.Util in
+    let feeds =
+      match json |> member "feeds" with
+      | `List items ->
+          List.filter_map
+            (fun item ->
+              match item |> member "uri" with `String s -> Some s | _ -> None)
+            items
+      | _ -> []
+    in
+    {
+      name = (match json |> member "name" with `String s -> s | _ -> "");
+      list = (match json |> member "list" with `String s -> s | _ -> "");
+      description =
+        (match json |> member "description" with
+        | `String s -> Some s
+        | _ -> None);
+      description_facets = parse_facets_option json "descriptionFacets";
+      feeds;
+      created_at =
+        (match json |> member "createdAt" with `String s -> s | _ -> "");
+    }
 end

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -1,6 +1,8 @@
 open Session
 open Client
 open Xrpc
+open Facet
+open Embed
 
 (** chat.bsky.convo — DMs. Requests must include atproto-proxy for the chat service. *)
 module Chat = struct
@@ -15,6 +17,8 @@ module Chat = struct
     display_name : string option;
   }
 
+  type reaction = { value : string; sender_did : string; created_at : string }
+
   type message = {
     id : string;
     rev : string;
@@ -22,6 +26,10 @@ module Chat = struct
     sender_did : string option;
     sent_at : string;
     deleted : bool;
+    facets : Facet.facet list;
+    reactions : reaction list;
+    embed : Embed.embed option;
+    reply_to_id : string option;
     original : Yojson.Safe.t;
   }
 
@@ -46,6 +54,30 @@ module Chat = struct
       display_name = Client.string_opt json "displayName";
     }
 
+  let parse_reaction json : reaction =
+    let sender_did =
+      match Yojson.Safe.Util.member "sender" json with
+      | `Assoc _ as s -> Client.string_member s "did"
+      | _ -> Client.string_member json "sender"
+    in
+    {
+      value = Client.string_member json "value";
+      sender_did;
+      created_at = Client.string_member json "createdAt";
+    }
+
+  let parse_message_facets json : Facet.facet list =
+    List.map Facet.parse_facet (Client.list_member json "facets")
+
+  let parse_reply_to_id json : string option =
+    match Yojson.Safe.Util.member "replyTo" json with
+    | `Assoc _ as r -> (
+        match Client.string_opt r "messageId" with
+        | Some id -> Some id
+        | None -> Client.string_opt r "id")
+    | `String s -> Some s
+    | _ -> None
+
   let parse_message json : message =
     let ty = Client.string_opt json "$type" in
     let deleted =
@@ -69,6 +101,10 @@ module Chat = struct
       sender_did;
       sent_at = Client.string_member json "sentAt";
       deleted;
+      facets = parse_message_facets json;
+      reactions = List.map parse_reaction (Client.list_member json "reactions");
+      embed = Embed.parse_embed_option json;
+      reply_to_id = parse_reply_to_id json;
       original = json;
     }
 
@@ -99,10 +135,15 @@ module Chat = struct
       messages = List.map parse_message (Client.list_member json "messages");
     }
 
-  let message_input ?facets ?reply_to text : Yojson.Safe.t =
+  let message_input ?facets ?embed ?reply_to text : Yojson.Safe.t =
     let fields =
       [ ("text", `String text) ]
-      @ (match facets with Some f -> [ ("facets", f) ] | None -> [])
+      @ (match facets with
+        | Some fs -> [ ("facets", Facet.facets_to_json fs) ]
+        | None -> [])
+      @ (match embed with
+        | Some e -> [ ("embed", Embed.embed_to_json e) ]
+        | None -> [])
       @
       match reply_to with
       | Some id -> [ ("replyTo", `Assoc [ ("messageId", `String id) ]) ]
@@ -110,11 +151,12 @@ module Chat = struct
     in
     `Assoc fields
 
-  let send_message_body ~convo_id ~text ?facets ?reply_to () : Yojson.Safe.t =
+  let send_message_body ~convo_id ~text ?facets ?embed ?reply_to () :
+      Yojson.Safe.t =
     `Assoc
       [
         ("convoId", `String convo_id);
-        ("message", message_input ?facets ?reply_to text);
+        ("message", message_input ?facets ?embed ?reply_to text);
       ]
 
   let update_read_body ~convo_id ?message_id () : Yojson.Safe.t =
@@ -165,12 +207,12 @@ module Chat = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_messages
 
-  let send_message (s : Session.session) ?proxy ~convo_id ~text ?facets
+  let send_message (s : Session.session) ?proxy ~convo_id ~text ?facets ?embed
       ?reply_to () : message =
     Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
       "chat.bsky.convo.sendMessage"
       (Yojson.Safe.to_string
-         (send_message_body ~convo_id ~text ?facets ?reply_to ()))
+         (send_message_body ~convo_id ~text ?facets ?embed ?reply_to ()))
     |> parse_message
 
   let update_read (s : Session.session) ?proxy ~convo_id ?message_id () : convo
@@ -231,7 +273,8 @@ module Chat = struct
   type batch_item = {
     convo_id : string;
     text : string;
-    facets : Yojson.Safe.t option;
+    facets : Facet.facet list option;
+    embed : Embed.embed option;
     reply_to : string option;
   }
 
@@ -368,8 +411,8 @@ module Chat = struct
                      [
                        ("convoId", `String i.convo_id);
                        ( "message",
-                         message_input ?facets:i.facets ?reply_to:i.reply_to
-                           i.text );
+                         message_input ?facets:i.facets ?embed:i.embed
+                           ?reply_to:i.reply_to i.text );
                      ])
                  items) );
         ]
@@ -392,12 +435,117 @@ module Chat = struct
     | `Int n -> n
     | _ -> 0
 
-  let message_input_with_facets ?facets ?reply_to text : Yojson.Safe.t =
-    let facets_json =
-      match facets with
-      | Some (`List _ as f) -> Some f
-      | Some f -> Some f
-      | None -> None
+  let message_input_with_facets ?facets ?embed ?reply_to text : Yojson.Safe.t =
+    message_input ?facets ?embed ?reply_to text
+
+  let lock_convo (s : Session.session) ?proxy ~convo_id () : convo =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.lockConvo"
+      (Yojson.Safe.to_string (convo_id_body convo_id))
+    |> unwrap_convo
+
+  let unlock_convo (s : Session.session) ?proxy ~convo_id () : convo =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.convo.unlockConvo"
+      (Yojson.Safe.to_string (convo_id_body convo_id))
+    |> unwrap_convo
+
+  type add_members_result = { convo : convo; added_members : member list }
+
+  let add_members (s : Session.session) ?proxy ~convo_id ~members () :
+      add_members_result =
+    let json =
+      Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+        "chat.bsky.group.addMembers"
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("convoId", `String convo_id);
+               ("members", `List (List.map (fun d -> `String d) members));
+             ]))
     in
-    message_input ?facets:facets_json ?reply_to text
+    {
+      convo = unwrap_convo json;
+      added_members =
+        List.map parse_member (Client.list_member json "addedMembers");
+    }
+
+  let remove_members (s : Session.session) ?proxy ~convo_id ~members () : convo
+      =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.group.removeMembers"
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("convoId", `String convo_id);
+             ("members", `List (List.map (fun d -> `String d) members));
+           ]))
+    |> unwrap_convo
+
+  let edit_group (s : Session.session) ?proxy ~convo_id ~name () : convo =
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.group.editGroup"
+      (Yojson.Safe.to_string
+         (`Assoc [ ("convoId", `String convo_id); ("name", `String name) ]))
+    |> unwrap_convo
+
+  type chat_pref = { include_ : string; push : bool }
+
+  type notification_preferences = {
+    chat : chat_pref;
+    chat_request : chat_pref;
+    original : Yojson.Safe.t;
+  }
+
+  let parse_chat_pref json : chat_pref =
+    {
+      include_ =
+        (match Client.string_opt json "include" with
+        | Some s -> s
+        | None -> "all");
+      push = Client.bool_member json "push";
+    }
+
+  let chat_pref_to_json (p : chat_pref) : Yojson.Safe.t =
+    `Assoc [ ("include", `String p.include_); ("push", `Bool p.push) ]
+
+  let parse_notification_preferences json : notification_preferences =
+    let prefs =
+      match Yojson.Safe.Util.member "preferences" json with
+      | `Assoc _ as p -> p
+      | _ -> json
+    in
+    {
+      chat =
+        (match Yojson.Safe.Util.member "chat" prefs with
+        | `Assoc _ as c -> parse_chat_pref c
+        | _ -> { include_ = "all"; push = false });
+      chat_request =
+        (match Yojson.Safe.Util.member "chatRequest" prefs with
+        | `Assoc _ as c -> parse_chat_pref c
+        | _ -> { include_ = "all"; push = false });
+      original = prefs;
+    }
+
+  let get_notification_preferences (s : Session.session) ?proxy () :
+      notification_preferences =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.notification.getPreferences" []
+    |> parse_notification_preferences
+
+  let put_notification_preferences (s : Session.session) ?proxy ?chat
+      ?chat_request () : notification_preferences =
+    let fields =
+      (match chat with
+      | Some p -> [ ("chat", chat_pref_to_json p) ]
+      | None -> [])
+      @
+      match chat_request with
+      | Some p -> [ ("chatRequest", chat_pref_to_json p) ]
+      | None -> []
+    in
+    Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.notification.putPreferences"
+      (Yojson.Safe.to_string (`Assoc fields))
+    |> parse_notification_preferences
 end

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -6,7 +6,7 @@ module Lexicon = struct
     | Integer
     | String
     | Ref
-    | Union
+    | Union of string list
     | Unknown
     | Cid_link
     | Bytes
@@ -54,7 +54,7 @@ module Lexicon = struct
     | "integer" -> Integer
     | "string" -> String
     | "ref" -> Ref
-    | "union" -> Union
+    | "union" -> Union []
     | "unknown" -> Unknown
     | "cid-link" -> Cid_link
     | "bytes" -> Bytes
@@ -79,17 +79,23 @@ module Lexicon = struct
     | `String s -> Some s
     | _ -> None
 
+  let parse_union_refs json : string list =
+    match Yojson.Safe.Util.member "refs" json with
+    | `List items ->
+        List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> []
+
   let parse_property json : primitive =
     let open Yojson.Safe.Util in
     match json |> member "type" with
     | `String "ref" -> Ref
-    | `String "union" -> Union
+    | `String "union" -> Union (parse_union_refs json)
     | `String "array" -> (
         match json |> member "items" with
         | `Assoc _ as items -> (
             match items |> member "type" with
             | `String "ref" -> Ref
-            | `String "union" -> Union
+            | `String "union" -> Union (parse_union_refs items)
             | `String t -> lookup_primitive t
             | _ -> Unknown)
         | _ -> Unknown)
@@ -196,7 +202,14 @@ module Lexicon = struct
     | Number -> "float"
     | Integer -> "int"
     | String | Ref | Cid_link | Bytes -> "string"
-    | Union | Unknown -> "Yojson.Safe.t"
+    | Union refs ->
+        if refs = [] then "Yojson.Safe.t"
+        else
+          let variant r = "`" ^ ocaml_ident r ^ " of Yojson.Safe.t" in
+          "[ "
+          ^ String.concat " | " (List.map variant refs)
+          ^ " | `Unknown of Yojson.Safe.t ]"
+    | Unknown -> "Yojson.Safe.t"
 
   let kind_label = function
     | Record -> "record"
@@ -262,7 +275,7 @@ module Lexicon = struct
     | Number, (`Float _ | `Int _) -> true
     | Integer, (`Int _ | `Intlit _) -> true
     | (String | Ref | Cid_link | Bytes), `String _ -> true
-    | (Union | Unknown), _ -> true
+    | (Union _ | Unknown), _ -> true
     | _ -> false
 
   let validate (d : def) (json : Yojson.Safe.t) : (unit, string) result =
@@ -285,4 +298,33 @@ module Lexicon = struct
           in
           check d.properties
     | _ -> Error "expected JSON object"
+
+  let union_refs = function Union refs -> refs | _ -> []
+
+  let official_listitem =
+    {|{"lexicon":1,"id":"app.bsky.graph.listitem","defs":{"main":{"type":"record","description":"Record representing an account's inclusion on a specific list.","key":"tid","record":{"type":"object","required":["subject","list","createdAt"],"properties":{"subject":{"type":"string","format":"did"},"list":{"type":"string","format":"at-uri"},"createdAt":{"type":"string","format":"datetime"}}}}}}|}
+
+  let official_starterpack =
+    {|{"lexicon":1,"id":"app.bsky.graph.starterpack","defs":{"main":{"type":"record","description":"Record defining a starter pack of actors and feeds for new users.","key":"tid","record":{"type":"object","required":["name","list","createdAt"],"properties":{"name":{"type":"string"},"description":{"type":"string"},"descriptionFacets":{"type":"array","items":{"type":"ref","ref":"app.bsky.richtext.facet"}},"list":{"type":"string","format":"at-uri"},"feeds":{"type":"array","items":{"type":"ref","ref":"#feedItem"}},"createdAt":{"type":"string","format":"datetime"}}}},"feedItem":{"type":"object","required":["uri"],"properties":{"uri":{"type":"string","format":"at-uri"}}}}}|}
+
+  let official_list =
+    {|{"lexicon":1,"id":"app.bsky.graph.list","defs":{"main":{"type":"record","description":"Record representing a list of accounts.","key":"tid","record":{"type":"object","required":["name","purpose","createdAt"],"properties":{"purpose":{"type":"ref","ref":"app.bsky.graph.defs#listPurpose"},"name":{"type":"string"},"description":{"type":"string"},"descriptionFacets":{"type":"array","items":{"type":"ref","ref":"app.bsky.richtext.facet"}},"avatar":{"type":"blob"},"labels":{"type":"union","refs":["com.atproto.label.defs#selfLabels"]},"createdAt":{"type":"string","format":"datetime"}}}}}}|}
+
+  let official_chat_notification_defs =
+    {|{"lexicon":1,"id":"chat.bsky.notification.defs","defs":{"preferences":{"type":"object","required":["chat","chatRequest"],"properties":{"chat":{"type":"ref","ref":"#chatPreference"},"chatRequest":{"type":"ref","ref":"#chatPreference"}}},"chatPreference":{"type":"object","required":["include","push"],"properties":{"include":{"type":"string","knownValues":["all","follows"]},"push":{"type":"boolean"}}}}}|}
+
+  let official_get_post_thread =
+    {|{"lexicon":1,"id":"app.bsky.feed.getPostThread","defs":{"main":{"type":"query","description":"Get posts in a thread.","parameters":{"type":"params","required":["uri"],"properties":{"uri":{"type":"string","format":"at-uri"},"depth":{"type":"integer"},"parentHeight":{"type":"integer"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["thread"],"properties":{"thread":{"type":"union","refs":["app.bsky.feed.defs#threadViewPost","app.bsky.feed.defs#notFoundPost","app.bsky.feed.defs#blockedPost"]},"threadgate":{"type":"ref","ref":"app.bsky.feed.defs#threadgateView"}}}}}}}|}
+
+  let official_lexicons : (string * string) list =
+    [
+      ("app.bsky.graph.listitem", official_listitem);
+      ("app.bsky.graph.starterpack", official_starterpack);
+      ("app.bsky.graph.list", official_list);
+      ("chat.bsky.notification.defs", official_chat_notification_defs);
+      ("app.bsky.feed.getPostThread", official_get_post_thread);
+    ]
+
+  let official_documents () : document list =
+    List.map (fun (_id, body) -> of_string body) official_lexicons
 end

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -7,8 +7,77 @@ module Ozone = struct
   let labeler_proxy (did : string) : Xrpc.proxy = Xrpc.labeler_proxy did
   let proxy_headers proxy = [ Xrpc.proxy_header proxy ]
 
+  type repo_ref = { did : string }
+  type strong_ref = { uri : string; cid : string }
+  type message_ref = { did : string; convo_id : string; message_id : string }
+  type convo_ref = { did : string; convo_id : string }
+
+  type subject =
+    [ `Repo_ref of repo_ref
+    | `Strong_ref of strong_ref
+    | `Message_ref of message_ref
+    | `Convo_ref of convo_ref
+    | `Unknown of Yojson.Safe.t ]
+
+  type comment_event = { comment : string; sticky : bool option }
+
+  type acknowledge_event = {
+    comment : string option;
+    acknowledge_account_subjects : bool option;
+  }
+
+  type takedown_event = {
+    comment : string option;
+    duration_in_hours : int option;
+    acknowledge_account_subjects : bool option;
+    policies : string list;
+  }
+
+  type comment_only_event = { comment : string option }
+  type report_event = { comment : string option; report_type : string }
+
+  type label_event = {
+    comment : string option;
+    create_label_vals : string list;
+    negate_label_vals : string list;
+    duration_in_hours : int option;
+  }
+
+  type mute_event = { comment : string option; duration_in_hours : int option }
+
+  type email_event = {
+    subject_line : string;
+    content : string option;
+    comment : string option;
+  }
+
+  type tag_event = {
+    add : string list;
+    remove : string list;
+    comment : string option;
+  }
+
+  type priority_score_event = { comment : string option; score : int }
+  type unknown_event = { type_ : string; original : Yojson.Safe.t }
+
+  type event =
+    [ `Comment of comment_event
+    | `Acknowledge of acknowledge_event
+    | `Takedown of takedown_event
+    | `Reverse_takedown of comment_only_event
+    | `Report of report_event
+    | `Label of label_event
+    | `Escalate of comment_only_event
+    | `Mute of mute_event
+    | `Unmute of comment_only_event
+    | `Email of email_event
+    | `Tag of tag_event
+    | `Resolve_appeal of comment_only_event
+    | `Priority_score of priority_score_event
+    | `Unknown of unknown_event ]
+
   type subject_status = {
-    subject : Yojson.Safe.t;
+    subject : subject;
     subject_repo_handle : string option;
     updated_at : string option;
     created_at : string option;
@@ -25,8 +94,8 @@ module Ozone = struct
 
   type mod_event = {
     id : int option;
-    event : Yojson.Safe.t;
-    subject : Yojson.Safe.t;
+    event : event;
+    subject : subject;
     created_by : string option;
     created_at : string option;
     original : Yojson.Safe.t;
@@ -56,9 +125,132 @@ module Ozone = struct
     original : Yojson.Safe.t;
   }
 
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.list_member json field)
+
+  let type_name json =
+    match Yojson.Safe.Util.member "$type" json with `String s -> s | _ -> ""
+
+  let ends_with suffix s =
+    let n = String.length suffix in
+    let m = String.length s in
+    m >= n && String.sub s (m - n) n = suffix
+
+  let parse_subject json : subject =
+    let t = type_name json in
+    let has_did =
+      match Yojson.Safe.Util.member "did" json with
+      | `String _ -> true
+      | _ -> false
+    in
+    let has_uri =
+      match Yojson.Safe.Util.member "uri" json with
+      | `String _ -> true
+      | _ -> false
+    in
+    let has_message =
+      match Yojson.Safe.Util.member "messageId" json with
+      | `String _ -> true
+      | _ -> false
+    in
+    let has_convo =
+      match Yojson.Safe.Util.member "convoId" json with
+      | `String _ -> true
+      | _ -> false
+    in
+    if ends_with "messageRef" t || (has_message && has_convo) then
+      `Message_ref
+        {
+          did = Client.string_member json "did";
+          convo_id = Client.string_member json "convoId";
+          message_id = Client.string_member json "messageId";
+        }
+    else if ends_with "convoRef" t || (has_convo && has_did && not has_message)
+    then
+      `Convo_ref
+        {
+          did = Client.string_member json "did";
+          convo_id = Client.string_member json "convoId";
+        }
+    else if ends_with "strongRef" t || (has_uri && not has_did) then
+      `Strong_ref
+        {
+          uri = Client.string_member json "uri";
+          cid = Client.string_member json "cid";
+        }
+    else if ends_with "repoRef" t || has_did then
+      `Repo_ref { did = Client.string_member json "did" }
+    else `Unknown json
+
+  let parse_event json : event =
+    let t = type_name json in
+    let comment = Client.string_opt json "comment" in
+    if ends_with "modEventComment" t then
+      `Comment
+        {
+          comment = Option.value comment ~default:"";
+          sticky = Client.bool_opt json "sticky";
+        }
+    else if ends_with "modEventAcknowledge" t then
+      `Acknowledge
+        {
+          comment;
+          acknowledge_account_subjects =
+            Client.bool_opt json "acknowledgeAccountSubjects";
+        }
+    else if ends_with "modEventTakedown" t then
+      `Takedown
+        {
+          comment;
+          duration_in_hours = Client.int_opt json "durationInHours";
+          acknowledge_account_subjects =
+            Client.bool_opt json "acknowledgeAccountSubjects";
+          policies = string_list json "policies";
+        }
+    else if ends_with "modEventReverseTakedown" t then
+      `Reverse_takedown { comment }
+    else if ends_with "modEventReport" t then
+      `Report { comment; report_type = Client.string_member json "reportType" }
+    else if ends_with "modEventLabel" t then
+      `Label
+        {
+          comment;
+          create_label_vals = string_list json "createLabelVals";
+          negate_label_vals = string_list json "negateLabelVals";
+          duration_in_hours = Client.int_opt json "durationInHours";
+        }
+    else if ends_with "modEventEscalate" t then `Escalate { comment }
+    else if ends_with "modEventMute" t then
+      `Mute
+        { comment; duration_in_hours = Client.int_opt json "durationInHours" }
+    else if ends_with "modEventUnmute" t then `Unmute { comment }
+    else if ends_with "modEventEmail" t then
+      `Email
+        {
+          subject_line = Client.string_member json "subjectLine";
+          content = Client.string_opt json "content";
+          comment;
+        }
+    else if ends_with "modEventTag" t then
+      `Tag
+        {
+          add = string_list json "add";
+          remove = string_list json "remove";
+          comment;
+        }
+    else if ends_with "modEventResolveAppeal" t then `Resolve_appeal { comment }
+    else if ends_with "modEventPriorityScore" t then
+      `Priority_score { comment; score = Client.int_member json "score" }
+    else `Unknown { type_ = t; original = json }
+
   let parse_subject_status json : subject_status =
     {
-      subject = Yojson.Safe.Util.member "subject" json;
+      subject =
+        (match Yojson.Safe.Util.member "subject" json with
+        | `Assoc _ as s -> parse_subject s
+        | other -> `Unknown other);
       subject_repo_handle = Client.string_opt json "subjectRepoHandle";
       updated_at = Client.string_opt json "updatedAt";
       created_at = Client.string_opt json "createdAt";
@@ -79,8 +271,14 @@ module Ozone = struct
   let parse_mod_event json : mod_event =
     {
       id = Client.int_opt json "id";
-      event = Yojson.Safe.Util.member "event" json;
-      subject = Yojson.Safe.Util.member "subject" json;
+      event =
+        (match Yojson.Safe.Util.member "event" json with
+        | `Assoc _ as e -> parse_event e
+        | other -> `Unknown { type_ = ""; original = other });
+      subject =
+        (match Yojson.Safe.Util.member "subject" json with
+        | `Assoc _ as s -> parse_subject s
+        | other -> `Unknown other);
       created_by = Client.string_opt json "createdBy";
       created_at = Client.string_opt json "createdAt";
       original = json;

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -2,6 +2,7 @@ open OUnit2
 open Atproto.Chat
 open Atproto.Xrpc
 open Atproto.Auth
+open Atproto.Facet
 
 let test_default_proxy _ =
   OUnit2.assert_equal
@@ -115,6 +116,106 @@ let test_parse_unread_and_logs _ =
   in
   OUnit2.assert_equal true avail.can_chat
 
+let test_parse_message_facets_reactions_embed _ =
+  let json =
+    `Assoc
+      [
+        ("id", `String "m1");
+        ("rev", `String "r1");
+        ("text", `String "hello #atp");
+        ("sentAt", `String "2024-01-01T00:00:00.000Z");
+        ("sender", `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]);
+        ( "facets",
+          `List
+            [
+              `Assoc
+                [
+                  ( "index",
+                    `Assoc [ ("byteStart", `Int 6); ("byteEnd", `Int 10) ] );
+                  ( "features",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ("$type", `String "app.bsky.richtext.facet#tag");
+                            ("tag", `String "atp");
+                          ];
+                      ] );
+                ];
+            ] );
+        ( "reactions",
+          `List
+            [
+              `Assoc
+                [
+                  ("value", `String "👍");
+                  ( "sender",
+                    `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
+                  );
+                  ("createdAt", `String "2024-01-01T00:00:01.000Z");
+                ];
+            ] );
+        ( "embed",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.embed.record");
+              ( "record",
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+                    );
+                    ( "cid",
+                      `String "bafyreihdummy000000000000000000000000000000" );
+                  ] );
+            ] );
+        ("replyTo", `Assoc [ ("messageId", `String "m0") ]);
+      ]
+  in
+  let msg = Chat.parse_message json in
+  OUnit2.assert_equal 1 (List.length msg.facets);
+  OUnit2.assert_equal 1 (List.length msg.reactions);
+  OUnit2.assert_equal ~printer:(fun x -> x) "👍" (List.hd msg.reactions).value;
+  OUnit2.assert_equal (Some "m0") msg.reply_to_id;
+  match msg.embed with
+  | Some (`Record _) -> ()
+  | _ -> OUnit2.assert_failure "expected record embed attachment"
+
+let test_lock_unlock_and_group_bodies _ =
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "c1"
+    (Chat.convo_id_body "c1" |> member "convoId" |> to_string);
+  let prefs =
+    Chat.parse_notification_preferences
+      (`Assoc
+        [
+          ( "preferences",
+            `Assoc
+              [
+                ( "chat",
+                  `Assoc [ ("include", `String "all"); ("push", `Bool true) ] );
+                ( "chatRequest",
+                  `Assoc
+                    [ ("include", `String "follows"); ("push", `Bool false) ] );
+              ] );
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "all" prefs.chat.include_;
+  OUnit2.assert_equal true prefs.chat.push;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "follows" prefs.chat_request.include_;
+  OUnit2.assert_equal false prefs.chat_request.push;
+  let body =
+    Chat.message_input
+      ~facets:[ Facet.tag ~byte_start:0 ~byte_end:4 "atp" ]
+      "hi #atp"
+  in
+  OUnit2.assert_equal 1 (body |> member "facets" |> to_list |> List.length)
+
 let test_list_convos_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -133,6 +234,10 @@ let suite =
          "test_parse_convos" >:: test_parse_convos;
          "test_send_message_body" >:: test_send_message_body;
          "test_parse_unread_and_logs" >:: test_parse_unread_and_logs;
+         "test_parse_message_facets_reactions_embed"
+         >:: test_parse_message_facets_reactions_embed;
+         "test_lock_unlock_and_group_bodies"
+         >:: test_lock_unlock_and_group_bodies;
          "test_list_convos_auth_skipped" >:: test_list_convos_auth_skipped;
        ]
 

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -40,11 +40,11 @@ let test_get_post_thread _ =
     Feed.get_post_thread test_session
       "at://did:plc:xov3uvxfd4to6ev3ak5g5uxk/app.bsky.feed.post/3jyf6gx25eb27" 1
   in
-  match post_thread with
-  | { thread; _ } -> (
-      match thread with
-      | { thread_type; _ } ->
-          OUnit2.assert_bool "Post Thread Feed is empty" (thread_type <> ""))
+  match post_thread.thread with
+  | `Thread t ->
+      OUnit2.assert_bool "Post Thread Feed is empty" (t.thread_type <> "")
+  | `NotFound _ -> OUnit2.assert_failure "thread not found"
+  | `Blocked _ -> OUnit2.assert_failure "thread blocked"
 
 let test_get_posts _ =
   skip_if
@@ -210,6 +210,165 @@ let test_parse_post_record_embed_and_tags _ =
   | Some (`Gallery g) -> OUnit2.assert_equal 1 (List.length g.items)
   | _ -> OUnit2.assert_failure "expected gallery embed on post record"
 
+let post_view_json ~uri ~text ?embed () =
+  `Assoc
+    ([
+       ("uri", `String uri);
+       ("cid", `String "bafyreiabc");
+       ( "author",
+         `Assoc
+           [
+             ("did", `String "did:plc:abc123xyz0001112223333");
+             ("handle", `String "alice.test");
+           ] );
+       ( "record",
+         `Assoc
+           [
+             ("$type", `String "app.bsky.feed.post");
+             ("text", `String text);
+             ("createdAt", `String "2024-01-01T00:00:00.000Z");
+           ] );
+       ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+       ("replyCount", `Int 2);
+       ("repostCount", `Int 1);
+       ("likeCount", `Int 4);
+       ("quoteCount", `Int 3);
+       ("bookmarkCount", `Int 5);
+     ]
+    @ match embed with Some e -> [ ("embed", e) ] | None -> [])
+
+let test_parse_thread_view_with_embed _ =
+  let embed =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.external#view");
+        ( "external",
+          `Assoc
+            [
+              ("uri", `String "https://atproto.com");
+              ("title", `String "AT Protocol");
+              ("description", `String "docs");
+              ("thumb", `String "https://cdn.example/t.jpg");
+            ] );
+      ]
+  in
+  let root =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.feed.defs#threadViewPost");
+        ( "post",
+          post_view_json
+            ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/root"
+            ~text:"root post" ~embed () );
+        ( "replies",
+          `List
+            [
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.feed.defs#threadViewPost");
+                  ( "post",
+                    post_view_json
+                      ~uri:
+                        "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/reply"
+                      ~text:"a reply" () );
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.feed.defs#notFoundPost");
+                  ( "uri",
+                    `String
+                      "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/gone"
+                  );
+                  ("notFound", `Bool true);
+                ];
+            ] );
+      ]
+  in
+  let feed =
+    Feed.parse_thread_feed
+      (`Assoc
+        [
+          ("thread", root);
+          ( "threadgate",
+            `Assoc
+              [
+                ( "uri",
+                  `String
+                    "at://did:plc:abc123xyz0001112223333/app.bsky.feed.threadgate/1"
+                );
+              ] );
+        ])
+  in
+  match feed.thread with
+  | `Thread t -> (
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "app.bsky.feed.defs#threadViewPost" t.thread_type;
+      OUnit2.assert_equal None t.parent;
+      OUnit2.assert_equal (Some 3) t.post.quote_count;
+      OUnit2.assert_equal (Some 5) t.post.bookmark_count;
+      (match t.post.embed with
+      | Some (`ExternalView e) ->
+          OUnit2.assert_equal
+            ~printer:(fun x -> x)
+            "https://atproto.com" e.ext.uri
+      | _ -> OUnit2.assert_failure "expected top-level external view embed");
+      OUnit2.assert_equal 2 (List.length t.replies);
+      match List.nth t.replies 1 with
+      | `NotFound n -> OUnit2.assert_bool "not found" n.not_found
+      | _ -> OUnit2.assert_failure "expected notFound reply")
+  | _ -> OUnit2.assert_failure "expected thread view"
+
+let test_parse_blocked_thread _ =
+  let json =
+    `Assoc
+      [
+        ( "thread",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.feed.defs#blockedPost");
+              ( "uri",
+                `String
+                  "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/x" );
+              ("blocked", `Bool true);
+              ( "author",
+                `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
+            ] );
+      ]
+  in
+  match (Feed.parse_thread_feed json).thread with
+  | `Blocked b ->
+      OUnit2.assert_equal (Some "did:plc:abc123xyz0001112223333") b.author_did
+  | _ -> OUnit2.assert_failure "expected blocked thread"
+
+let test_parse_reply_ref_not_found _ =
+  let json =
+    `Assoc
+      [
+        ( "root",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.feed.defs#notFoundPost");
+              ( "uri",
+                `String
+                  "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/root"
+              );
+              ("notFound", `Bool true);
+            ] );
+        ( "parent",
+          post_view_json
+            ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/p"
+            ~text:"parent" () );
+      ]
+  in
+  let reply = Feed.parse_reply json in
+  (match reply.root with
+  | `NotFound n -> OUnit2.assert_bool "root missing" n.not_found
+  | _ -> OUnit2.assert_failure "expected notFound root");
+  match reply.parent with
+  | `Post p -> OUnit2.assert_equal ~printer:(fun x -> x) "parent" p.record.text
+  | _ -> OUnit2.assert_failure "expected parent post"
+
 let test_parse_post_view_embed _ =
   let json =
     `Assoc
@@ -298,6 +457,10 @@ let suite =
          "test_parse_search_posts" >:: test_parse_search_posts;
          "test_parse_post_record_embed_and_tags"
          >:: test_parse_post_record_embed_and_tags;
+         "test_parse_thread_view_with_embed"
+         >:: test_parse_thread_view_with_embed;
+         "test_parse_blocked_thread" >:: test_parse_blocked_thread;
+         "test_parse_reply_ref_not_found" >:: test_parse_reply_ref_not_found;
          "test_parse_post_view_embed" >:: test_parse_post_view_embed;
          "test_send_interactions_body" >:: test_send_interactions_body;
          "test_get_feed_generator_live" >:: test_get_feed_generator_live;

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -139,6 +139,54 @@ let test_validate_errors _ =
       | Error _ -> ()
       | Ok () -> OUnit2.assert_failure "wrong type accepted")
 
+let test_union_codegen_and_official_bundle _ =
+  let docs = Lexicon.official_documents () in
+  OUnit2.assert_bool "bundled lexicons" (List.length docs >= 5);
+  List.iter
+    (fun (doc : Lexicon.document) ->
+      OUnit2.assert_equal 1 doc.lexicon;
+      OUnit2.assert_bool "id" (String.length doc.id > 3))
+    docs;
+  let thread =
+    List.find
+      (fun (d : Lexicon.document) -> d.id = "app.bsky.feed.getPostThread")
+      docs
+  in
+  match Lexicon.main thread with
+  | None -> OUnit2.assert_failure "missing main"
+  | Some main -> (
+      (match List.assoc_opt "thread" main.output.properties with
+      | Some (Lexicon.Union refs) ->
+          OUnit2.assert_bool "thread union refs"
+            (List.exists
+               (fun r ->
+                 let n = String.length r in
+                 n >= 14 && String.sub r (n - 14) 14 = "threadViewPost")
+               refs);
+          let ocaml = Lexicon.to_ocaml thread in
+          OUnit2.assert_bool "codegen emits union variant"
+            (let needle = "threadViewPost" in
+             let rec contains i =
+               i + String.length needle <= String.length ocaml
+               && (String.sub ocaml i (String.length needle) = needle
+                  || contains (i + 1))
+             in
+             contains 0)
+      | Some _ -> OUnit2.assert_failure "thread is not a union"
+      | None -> OUnit2.assert_failure "missing thread output property");
+      let list_doc =
+        List.find
+          (fun (d : Lexicon.document) -> d.id = "app.bsky.graph.list")
+          docs
+      in
+      match Lexicon.main list_doc with
+      | None -> OUnit2.assert_failure "missing list main"
+      | Some main -> (
+          match List.assoc_opt "labels" main.properties with
+          | Some (Lexicon.Union refs) ->
+              OUnit2.assert_equal [ "com.atproto.label.defs#selfLabels" ] refs
+          | _ -> OUnit2.assert_failure "list labels should be a union"))
+
 let suite =
   "lexicon"
   >::: [
@@ -148,6 +196,8 @@ let suite =
          >:: test_nested_parameters_and_codegen;
          "test_procedure_input_output" >:: test_procedure_input_output;
          "test_validate_errors" >:: test_validate_errors;
+         "test_union_codegen_and_official_bundle"
+         >:: test_union_codegen_and_official_bundle;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -130,6 +130,68 @@ let test_parse_timeline_and_schedule _ =
     "tools.ozone.moderation.scheduleAction#takedown"
     (body |> member "action" |> member "$type" |> to_string)
 
+let test_parse_typed_event_and_subject _ =
+  let ev =
+    Ozone.parse_mod_event
+      (`Assoc
+        [
+          ("id", `Int 9);
+          ( "event",
+            `Assoc
+              [
+                ("$type", `String "tools.ozone.moderation.defs#modEventReport");
+                ("comment", `String "spam");
+                ("reportType", `String "com.atproto.moderation.defs#reasonSpam");
+              ] );
+          ( "subject",
+            `Assoc
+              [
+                ("$type", `String "com.atproto.admin.defs#repoRef");
+                ("did", `String "did:plc:abc123xyz0001112223333");
+              ] );
+          ("createdBy", `String "did:plc:mod000111222333444555666");
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ])
+  in
+  (match ev.event with
+  | `Report r ->
+      OUnit2.assert_equal (Some "spam") r.comment;
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "com.atproto.moderation.defs#reasonSpam" r.report_type
+  | _ -> OUnit2.assert_failure "expected report event");
+  (match ev.subject with
+  | `Repo_ref r ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:abc123xyz0001112223333" r.did
+  | _ -> OUnit2.assert_failure "expected repoRef");
+  let msg_subj =
+    Ozone.parse_subject
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.convo.defs#messageRef");
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("convoId", `String "c1");
+          ("messageId", `String "m1");
+        ])
+  in
+  (match msg_subj with
+  | `Message_ref m -> OUnit2.assert_equal ~printer:(fun x -> x) "c1" m.convo_id
+  | _ -> OUnit2.assert_failure "expected messageRef");
+  let label =
+    Ozone.parse_event
+      (`Assoc
+        [
+          ("$type", `String "tools.ozone.moderation.defs#modEventLabel");
+          ("createLabelVals", `List [ `String "spam" ]);
+          ("negateLabelVals", `List []);
+        ])
+  in
+  match label with
+  | `Label l -> OUnit2.assert_equal [ "spam" ] l.create_label_vals
+  | _ -> OUnit2.assert_failure "expected label event"
+
 let test_query_statuses_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -150,6 +212,8 @@ let suite =
          "test_emit_event_body" >:: test_emit_event_body;
          "test_takedown_event" >:: test_takedown_event;
          "test_parse_timeline_and_schedule" >:: test_parse_timeline_and_schedule;
+         "test_parse_typed_event_and_subject"
+         >:: test_parse_typed_event_and_subject;
          "test_query_statuses_auth_skipped" >:: test_query_statuses_auth_skipped;
        ]
 

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -76,6 +76,55 @@ let test_graph_and_like_builders _ =
     "Ada"
     (profile |> member "displayName" |> to_string)
 
+let test_list_and_starterpack_builders _ =
+  let list =
+    Records.list ~name:"Friends" ~purpose:Records.purpose_curatelist
+      ~created_at:"2024-01-01T00:00:00.000Z" ~description:"pals"
+      ~self_labels:[ "graphic-media" ] ()
+  in
+  let item =
+    Records.listitem ~subject:"did:plc:alice000111222333444555666"
+      ~list:"at://did:plc:alice000111222333444555666/app.bsky.graph.list/3k"
+      ~created_at:"2024-01-01T00:00:00.000Z" ()
+  in
+  let pack =
+    Records.starterpack ~name:"Start here"
+      ~list:"at://did:plc:alice000111222333444555666/app.bsky.graph.list/3k"
+      ~created_at:"2024-01-01T00:00:00.000Z"
+      ~feeds:
+        [
+          "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot";
+        ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.graph.list"
+    (list |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.graph.defs#curatelist"
+    (list |> member "purpose" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.graph.listitem"
+    (item |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.graph.starterpack"
+    (pack |> member "$type" |> to_string);
+  OUnit2.assert_equal 1 (pack |> member "feeds" |> to_list |> List.length);
+  let parsed_list = Records.parse_list list in
+  OUnit2.assert_equal ~printer:(fun x -> x) "Friends" parsed_list.name;
+  let parsed_item = Records.parse_listitem item in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:alice000111222333444555666" parsed_item.subject;
+  let parsed_pack = Records.parse_starterpack pack in
+  OUnit2.assert_equal ~printer:(fun x -> x) "Start here" parsed_pack.name;
+  OUnit2.assert_equal 1 (List.length parsed_pack.feeds)
+
 let test_parse_like_and_follow _ =
   let like =
     Records.parse_like
@@ -113,6 +162,8 @@ let suite =
   >::: [
          "test_post_builder" >:: test_post_builder;
          "test_graph_and_like_builders" >:: test_graph_and_like_builders;
+         "test_list_and_starterpack_builders"
+         >:: test_list_and_starterpack_builders;
          "test_parse_like_and_follow" >:: test_parse_like_and_follow;
        ]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks the next library slice on #78: current-lexicon types and clients that were left explicit leftovers.

## What landed

- **Feed threads / `postView`**: `getPostThread` parses `threadViewPost` | `notFoundPost` | `blockedPost`, optional parent, recursive replies, threadgate, and **top-level view embed** plus quote/bookmark counts. Post records share one shape (optional reply, facets, tags, selfLabels).
- **Chat**: message facets, reactions, and embed attachments are typed (not only `original` JSON). `lockConvo` / `unlockConvo`, `chat.bsky.group.addMembers` / `removeMembers` / `editGroup`, and **`chat.bsky.notification.getPreferences` / `putPreferences`** (2026 move off `app.bsky.notification`).
- **Ozone**: `modEvent` / `subjectStatus` event and subject fields are lexicon unions (`repoRef` / `strongRef` / `messageRef` / `convoRef`; comment/ack/takedown/report/label/…), not raw `Yojson.Safe.t`.
- **Records**: `app.bsky.graph.list`, `#listitem`, and `#starterpack` builders + parsers (beyond follow/block/listblock).
- **Lexicon**: `to_ocaml` emits unions as polymorphic variants when `refs` are present; small official lexicon JSON is bundled (`list` / `listitem` / `starterpack` / chat notification defs / `getPostThread`).
- **Http_client H2 stub**: left unchanged (does not unblock a real HTTP/2 path).

Fixture tests cover the new parsers/builders. No invented credentials. Hosted OAuth/PDS/Tap/transcoder still skipped. GitHub Action majors unchanged (`checkout@v4`, `setup-ocaml@v3`, `cache@v4`, `upload-artifact@v4`).

## Test plan

- `dune build` and `dune runtest` (fixture tests; live Bluesky auth tests skip without real `ATP_AUTH`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94a2d9e7-036c-496f-ba04-a4d3c90f44c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94a2d9e7-036c-496f-ba04-a4d3c90f44c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

