### PR TITLE
Add remaining chat, video, unspecced, and bookmark lexicon clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences |
 | AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts), generators, `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
-| Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks` |
+| Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
-| Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
-| Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics, config |
+| Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
+| Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, age-assurance state, suggestion / feed / starter-pack skeletons, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `chat.bsky.group` add/remove/edit, `chat.bsky.notification.getPreferences` / `putPreferences`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `chat.bsky.group` add/remove/edit, `chat.bsky.notification.getPreferences` / `putPreferences`, `chat.bsky.actor.getStatus` / declaration / export / delete, `chat.bsky.moderation.*` actor metadata + convo/message-context views (not `subscribeModEvents`); `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions (repoRef / strongRef / messageRef / convoRef), subjects/repos/records, account timeline, reporter stats, scheduled actions + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile |
@@ -64,7 +64,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
 | Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video, **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
-| User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef) |
+| User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
 | Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
 | HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST, method enum |
 
@@ -78,17 +78,15 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encode/verify + collection-subset proofs, `.jss` v1 columnar decode, blessed CID / repo-path / firehose size+future-rev checks landed in #70–#77. This slice adds current-lexicon AppView record/embed parsers (gallery + record views), typed repo reads, Bluesky record builders, notification prefs/push, and remaining chat/ozone XRPC clients.
+Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encode/verify + collection-subset proofs, `.jss` v1 columnar decode, blessed CID / repo-path / firehose size+future-rev checks landed in #70–#77. Lexicon-accurate AppView record/embed parsers, typed repo reads, Bluesky record builders, notification prefs/push, and remaining chat/ozone XRPC clients landed in #78–#79.
 
 Still thin vs current lexicons (library leftovers, not product work):
 
-- Feed thread types remain the original (sometimes inaccurate) shapes; `post` / `thread_post` views still omit top-level embed
-- Chat message facets/reactions/attachments stay on `original` JSON; lock/unlock/group-admin convo methods are not wrapped
-- Ozone event/subject payloads remain `Yojson.Safe.t` (query/emit clients exist)
-- `Lexicon.to_ocaml` still emits unions as `Yojson.Safe.t`; no bundled official lexicon JSON
+- `app.bsky.unspecced.getPostThreadV2` / `getPostThreadOtherV2` and the many onboarding/discover/explore/seeMore suggestion variants
+- `chat.bsky.moderation.subscribeModEvents` (operator firehose)
+- `app.bsky.draft` / `app.bsky.contact` / `app.bsky.ageassurance` namespaces
+- Actor preference kinds beyond adult-content / content-label / saved-feeds-v2 / interests / hidden-posts (`original` JSON is kept)
 - `Http_client` H2 stub and unused `Request`/`Response` types
-- `chat.bsky.notification.*` preference endpoints (moved off `app.bsky.notification` in 2026)
-- Graph list/starter-pack **record** builders beyond follow/block/listblock
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -104,6 +102,7 @@ let discover =
     ()
 let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 let popular = Unspecced.get_popular_feed_generators ~limit:5 ()
+let trends = Unspecced.get_trends ~limit:5 ()
 let services =
   Labeler.get_services ~dids:[ "did:plc:ar7c4by46qjdydhdevvrndac" ] ()
 
@@ -133,6 +132,9 @@ let embed =
   Video.video_embed_json
     ~video:(`Assoc [ ("$type", `String "blob"); ("mimeType", `String "video/mp4") ])
     ~alt:"demo" ()
+let start =
+  Video.start_upload_body ~size_bytes:1_048_576 ~mime_type:"video/mp4"
+    ~name:"clip.mp4" ()
 
 (* firehose: one subscribeRepos frame from the public relay *)
 let _header, msg = Firehose.subscribe_one ()
@@ -165,4 +167,5 @@ let prefs = Actor.get_preferences session
 let bookmarks = Bookmark.get_bookmarks session ~limit:10 ()
 (* chat + ozone always need atproto-proxy (defaults shown) *)
 let convos = Chat.list_convos session ~limit:10 ()
+let chat_status = Chat.get_actor_status session ()
 ```

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -16,6 +16,7 @@ open Atproto.Mst
 open Atproto.Oauth
 open Atproto.Xrpc
 open Atproto.Jetstream
+open Atproto.Unspecced
 open Atproto.Oauth_scope
 open Atproto.Repo_sync
 open Atproto.Cid
@@ -61,6 +62,27 @@ let () =
     match Yojson.Safe.Util.member "$type" embed with
     | `String "app.bsky.embed.video" -> true
     | _ -> false);
+  let start =
+    Video.start_upload_body ~size_bytes:1_048_576 ~mime_type:"video/mp4"
+      ~name:"clip.mp4" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "sizeBytes" start with
+    | `Int 1048576 -> true
+    | _ -> false);
+  let upload_st =
+    Video.parse_upload_status
+      (`Assoc
+        [
+          ("jobId", `String "job-m");
+          ("partSizeBytes", `Int 100);
+          ("partCount", `Int 2);
+          ("receivedParts", `List [ `Int 1 ]);
+          ("expiresAt", `String "2026-01-01T00:00:00.000Z");
+          ("state", `String "created");
+        ])
+  in
+  assert (Video.missing_parts upload_st = [ 2 ]);
   (match
      Embed.parse_embed
        (`Assoc
@@ -167,6 +189,41 @@ let () =
         ])
   in
   assert chat_prefs.chat.push;
+  let actor_st =
+    Chat.parse_actor_status
+      (`Assoc
+        [
+          ("chatDisabled", `Bool false);
+          ("canCreateGroups", `Bool true);
+          ("groupMemberLimit", `Int 50);
+        ])
+  in
+  assert (actor_st.group_member_limit = 50);
+  let decl = Records.chat_declaration ~allow_incoming:"following" () in
+  assert (
+    match Yojson.Safe.Util.member "$type" decl with
+    | `String "chat.bsky.actor.declaration" -> true
+    | _ -> false);
+  let tagged =
+    Unspecced.parse_tagged_suggestions
+      (`Assoc
+        [
+          ( "suggestions",
+            `List
+              [
+                `Assoc
+                  [
+                    ("tag", `String "news");
+                    ("subjectType", `String "feed");
+                    ( "subject",
+                      `String
+                        "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
+                    );
+                  ];
+              ] );
+        ])
+  in
+  assert (List.length tagged.suggestions = 1);
   (match
      Ozone.parse_subject
        (`Assoc

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -320,17 +320,92 @@ module Actor = struct
     in
     profiles |> convert_body_to_json |> parse_typeahead_profiles
 
-  type preference = { type_ : string; original : Yojson.Safe.t }
+  type saved_feed = {
+    id : string;
+    type_ : string;
+    value : string;
+    pinned : bool;
+  }
+
+  type adult_content_pref = { enabled : bool }
+
+  type content_label_pref = {
+    label : string;
+    visibility : string;
+    labeler_did : string option;
+  }
+
+  type saved_feeds_v2_pref = { items : saved_feed list }
+  type interests_pref = { tags : string list }
+  type hidden_posts_pref = { items : string list }
+
+  type preference_kind =
+    [ `Adult_content of adult_content_pref
+    | `Content_label of content_label_pref
+    | `Saved_feeds_v2 of saved_feeds_v2_pref
+    | `Interests of interests_pref
+    | `Hidden_posts of hidden_posts_pref
+    | `Other ]
+
+  type preference = {
+    type_ : string;
+    kind : preference_kind;
+    original : Yojson.Safe.t;
+  }
+
   type preferences = { preferences : preference list }
 
-  let parse_preference json : preference =
+  let ends_with suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+
+  let parse_saved_feed json : saved_feed =
     {
-      type_ =
-        (match Yojson.Safe.Util.member "$type" json with
-        | `String s -> s
-        | _ -> "");
-      original = json;
+      id = Client.Client.string_member json "id";
+      type_ = Client.Client.string_member json "type";
+      value = Client.Client.string_member json "value";
+      pinned = Client.Client.bool_member json "pinned";
     }
+
+  let parse_preference_kind ~type_ json : preference_kind =
+    if ends_with "adultContentPref" type_ then
+      `Adult_content { enabled = Client.Client.bool_member json "enabled" }
+    else if ends_with "contentLabelPref" type_ then
+      `Content_label
+        {
+          label = Client.Client.string_member json "label";
+          visibility = Client.Client.string_member json "visibility";
+          labeler_did = Client.Client.string_opt json "labelerDid";
+        }
+    else if ends_with "savedFeedsPrefV2" type_ then
+      `Saved_feeds_v2
+        {
+          items =
+            List.map parse_saved_feed (Client.Client.list_member json "items");
+        }
+    else if ends_with "interestsPref" type_ then
+      `Interests
+        {
+          tags =
+            List.filter_map
+              (function `String s -> Some s | _ -> None)
+              (Client.Client.list_member json "tags");
+        }
+    else if ends_with "hiddenPostsPref" type_ then
+      `Hidden_posts
+        {
+          items =
+            List.filter_map
+              (function `String s -> Some s | _ -> None)
+              (Client.Client.list_member json "items");
+        }
+    else `Other
+
+  let parse_preference json : preference =
+    let type_ =
+      match Yojson.Safe.Util.member "$type" json with `String s -> s | _ -> ""
+    in
+    { type_; kind = parse_preference_kind ~type_ json; original = json }
 
   let parse_preferences json : preferences =
     {

--- a/src/bsky/bookmark.ml
+++ b/src/bsky/bookmark.ml
@@ -1,15 +1,18 @@
 open Session
 open Client
+open Feed
 
 (** app.bsky.bookmark — private post bookmarks (auth required). *)
 module Bookmark = struct
   type strong_ref = { uri : string; cid : string }
+  type bookmark_item = Feed.reply_ref_item
 
   type bookmark_view = {
     uri : string;
     cid : string;
     created_at : string option;
-    item : Yojson.Safe.t;
+    item : bookmark_item;
+    original : Yojson.Safe.t;
   }
 
   type bookmarks = { cursor : string option; bookmarks : bookmark_view list }
@@ -20,17 +23,21 @@ module Bookmark = struct
       cid = Client.string_member json "cid";
     }
 
+  let parse_bookmark_item json : bookmark_item = Feed.parse_reply_ref_item json
+
   let parse_bookmark_view json : bookmark_view =
     let subject =
       match Yojson.Safe.Util.member "subject" json with
       | `Assoc _ as s -> parse_strong_ref s
       | _ -> { uri = ""; cid = "" }
     in
+    let item_json = Yojson.Safe.Util.member "item" json in
     {
       uri = subject.uri;
       cid = subject.cid;
       created_at = Client.string_opt json "createdAt";
-      item = Yojson.Safe.Util.member "item" json;
+      item = parse_bookmark_item item_json;
+      original = json;
     }
 
   let parse_bookmarks json : bookmarks =

--- a/src/bsky/bookmark.ml
+++ b/src/bsky/bookmark.ml
@@ -23,7 +23,17 @@ module Bookmark = struct
       cid = Client.string_member json "cid";
     }
 
-  let parse_bookmark_item json : bookmark_item = Feed.parse_reply_ref_item json
+  let parse_bookmark_item json : bookmark_item =
+    try Feed.parse_reply_ref_item json
+    with Yojson.Safe.Util.Type_error _ ->
+      `NotFound
+        {
+          uri = Client.string_member json "uri";
+          not_found =
+            (match Yojson.Safe.Util.member "notFound" json with
+            | `Bool b -> b
+            | _ -> true);
+        }
 
   let parse_bookmark_view json : bookmark_view =
     let subject =

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -14,6 +14,7 @@ module Records = struct
   let nsid_listitem = "app.bsky.graph.listitem"
   let nsid_starterpack = "app.bsky.graph.starterpack"
   let nsid_profile = "app.bsky.actor.profile"
+  let nsid_chat_declaration = "chat.bsky.actor.declaration"
   let purpose_modlist = "app.bsky.graph.defs#modlist"
   let purpose_curatelist = "app.bsky.graph.defs#curatelist"
   let purpose_referencelist = "app.bsky.graph.defs#referencelist"
@@ -191,6 +192,19 @@ module Records = struct
     in
     `Assoc fields
 
+  let chat_declaration ~allow_incoming ?allow_group_invites () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_chat_declaration);
+        ("allowIncoming", `String allow_incoming);
+      ]
+      @
+      match allow_group_invites with
+      | Some s -> [ ("allowGroupInvites", `String s) ]
+      | None -> []
+    in
+    `Assoc fields
+
   type like_record = {
     subject : Embed.strong_ref;
     created_at : string;
@@ -227,6 +241,11 @@ module Records = struct
     description_facets : Facet.facet list option;
     feeds : string list;
     created_at : string;
+  }
+
+  type chat_declaration_record = {
+    allow_incoming : string;
+    allow_group_invites : string option;
   }
 
   let parse_via json : Embed.strong_ref option =
@@ -315,5 +334,18 @@ module Records = struct
       feeds;
       created_at =
         (match json |> member "createdAt" with `String s -> s | _ -> "");
+    }
+
+  let parse_chat_declaration json : chat_declaration_record =
+    let open Yojson.Safe.Util in
+    {
+      allow_incoming =
+        (match json |> member "allowIncoming" with
+        | `String s -> s
+        | _ -> "all");
+      allow_group_invites =
+        (match json |> member "allowGroupInvites" with
+        | `String s -> Some s
+        | _ -> None);
     }
 end

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -1,4 +1,7 @@
+open Session
 open Client
+open Actor
+open Graph
 
 (** app.bsky.unspecced — public search skeletons, popular feeds, trends. *)
 module Unspecced = struct
@@ -195,6 +198,265 @@ module Unspecced = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_generators
 
-  let get_tagged_suggestions ?session ?host () : Yojson.Safe.t =
+  type tagged_suggestion = {
+    tag : string;
+    subject_type : string;
+    subject : string;
+  }
+
+  type tagged_suggestions = { suggestions : tagged_suggestion list }
+
+  type age_assurance_state = {
+    status : string;
+    last_initiated_at : string option;
+  }
+
+  type skeleton_trend = {
+    topic : string;
+    display_name : string;
+    description : string option;
+    link : string;
+    started_at : string;
+    post_count : int;
+    status : string option;
+    category : string option;
+    dids : string list;
+  }
+
+  type trend_view = {
+    topic : string;
+    display_name : string;
+    description : string option;
+    link : string;
+    started_at : string;
+    post_count : int;
+    status : string option;
+    category : string option;
+    actor_dids : string list;
+  }
+
+  type trends = { trends : trend_view list; rec_id_str : string option }
+
+  type trends_skeleton = {
+    trends : skeleton_trend list;
+    rec_id_str : string option;
+  }
+
+  type suggestions_skeleton = {
+    cursor : string option;
+    actors : skeleton_actor list;
+    relative_to_did : string option;
+    rec_id : int option;
+    rec_id_str : string option;
+  }
+
+  type suggested_users = {
+    actors : Actor.short_profile list;
+    rec_id : string option;
+    rec_id_str : string option;
+  }
+
+  type suggested_feeds = { feeds : generator_view list }
+  type uri_skeleton = { uris : string list }
+  type did_skeleton = { dids : string list; rec_id_str : string option }
+
+  let parse_tagged_suggestion json : tagged_suggestion =
+    {
+      tag = Client.string_member json "tag";
+      subject_type = Client.string_member json "subjectType";
+      subject = Client.string_member json "subject";
+    }
+
+  let parse_tagged_suggestions json : tagged_suggestions =
+    {
+      suggestions =
+        List.map parse_tagged_suggestion (Client.list_member json "suggestions");
+    }
+
+  let parse_age_assurance_state json : age_assurance_state =
+    {
+      status = Client.string_member json "status";
+      last_initiated_at = Client.string_opt json "lastInitiatedAt";
+    }
+
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.list_member json field)
+
+  let parse_skeleton_trend json : skeleton_trend =
+    {
+      topic = Client.string_member json "topic";
+      display_name = Client.string_member json "displayName";
+      description = Client.string_opt json "description";
+      link = Client.string_member json "link";
+      started_at = Client.string_member json "startedAt";
+      post_count = Client.int_member json "postCount";
+      status = Client.string_opt json "status";
+      category = Client.string_opt json "category";
+      dids = string_list json "dids";
+    }
+
+  let parse_trend_view json : trend_view =
+    let actor_dids =
+      List.filter_map
+        (function
+          | `Assoc _ as a -> Client.string_opt a "did"
+          | `String s -> Some s
+          | _ -> None)
+        (Client.list_member json "actors")
+    in
+    {
+      topic = Client.string_member json "topic";
+      display_name = Client.string_member json "displayName";
+      description = Client.string_opt json "description";
+      link = Client.string_member json "link";
+      started_at = Client.string_member json "startedAt";
+      post_count = Client.int_member json "postCount";
+      status = Client.string_opt json "status";
+      category = Client.string_opt json "category";
+      actor_dids;
+    }
+
+  let parse_trends json : trends =
+    {
+      trends = List.map parse_trend_view (Client.list_member json "trends");
+      rec_id_str = Client.string_opt json "recIdStr";
+    }
+
+  let parse_trends_skeleton json : trends_skeleton =
+    {
+      trends = List.map parse_skeleton_trend (Client.list_member json "trends");
+      rec_id_str = Client.string_opt json "recIdStr";
+    }
+
+  let parse_suggestions_skeleton json : suggestions_skeleton =
+    {
+      cursor = Client.string_opt json "cursor";
+      actors = List.map parse_skeleton_actor (Client.list_member json "actors");
+      relative_to_did = Client.string_opt json "relativeToDid";
+      rec_id = Client.int_opt json "recId";
+      rec_id_str = Client.string_opt json "recIdStr";
+    }
+
+  let parse_suggested_users json : suggested_users =
+    {
+      actors =
+        List.map Actor.parse_short_profile (Client.list_member json "actors");
+      rec_id =
+        (match Yojson.Safe.Util.member "recId" json with
+        | `String s -> Some s
+        | `Int n -> Some (string_of_int n)
+        | _ -> None);
+      rec_id_str = Client.string_opt json "recIdStr";
+    }
+
+  let parse_suggested_feeds json : suggested_feeds =
+    { feeds = List.map parse_generator_view (Client.list_member json "feeds") }
+
+  let parse_uri_list json field : uri_skeleton =
+    { uris = string_list json field }
+
+  let parse_did_skeleton json : did_skeleton =
+    {
+      dids = string_list json "dids";
+      rec_id_str = Client.string_opt json "recIdStr";
+    }
+
+  let get_tagged_suggestions ?session ?host () : tagged_suggestions =
     Client.get_json ?session ?host "app.bsky.unspecced.getTaggedSuggestions" []
+    |> parse_tagged_suggestions
+
+  let get_age_assurance_state (s : Session.session) : age_assurance_state =
+    Client.get_json ~session:s "app.bsky.unspecced.getAgeAssuranceState" []
+    |> parse_age_assurance_state
+
+  let init_age_assurance_body ~email ~language ~country_code : Yojson.Safe.t =
+    `Assoc
+      [
+        ("email", `String email);
+        ("language", `String language);
+        ("countryCode", `String country_code);
+      ]
+
+  let init_age_assurance (s : Session.session) ~email ~language ~country_code ()
+      : age_assurance_state =
+    Client.post_json ~session:s "app.bsky.unspecced.initAgeAssurance"
+      (Yojson.Safe.to_string
+         (init_age_assurance_body ~email ~language ~country_code))
+    |> parse_age_assurance_state
+
+  let get_trends ?session ?host ?limit () : trends =
+    Client.get_json ?session ?host "app.bsky.unspecced.getTrends"
+      (Client.opt_int "limit" limit)
+    |> parse_trends
+
+  let get_trends_skeleton ?session ?host ?viewer ?limit () : trends_skeleton =
+    Client.get_json ?session ?host "app.bsky.unspecced.getTrendsSkeleton"
+      (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
+    |> parse_trends_skeleton
+
+  let get_suggestions_skeleton ?session ?host ?viewer ?limit ?cursor
+      ?relative_to_did () : suggestions_skeleton =
+    Client.get_json ?session ?host "app.bsky.unspecced.getSuggestionsSkeleton"
+      (Client.opt_pair "viewer" viewer
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor
+      @ Client.opt_pair "relativeToDid" relative_to_did)
+    |> parse_suggestions_skeleton
+
+  let get_suggested_feeds ?session ?host ?limit () : suggested_feeds =
+    Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedFeeds"
+      (Client.opt_int "limit" limit)
+    |> parse_suggested_feeds
+
+  let get_suggested_feeds_skeleton ?session ?host ?viewer ?limit () :
+      uri_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedFeedsSkeleton"
+      (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
+    |> fun json -> parse_uri_list json "feeds"
+
+  let get_suggested_users ?session ?host ?category ?limit () : suggested_users =
+    Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedUsers"
+      (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
+    |> parse_suggested_users
+
+  let get_suggested_users_skeleton ?session ?host ?viewer ?category ?limit () :
+      did_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersSkeleton"
+      (Client.opt_pair "viewer" viewer
+      @ Client.opt_pair "category" category
+      @ Client.opt_int "limit" limit)
+    |> parse_did_skeleton
+
+  let get_suggested_starter_packs ?session ?host ?limit () :
+      Graph.starter_pack list =
+    Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedStarterPacks"
+      (Client.opt_int "limit" limit)
+    |> fun json ->
+    List.map Graph.parse_starter_pack (Client.list_member json "starterPacks")
+
+  let get_suggested_starter_packs_skeleton ?session ?host ?viewer ?limit () :
+      uri_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedStarterPacksSkeleton"
+      (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
+    |> fun json -> parse_uri_list json "starterPacks"
+
+  let get_onboarding_suggested_starter_packs ?session ?host ?limit () :
+      Graph.starter_pack list =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getOnboardingSuggestedStarterPacks"
+      (Client.opt_int "limit" limit)
+    |> fun json ->
+    List.map Graph.parse_starter_pack (Client.list_member json "starterPacks")
+
+  let get_onboarding_suggested_starter_packs_skeleton ?session ?host ?viewer
+      ?limit () : uri_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getOnboardingSuggestedStarterPacksSkeleton"
+      (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
+    |> fun json -> parse_uri_list json "starterPacks"
 end

--- a/src/bsky/video.ml
+++ b/src/bsky/video.ml
@@ -217,4 +217,205 @@ module Video = struct
       | None -> []
     in
     `Assoc fields
+
+  (* Multipart upload — start / part / finish / abort / status.
+     Client only; the hosted transcoder still lives on video.bsky.app. *)
+
+  type upload_session = {
+    job_id : string;
+    part_size_bytes : int;
+    part_count : int;
+    expires_at : string;
+  }
+
+  type part_ack = { part_number : int; size_bytes : int }
+  type finish_result = { completed_job_id : string; job_status : job_status }
+
+  type abort_state =
+    | Abort_aborted
+    | Abort_completed
+    | Abort_failed
+    | Abort_expired
+    | Abort_other of string
+
+  type abort_result = {
+    state : abort_state;
+    completed_job_id : string option;
+    failure_reason : string option;
+  }
+
+  type upload_phase =
+    | Phase_created
+    | Phase_finishing
+    | Phase_completed
+    | Phase_failed
+    | Phase_aborted
+    | Phase_expired
+    | Phase_other of string
+
+  type upload_status = {
+    job_id : string;
+    part_size_bytes : int;
+    part_count : int;
+    received_parts : int list;
+    expires_at : string;
+    state : upload_phase;
+    completed_job_id : string option;
+    job_status : job_status option;
+    failure_reason : string option;
+  }
+
+  let parse_abort_state (s : string) : abort_state =
+    match String.lowercase_ascii s with
+    | "aborted" -> Abort_aborted
+    | "completed" -> Abort_completed
+    | "failed" -> Abort_failed
+    | "expired" -> Abort_expired
+    | other -> Abort_other other
+
+  let parse_upload_phase (s : string) : upload_phase =
+    match String.lowercase_ascii s with
+    | "created" -> Phase_created
+    | "finishing" -> Phase_finishing
+    | "completed" -> Phase_completed
+    | "failed" -> Phase_failed
+    | "aborted" -> Phase_aborted
+    | "expired" -> Phase_expired
+    | other -> Phase_other other
+
+  let parse_upload_session json : upload_session =
+    {
+      job_id = Client.string_member json "jobId";
+      part_size_bytes = Client.int_member json "partSizeBytes";
+      part_count = Client.int_member json "partCount";
+      expires_at = Client.string_member json "expiresAt";
+    }
+
+  let parse_part_ack json : part_ack =
+    {
+      part_number = Client.int_member json "partNumber";
+      size_bytes = Client.int_member json "sizeBytes";
+    }
+
+  let parse_finish_result json : finish_result =
+    {
+      completed_job_id = Client.string_member json "completedJobId";
+      job_status = parse_job_status_response json;
+    }
+
+  let parse_abort_result json : abort_result =
+    {
+      state = parse_abort_state (Client.string_member json "state");
+      completed_job_id = Client.string_opt json "completedJobId";
+      failure_reason = Client.string_opt json "failureReason";
+    }
+
+  let int_list json field =
+    List.filter_map
+      (function
+        | `Int n -> Some n
+        | `Intlit s -> ( try Some (int_of_string s) with _ -> None)
+        | _ -> None)
+      (Client.list_member json field)
+
+  let parse_upload_status json : upload_status =
+    {
+      job_id = Client.string_member json "jobId";
+      part_size_bytes = Client.int_member json "partSizeBytes";
+      part_count = Client.int_member json "partCount";
+      received_parts = int_list json "receivedParts";
+      expires_at = Client.string_member json "expiresAt";
+      state = parse_upload_phase (Client.string_member json "state");
+      completed_job_id = Client.string_opt json "completedJobId";
+      job_status =
+        (match Yojson.Safe.Util.member "jobStatus" json with
+        | `Assoc _ as st -> Some (parse_job_status st)
+        | _ -> None);
+      failure_reason = Client.string_opt json "failureReason";
+    }
+
+  let start_upload_body ~size_bytes ~mime_type ?name ?duration_ms ?width ?height
+      () : Yojson.Safe.t =
+    let fields =
+      [ ("sizeBytes", `Int size_bytes); ("mimeType", `String mime_type) ]
+      @ (match name with Some n -> [ ("name", `String n) ] | None -> [])
+      @ (match duration_ms with
+        | Some n -> [ ("durationMs", `Int n) ]
+        | None -> [])
+      @ (match width with Some n -> [ ("width", `Int n) ] | None -> [])
+      @ match height with Some n -> [ ("height", `Int n) ] | None -> []
+    in
+    `Assoc fields
+
+  let job_id_body ~job_id : Yojson.Safe.t = `Assoc [ ("jobId", `String job_id) ]
+
+  let bearer_extra ?token () =
+    match token with
+    | Some t -> [ ("Authorization", "Bearer " ^ t) ]
+    | None -> []
+
+  let start_upload ?session ?host ?token ~size_bytes ~mime_type ?name
+      ?duration_ms ?width ?height () : upload_session =
+    Client.post_json ?session ~host:(video_host ?host ())
+      ~extra:(bearer_extra ?token ()) "app.bsky.video.startUpload"
+      (Yojson.Safe.to_string
+         (start_upload_body ~size_bytes ~mime_type ?name ?duration_ms ?width
+            ?height ()))
+    |> parse_upload_session
+
+  let upload_part_url ?host ~job_id ~part_number () =
+    let base =
+      Client.nsid_url ~host:(video_host ?host ()) "app.bsky.video.uploadPart"
+    in
+    let qs =
+      Cohttp_client.Cohttp_client.create_body_from_pairs
+        [ ("jobId", job_id); ("partNumber", string_of_int part_number) ]
+    in
+    if qs = "" then base else base ^ "?" ^ qs
+
+  let upload_part ?host ~token ~job_id ~part_number
+      ?(content_type = "application/octet-stream") (bytes : string) : part_ack =
+    let url = upload_part_url ?host ~job_id ~part_number () in
+    let headers =
+      Cohttp_client.Cohttp_client.create_headers_from_pairs
+        (upload_header_pairs ~token ~content_type)
+    in
+    let body =
+      Lwt_main.run
+        (Cohttp_client.Cohttp_client.post_data_with_headers url bytes headers)
+    in
+    parse_part_ack (Yojson.Safe.from_string body)
+
+  let finish_upload ?session ?host ?token ~job_id () : finish_result =
+    Client.post_json ?session ~host:(video_host ?host ())
+      ~extra:(bearer_extra ?token ()) "app.bsky.video.finishUpload"
+      (Yojson.Safe.to_string (job_id_body ~job_id))
+    |> parse_finish_result
+
+  let abort_upload ?session ?host ?token ~job_id () : abort_result =
+    Client.post_json ?session ~host:(video_host ?host ())
+      ~extra:(bearer_extra ?token ()) "app.bsky.video.abortUpload"
+      (Yojson.Safe.to_string (job_id_body ~job_id))
+    |> parse_abort_result
+
+  let get_upload_status ?session ?host ?token ~job_id () : upload_status =
+    Client.get_json ?session ~host:(video_host ?host ())
+      ~extra:(bearer_extra ?token ()) "app.bsky.video.getUploadStatus"
+      [ ("jobId", job_id) ]
+    |> parse_upload_status
+
+  let expected_part_size (sess : upload_session) ~part_number : int option =
+    if part_number < 1 || part_number > sess.part_count then None
+    else if part_number < sess.part_count then Some sess.part_size_bytes
+    else
+      (* last part may be shorter; callers that know the total size can compute it *)
+      Some sess.part_size_bytes
+
+  let missing_parts (st : upload_status) : int list =
+    let rec loop i acc =
+      if i > st.part_count then List.rev acc
+      else if List.mem i st.received_parts then loop (i + 1) acc
+      else loop (i + 1) (i :: acc)
+    in
+    loop 1 []
 end

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -548,4 +548,232 @@ module Chat = struct
       "chat.bsky.notification.putPreferences"
       (Yojson.Safe.to_string (`Assoc fields))
     |> parse_notification_preferences
+
+  (* chat.bsky.actor — viewer status, declaration record, account export/delete. *)
+
+  type actor_status = {
+    chat_disabled : bool;
+    can_create_groups : bool;
+    group_member_limit : int;
+  }
+
+  type declaration = {
+    allow_incoming : string;
+    allow_group_invites : string option;
+  }
+
+  let parse_actor_status json : actor_status =
+    {
+      chat_disabled = Client.bool_member json "chatDisabled";
+      can_create_groups = Client.bool_member json "canCreateGroups";
+      group_member_limit = Client.int_member json "groupMemberLimit";
+    }
+
+  let parse_declaration json : declaration =
+    {
+      allow_incoming =
+        (match Client.string_opt json "allowIncoming" with
+        | Some s -> s
+        | None -> "all");
+      allow_group_invites = Client.string_opt json "allowGroupInvites";
+    }
+
+  let declaration_json ~allow_incoming ?allow_group_invites () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String "chat.bsky.actor.declaration");
+        ("allowIncoming", `String allow_incoming);
+      ]
+      @
+      match allow_group_invites with
+      | Some s -> [ ("allowGroupInvites", `String s) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let get_actor_status (s : Session.session) ?proxy () : actor_status =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.actor.getStatus" []
+    |> parse_actor_status
+
+  let delete_account (s : Session.session) ?proxy () : unit =
+    ignore
+      (Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+         "chat.bsky.actor.deleteAccount" "{}")
+
+  let export_account_data (s : Session.session) ?proxy () : string =
+    Client.get_text ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.actor.exportAccountData" []
+
+  (* chat.bsky.moderation — operator views of convos / actor access. *)
+
+  type actor_metadata_window = {
+    messages_sent : int;
+    messages_received : int;
+    convos : int;
+    convos_started : int;
+  }
+
+  type actor_metadata = {
+    day : actor_metadata_window;
+    month : actor_metadata_window;
+    all : actor_metadata_window;
+  }
+
+  type mod_group = {
+    created_at : string;
+    join_request_count : int;
+    lock_status : string option;
+    member_count : int;
+    member_limit : int;
+    name : string;
+  }
+
+  type mod_convo_kind =
+    [ `Direct | `Group of mod_group | `Unknown of Yojson.Safe.t ]
+
+  type mod_convo = {
+    id : string;
+    rev : string;
+    kind : mod_convo_kind;
+    original : Yojson.Safe.t;
+  }
+
+  type mod_members = { cursor : string option; members : member list }
+
+  let parse_metadata_window json : actor_metadata_window =
+    {
+      messages_sent = Client.int_member json "messagesSent";
+      messages_received = Client.int_member json "messagesReceived";
+      convos = Client.int_member json "convos";
+      convos_started = Client.int_member json "convosStarted";
+    }
+
+  let parse_actor_metadata json : actor_metadata =
+    let window field =
+      match Yojson.Safe.Util.member field json with
+      | `Assoc _ as w -> parse_metadata_window w
+      | _ ->
+          {
+            messages_sent = 0;
+            messages_received = 0;
+            convos = 0;
+            convos_started = 0;
+          }
+    in
+    { day = window "day"; month = window "month"; all = window "all" }
+
+  let parse_lock_status json : string option =
+    match Yojson.Safe.Util.member "lockStatus" json with
+    | `String s -> Some s
+    | `Assoc _ as o -> (
+        match Client.string_opt o "status" with
+        | Some s -> Some s
+        | None -> Client.string_opt o "$type")
+    | _ -> None
+
+  let parse_mod_group json : mod_group =
+    {
+      created_at = Client.string_member json "createdAt";
+      join_request_count = Client.int_member json "joinRequestCount";
+      lock_status = parse_lock_status json;
+      member_count = Client.int_member json "memberCount";
+      member_limit = Client.int_member json "memberLimit";
+      name = Client.string_member json "name";
+    }
+
+  let parse_mod_kind json : mod_convo_kind =
+    match Yojson.Safe.Util.member "kind" json with
+    | `Assoc _ as k ->
+        let ty = Client.string_opt k "$type" |> Option.value ~default:"" in
+        if
+          let n = String.length ty in
+          n >= 10 && String.sub ty (n - 10) 10 = "groupConvo"
+        then `Group (parse_mod_group k)
+        else if
+          let n = String.length ty in
+          n >= 11 && String.sub ty (n - 11) 11 = "directConvo"
+        then `Direct
+        else if Client.string_member k "name" <> "" then
+          `Group (parse_mod_group k)
+        else `Unknown k
+    | _ -> `Direct
+
+  let parse_mod_convo json : mod_convo =
+    {
+      id = Client.string_member json "id";
+      rev = Client.string_member json "rev";
+      kind = parse_mod_kind json;
+      original = json;
+    }
+
+  let unwrap_mod_convo json : mod_convo =
+    match Yojson.Safe.Util.member "convo" json with
+    | `Assoc _ as c -> parse_mod_convo c
+    | _ -> parse_mod_convo json
+
+  let parse_mod_convos json : mod_convo list =
+    List.map parse_mod_convo (Client.list_member json "convos")
+
+  let parse_mod_members json : mod_members =
+    {
+      cursor = Client.string_opt json "cursor";
+      members = List.map parse_member (Client.list_member json "members");
+    }
+
+  let update_actor_access_body ~actor ~allow_access ?ref () : Yojson.Safe.t =
+    let fields =
+      [ ("actor", `String actor); ("allowAccess", `Bool allow_access) ]
+      @ match ref with Some r -> [ ("ref", `String r) ] | None -> []
+    in
+    `Assoc fields
+
+  let get_actor_metadata (s : Session.session) ?proxy ~actor () : actor_metadata
+      =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.moderation.getActorMetadata"
+      [ ("actor", actor) ]
+    |> parse_actor_metadata
+
+  let get_mod_convo (s : Session.session) ?proxy ~convo_id () : mod_convo =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.moderation.getConvo"
+      [ ("convoId", convo_id) ]
+    |> unwrap_mod_convo
+
+  let get_mod_convos (s : Session.session) ?proxy ~convo_ids () : mod_convo list
+      =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.moderation.getConvos"
+      (Client.repeat_param "convoIds" convo_ids)
+    |> parse_mod_convos
+
+  let get_mod_convo_members (s : Session.session) ?proxy ~convo_id ?limit
+      ?cursor () : mod_members =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.moderation.getConvoMembers"
+      ([ ("convoId", convo_id) ]
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_mod_members
+
+  let get_message_context (s : Session.session) ?proxy ~message_id ?convo_id
+      ?before ?after ?max_interleaved_system_messages () : message list =
+    Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
+      "chat.bsky.moderation.getMessageContext"
+      ([ ("messageId", message_id) ]
+      @ Client.opt_pair "convoId" convo_id
+      @ Client.opt_int "before" before
+      @ Client.opt_int "after" after
+      @ Client.opt_int "maxInterleavedSystemMessages"
+          max_interleaved_system_messages)
+    |> fun json -> List.map parse_message (Client.list_member json "messages")
+
+  let update_actor_access (s : Session.session) ?proxy ~actor ~allow_access ?ref
+      () : unit =
+    ignore
+      (Client.post_json ~session:s ~extra:(proxy_headers ?proxy ())
+         "chat.bsky.moderation.updateActorAccess"
+         (Yojson.Safe.to_string
+            (update_actor_access_body ~actor ~allow_access ?ref ())))
 end

--- a/src/client.ml
+++ b/src/client.ml
@@ -76,6 +76,13 @@ module Client = struct
     in
     Yojson.Safe.from_string resp
 
+  let get_text ?session ?host ?(extra = []) nsid pairs =
+    let headers = request_headers ?session ~extra () in
+    let url = nsid_url ?session ?host nsid in
+    let body = Cohttp_client.create_body_from_pairs pairs in
+    Lwt_main.run
+      (Cohttp_client.get_request_with_body_and_headers url body headers)
+
   let post_json ?session ?host ?(extra = []) nsid data =
     let headers = request_headers ?session ~extra () in
     let url = nsid_url ?session ?host nsid in

--- a/src/moderation.ml
+++ b/src/moderation.ml
@@ -5,14 +5,48 @@ open Session
 module Moderation = struct
   type strong_ref = { uri : string; cid : string }
   type repo_ref = { did : string }
+  type mod_tool = { name : string; meta : Yojson.Safe.t option }
 
   type report_response = {
     id : int;
     created_at : string;
     reason_type : string;
     reported_by : string;
+    reason : string option;
     subject : Yojson.Safe.t;
+    mod_tool : mod_tool option;
   }
+
+  let reason_spam = "com.atproto.moderation.defs#reasonSpam"
+  let reason_violation = "com.atproto.moderation.defs#reasonViolation"
+  let reason_misleading = "com.atproto.moderation.defs#reasonMisleading"
+  let reason_sexual = "com.atproto.moderation.defs#reasonSexual"
+  let reason_rude = "com.atproto.moderation.defs#reasonRude"
+  let reason_other = "com.atproto.moderation.defs#reasonOther"
+  let reason_appeal = "com.atproto.moderation.defs#reasonAppeal"
+
+  let parse_mod_tool json : mod_tool option =
+    match Yojson.Safe.Util.member "modTool" json with
+    | `Assoc _ as t ->
+        Some
+          {
+            name =
+              (match Yojson.Safe.Util.member "name" t with
+              | `String s -> s
+              | _ -> "");
+            meta =
+              (match Yojson.Safe.Util.member "meta" t with
+              | `Null -> None
+              | other -> Some other);
+          }
+    | _ -> None
+
+  let mod_tool_json (t : mod_tool) : Yojson.Safe.t =
+    let fields =
+      ("name", `String t.name)
+      :: (match t.meta with Some m -> [ ("meta", m) ] | None -> [])
+    in
+    `Assoc fields
 
   let create_moderation_endpoint (query_name : string) : string =
     "com.atproto.moderation" ^ "." ^ query_name
@@ -27,8 +61,19 @@ module Moderation = struct
     let created_at = json |> member "createdAt" |> to_string in
     let reason_type = json |> member "reasonType" |> to_string in
     let reported_by = json |> member "reportedBy" |> to_string in
+    let reason =
+      match json |> member "reason" with `String s -> Some s | _ -> None
+    in
     let subject = json |> member "subject" in
-    { id; created_at; reason_type; reported_by; subject }
+    {
+      id;
+      created_at;
+      reason_type;
+      reported_by;
+      reason;
+      subject;
+      mod_tool = parse_mod_tool json;
+    }
 
   let create_subject_from_strong_ref (ref : strong_ref) =
     let subject =
@@ -51,42 +96,28 @@ module Moderation = struct
     in
     subject
 
-  let create_report_data_from_strong_ref (reason_type : string) ?reason
-      (subject : strong_ref) : string =
-    let subject = create_subject_from_strong_ref subject in
-    let report_data =
-      match reason with
-      | Some r ->
-          `Assoc
-            [
-              ("reasonType", `String reason_type);
-              ("reason", `String r);
-              ("subject", subject);
-            ]
-      | None ->
-          `Assoc [ ("reasonType", `String reason_type); ("subject", subject) ]
-    in
-    Yojson.Basic.to_string report_data
+  let report_fields reason_type ?reason ?mod_tool subject =
+    [ ("reasonType", `String reason_type); ("subject", subject) ]
+    @ (match reason with Some r -> [ ("reason", `String r) ] | None -> [])
+    @
+    match mod_tool with
+    | Some t -> [ ("modTool", mod_tool_json t) ]
+    | None -> []
 
-  let create_report_data_from_repo_ref (reason_type : string) ?reason
+  let create_report_data_from_strong_ref (reason_type : string) ?reason
+      ?mod_tool (subject : strong_ref) : string =
+    let subject = create_subject_from_strong_ref subject in
+    Yojson.Safe.to_string
+      (`Assoc (report_fields reason_type ?reason ?mod_tool subject))
+
+  let create_report_data_from_repo_ref (reason_type : string) ?reason ?mod_tool
       (subject : repo_ref) : string =
     let subject = create_subject_from_repo_ref subject in
-    let report_data =
-      match reason with
-      | Some r ->
-          `Assoc
-            [
-              ("reasonType", `String reason_type);
-              ("reason", `String r);
-              ("subject", subject);
-            ]
-      | None ->
-          `Assoc [ ("reasonType", `String reason_type); ("subject", subject) ]
-    in
-    Yojson.Basic.to_string report_data
+    Yojson.Safe.to_string
+      (`Assoc (report_fields reason_type ?reason ?mod_tool subject))
 
   let create_report_with_strong_ref (s : Session.session) (reason_type : string)
-      ?reason (subject : strong_ref) : report_response =
+      ?reason ?mod_tool (subject : strong_ref) : report_response =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
     let headers =
@@ -97,7 +128,9 @@ module Moderation = struct
       App.create_endpoint_url base_url
         (create_moderation_endpoint "createReport")
     in
-    let data = create_report_data_from_strong_ref reason_type ?reason subject in
+    let data =
+      create_report_data_from_strong_ref reason_type ?reason ?mod_tool subject
+    in
     let created_report =
       Lwt_main.run
         (Cohttp_client.post_data_with_headers create_report_url data headers)
@@ -105,7 +138,7 @@ module Moderation = struct
     created_report |> convert_body_to_json |> parse_report_response
 
   let create_report_with_repo_ref (s : Session.session) (reason_type : string)
-      ?reason (subject : repo_ref) : report_response =
+      ?reason ?mod_tool (subject : repo_ref) : report_response =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
     let headers =
@@ -116,7 +149,9 @@ module Moderation = struct
       App.create_endpoint_url base_url
         (create_moderation_endpoint "createReport")
     in
-    let data = create_report_data_from_repo_ref reason_type ?reason subject in
+    let data =
+      create_report_data_from_repo_ref reason_type ?reason ?mod_tool subject
+    in
     let created_report =
       Lwt_main.run
         (Cohttp_client.post_data_with_headers create_report_url data headers)

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -87,7 +87,13 @@ let test_parse_preferences _ =
   OUnit2.assert_equal 2 (List.length prefs.preferences);
   OUnit2.assert_equal
     ~printer:(fun x -> x)
-    "app.bsky.actor.defs#adultContentPref" (List.hd prefs.preferences).type_
+    "app.bsky.actor.defs#adultContentPref" (List.hd prefs.preferences).type_;
+  (match (List.hd prefs.preferences).kind with
+  | `Adult_content a -> OUnit2.assert_equal false a.enabled
+  | _ -> OUnit2.assert_failure "expected adultContentPref");
+  match (List.nth prefs.preferences 1).kind with
+  | `Saved_feeds_v2 s -> OUnit2.assert_equal 0 (List.length s.items)
+  | _ -> OUnit2.assert_failure "expected savedFeedsPrefV2"
 
 let test_get_preferences_auth_skipped _ =
   skip_if

--- a/test/test_bookmark.ml
+++ b/test/test_bookmark.ml
@@ -36,6 +36,24 @@ let test_parse_bookmarks _ =
                           `String
                             "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k2"
                         );
+                        ( "cid",
+                          `String
+                            "bafyreiarimgpoqvxxnf3sg4h52gvfzvmyeybxk2xgy6v3dra7zuldy73aq"
+                        );
+                        ( "author",
+                          `Assoc
+                            [
+                              ("did", `String "did:plc:abc123xyz0001112223333");
+                              ("handle", `String "alice.test");
+                            ] );
+                        ( "record",
+                          `Assoc
+                            [
+                              ("$type", `String "app.bsky.feed.post");
+                              ("text", `String "hi");
+                              ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                            ] );
+                        ("indexedAt", `String "2024-01-01T00:00:00.000Z");
                       ] );
                 ];
             ] );

--- a/test/test_bookmark.ml
+++ b/test/test_bookmark.ml
@@ -45,7 +45,10 @@ let test_parse_bookmarks _ =
   OUnit2.assert_equal (Some "abc") page.cursor;
   OUnit2.assert_equal 1 (List.length page.bookmarks);
   OUnit2.assert_bool "bookmark uri"
-    (String.length (List.hd page.bookmarks).uri > 10)
+    (String.length (List.hd page.bookmarks).uri > 10);
+  match (List.hd page.bookmarks).item with
+  | `Post p -> OUnit2.assert_bool "item uri" (String.length p.uri > 10)
+  | `NotFound _ | `Blocked _ -> OUnit2.assert_failure "expected post view item"
 
 let test_create_bookmark_body _ =
   let body =
@@ -57,6 +60,38 @@ let test_create_bookmark_body _ =
     ~printer:(fun x -> x)
     "at://did:plc:x/app.bsky.feed.post/1"
     (body |> member "uri" |> to_string)
+
+let test_parse_bookmark_item_unions _ =
+  let not_found =
+    Bookmark.parse_bookmark_item
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.feed.defs#notFoundPost");
+          ( "uri",
+            `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+          );
+          ("notFound", `Bool true);
+        ])
+  in
+  (match not_found with
+  | `NotFound n -> OUnit2.assert_equal true n.not_found
+  | _ -> OUnit2.assert_failure "expected notFound item");
+  let blocked =
+    Bookmark.parse_bookmark_item
+      (`Assoc
+        [
+          ("$type", `String "app.bsky.feed.defs#blockedPost");
+          ( "uri",
+            `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+          );
+          ("blocked", `Bool true);
+          ( "author",
+            `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
+        ])
+  in
+  match blocked with
+  | `Blocked b -> OUnit2.assert_equal true b.blocked
+  | _ -> OUnit2.assert_failure "expected blocked item"
 
 let test_get_bookmarks_auth_skipped _ =
   skip_if
@@ -71,6 +106,7 @@ let suite =
   >::: [
          "test_parse_bookmarks" >:: test_parse_bookmarks;
          "test_create_bookmark_body" >:: test_create_bookmark_body;
+         "test_parse_bookmark_item_unions" >:: test_parse_bookmark_item_unions;
          "test_get_bookmarks_auth_skipped" >:: test_get_bookmarks_auth_skipped;
        ]
 

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -216,6 +216,105 @@ let test_lock_unlock_and_group_bodies _ =
   in
   OUnit2.assert_equal 1 (body |> member "facets" |> to_list |> List.length)
 
+let test_actor_status_and_declaration _ =
+  let st =
+    Chat.parse_actor_status
+      (`Assoc
+        [
+          ("chatDisabled", `Bool false);
+          ("canCreateGroups", `Bool true);
+          ("groupMemberLimit", `Int 50);
+        ])
+  in
+  OUnit2.assert_equal false st.chat_disabled;
+  OUnit2.assert_equal true st.can_create_groups;
+  OUnit2.assert_equal 50 st.group_member_limit;
+  let dec =
+    Chat.parse_declaration
+      (`Assoc
+        [
+          ("allowIncoming", `String "following");
+          ("allowGroupInvites", `String "none");
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "following" dec.allow_incoming;
+  OUnit2.assert_equal (Some "none") dec.allow_group_invites;
+  let body = Chat.declaration_json ~allow_incoming:"all" () in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "chat.bsky.actor.declaration"
+    (body |> member "$type" |> to_string)
+
+let test_moderation_parsers _ =
+  let meta =
+    Chat.parse_actor_metadata
+      (`Assoc
+        [
+          ( "day",
+            `Assoc
+              [
+                ("messagesSent", `Int 1);
+                ("messagesReceived", `Int 2);
+                ("convos", `Int 3);
+                ("convosStarted", `Int 1);
+              ] );
+          ( "month",
+            `Assoc
+              [
+                ("messagesSent", `Int 10);
+                ("messagesReceived", `Int 20);
+                ("convos", `Int 4);
+                ("convosStarted", `Int 2);
+              ] );
+          ( "all",
+            `Assoc
+              [
+                ("messagesSent", `Int 100);
+                ("messagesReceived", `Int 200);
+                ("convos", `Int 8);
+                ("convosStarted", `Int 5);
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 meta.day.messages_sent;
+  OUnit2.assert_equal 200 meta.all.messages_received;
+  let convo =
+    Chat.parse_mod_convo
+      (`Assoc
+        [
+          ("id", `String "c9");
+          ("rev", `String "r9");
+          ( "kind",
+            `Assoc
+              [
+                ("$type", `String "chat.bsky.moderation.defs#groupConvo");
+                ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                ("joinRequestCount", `Int 2);
+                ("lockStatus", `String "unlocked");
+                ("memberCount", `Int 4);
+                ("memberLimit", `Int 50);
+                ("name", `String "mods");
+              ] );
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "c9" convo.id;
+  (match convo.kind with
+  | `Group g ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "mods" g.name;
+      OUnit2.assert_equal 4 g.member_count
+  | _ -> OUnit2.assert_failure "expected group convo");
+  let body =
+    Chat.update_actor_access_body ~actor:"did:plc:abc123xyz0001112223333"
+      ~allow_access:false ~ref:"ticket-1" ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal false (body |> member "allowAccess" |> to_bool);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "ticket-1"
+    (body |> member "ref" |> to_string)
+
 let test_list_convos_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -238,6 +337,9 @@ let suite =
          >:: test_parse_message_facets_reactions_embed;
          "test_lock_unlock_and_group_bodies"
          >:: test_lock_unlock_and_group_bodies;
+         "test_actor_status_and_declaration"
+         >:: test_actor_status_and_declaration;
+         "test_moderation_parsers" >:: test_moderation_parsers;
          "test_list_convos_auth_skipped" >:: test_list_convos_auth_skipped;
        ]
 

--- a/test/test_moderation.ml
+++ b/test/test_moderation.ml
@@ -42,7 +42,21 @@ let test_report_bodies _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "com.atproto.admin.defs#repoRef"
-    (repo_json |> member "subject" |> member "$type" |> to_string)
+    (repo_json |> member "subject" |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    Moderation.reason_spam "com.atproto.moderation.defs#reasonSpam";
+  let with_tool =
+    Moderation.create_report_data_from_strong_ref Moderation.reason_other
+      ~reason:"context"
+      ~mod_tool:{ name = "atproto-ocaml/test"; meta = None }
+      sample_strong_ref
+  in
+  let tool_json = Yojson.Safe.from_string with_tool in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "atproto-ocaml/test"
+    (tool_json |> member "modTool" |> member "name" |> to_string)
 
 let test_parse_report_response _ =
   let json =

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -123,7 +123,18 @@ let test_list_and_starterpack_builders _ =
     "did:plc:alice000111222333444555666" parsed_item.subject;
   let parsed_pack = Records.parse_starterpack pack in
   OUnit2.assert_equal ~printer:(fun x -> x) "Start here" parsed_pack.name;
-  OUnit2.assert_equal 1 (List.length parsed_pack.feeds)
+  OUnit2.assert_equal 1 (List.length parsed_pack.feeds);
+  let decl =
+    Records.chat_declaration ~allow_incoming:"following"
+      ~allow_group_invites:"none" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "chat.bsky.actor.declaration"
+    (decl |> member "$type" |> to_string);
+  let parsed = Records.parse_chat_declaration decl in
+  OUnit2.assert_equal ~printer:(fun x -> x) "following" parsed.allow_incoming;
+  OUnit2.assert_equal (Some "none") parsed.allow_group_invites
 
 let test_parse_like_and_follow _ =
   let like =

--- a/test/test_unspecced.ml
+++ b/test/test_unspecced.ml
@@ -79,6 +79,125 @@ let test_parse_popular _ =
     ~printer:(fun x -> x)
     "Discover" (List.hd gens.feeds).display_name
 
+let test_parse_tagged_and_age _ =
+  let tagged =
+    Unspecced.parse_tagged_suggestions
+      (`Assoc
+        [
+          ( "suggestions",
+            `List
+              [
+                `Assoc
+                  [
+                    ("tag", `String "news");
+                    ("subjectType", `String "feed");
+                    ( "subject",
+                      `String
+                        "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
+                    );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length tagged.suggestions);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "news" (List.hd tagged.suggestions).tag;
+  let aa =
+    Unspecced.parse_age_assurance_state
+      (`Assoc
+        [
+          ("status", `String "pending");
+          ("lastInitiatedAt", `String "2026-01-01T00:00:00.000Z");
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "pending" aa.status;
+  let body =
+    Unspecced.init_age_assurance_body ~email:"user@example.com" ~language:"en"
+      ~country_code:"US"
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "US"
+    (body |> member "countryCode" |> to_string)
+
+let test_parse_trends_and_skeletons _ =
+  let trends =
+    Unspecced.parse_trends
+      (`Assoc
+        [
+          ( "trends",
+            `List
+              [
+                `Assoc
+                  [
+                    ("topic", `String "atproto");
+                    ("displayName", `String "AT Protocol");
+                    ("link", `String "/topic/atproto");
+                    ("startedAt", `String "2026-01-01T00:00:00.000Z");
+                    ("postCount", `Int 42);
+                    ("status", `String "hot");
+                    ( "actors",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("did", `String "did:plc:abc123xyz0001112223333");
+                            ];
+                        ] );
+                  ];
+              ] );
+          ("recIdStr", `String "snow-1");
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length trends.trends);
+  OUnit2.assert_equal 42 (List.hd trends.trends).post_count;
+  OUnit2.assert_equal (Some "snow-1") trends.rec_id_str;
+  let skel =
+    Unspecced.parse_trends_skeleton
+      (`Assoc
+        [
+          ( "trends",
+            `List
+              [
+                `Assoc
+                  [
+                    ("topic", `String "ocaml");
+                    ("displayName", `String "OCaml");
+                    ("link", `String "/topic/ocaml");
+                    ("startedAt", `String "2026-01-01T00:00:00.000Z");
+                    ("postCount", `Int 3);
+                    ("dids", `List [ `String "did:plc:abc123xyz0001112223333" ]);
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length (List.hd skel.trends).dids);
+  let feeds =
+    Unspecced.parse_uri_list
+      (`Assoc
+        [
+          ( "feeds",
+            `List
+              [
+                `String
+                  "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot";
+              ] );
+        ])
+      "feeds"
+  in
+  OUnit2.assert_equal 1 (List.length feeds.uris);
+  let dids =
+    Unspecced.parse_did_skeleton
+      (`Assoc
+        [
+          ("dids", `List [ `String "did:plc:abc123xyz0001112223333" ]);
+          ("recIdStr", `String "r2");
+        ])
+  in
+  OUnit2.assert_equal (Some "r2") dids.rec_id_str
+
 let test_popular_live _ =
   try
     with_public_timeout (fun () ->
@@ -108,6 +227,8 @@ let suite =
          "test_parse_skeleton_posts" >:: test_parse_skeleton_posts;
          "test_parse_trending" >:: test_parse_trending;
          "test_parse_popular" >:: test_parse_popular;
+         "test_parse_tagged_and_age" >:: test_parse_tagged_and_age;
+         "test_parse_trends_and_skeletons" >:: test_parse_trends_and_skeletons;
          "test_popular_live" >:: test_popular_live;
          "test_search_posts_skeleton_live" >:: test_search_posts_skeleton_live;
        ]

--- a/test/test_video.ml
+++ b/test/test_video.ml
@@ -248,6 +248,75 @@ let test_upload_headers _ =
     [ ("Authorization", "Bearer svc"); ("Content-Type", "video/mp4") ]
     pairs
 
+let test_multipart_parsers _ =
+  let sess =
+    Video.parse_upload_session
+      (`Assoc
+        [
+          ("jobId", `String "job-m");
+          ("partSizeBytes", `Int 5_242_880);
+          ("partCount", `Int 3);
+          ("expiresAt", `String "2026-01-01T00:00:00.000Z");
+        ])
+  in
+  OUnit2.assert_equal 3 sess.part_count;
+  OUnit2.assert_equal (Some 5_242_880)
+    (Video.expected_part_size sess ~part_number:1);
+  OUnit2.assert_equal None (Video.expected_part_size sess ~part_number:9);
+  let body =
+    Video.start_upload_body ~size_bytes:10_000 ~mime_type:"video/mp4"
+      ~name:"clip.mp4" ~width:1920 ~height:1080 ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal 10000 (body |> member "sizeBytes" |> to_int);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "video/mp4"
+    (body |> member "mimeType" |> to_string);
+  let st =
+    Video.parse_upload_status
+      (`Assoc
+        [
+          ("jobId", `String "job-m");
+          ("partSizeBytes", `Int 100);
+          ("partCount", `Int 3);
+          ("receivedParts", `List [ `Int 1; `Int 3 ]);
+          ("expiresAt", `String "2026-01-01T00:00:00.000Z");
+          ("state", `String "created");
+        ])
+  in
+  OUnit2.assert_equal Video.Phase_created st.state;
+  OUnit2.assert_equal [ 2 ] (Video.missing_parts st);
+  let abort =
+    Video.parse_abort_result
+      (`Assoc
+        [ ("state", `String "aborted"); ("failureReason", `String "user") ])
+  in
+  OUnit2.assert_equal Video.Abort_aborted abort.state;
+  let finish =
+    Video.parse_finish_result
+      (`Assoc
+        [
+          ("completedJobId", `String "job-done");
+          ( "jobStatus",
+            `Assoc
+              [
+                ("jobId", `String "job-done");
+                ("did", `String "did:plc:abc123xyz0001112223333");
+                ("state", `String "JOB_STATE_CREATED");
+              ] );
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "job-done" finish.completed_job_id;
+  let url = Video.upload_part_url ~job_id:"job-m" ~part_number:2 () in
+  OUnit2.assert_bool "uploadPart nsid"
+    (let needle = "app.bsky.video.uploadPart" in
+     let rec contains i =
+       i + String.length needle <= String.length url
+       && (String.sub url i (String.length needle) = needle || contains (i + 1))
+     in
+     contains 0)
+
 let test_upload_limits_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -272,6 +341,7 @@ let suite =
          "test_ensure_blob_short_circuit" >:: test_ensure_blob_short_circuit;
          "test_video_embed_json" >:: test_video_embed_json;
          "test_upload_headers" >:: test_upload_headers;
+         "test_multipart_parsers" >:: test_multipart_parsers;
          "test_upload_limits_auth_skipped" >:: test_upload_limits_auth_skipped;
        ]
 

--- a/test/test_xrpc.ml
+++ b/test/test_xrpc.ml
@@ -214,6 +214,34 @@ let test_service_jwt_rejects _ =
   OUnit2.assert_bool "replayed jti"
     (Xrpc.remember_jti ~now:1_700_000_010.0 cache claims)
 
+let test_jti_cache_eviction _ =
+  let cache = Xrpc.create_jti_cache ~cap:2 () in
+  let claim jti : Xrpc.service_auth =
+    {
+      alg = "ES256";
+      typ = "JWT";
+      kid = "#atproto";
+      iss = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+      aud = "did:web:api.bsky.app#bsky_appview";
+      aud_did = "did:web:api.bsky.app";
+      aud_service = Some "bsky_appview";
+      exp = Some 2_000_000_000L;
+      iat = Some 1_700_000_000L;
+      lxm = Some "app.bsky.feed.getFeedSkeleton";
+      jti = Some jti;
+      raw = "";
+    }
+  in
+  OUnit2.assert_bool "a new"
+    (not (Xrpc.remember_jti ~now:1_700_000_010.0 cache (claim "a")));
+  OUnit2.assert_bool "b new"
+    (not (Xrpc.remember_jti ~now:1_700_000_010.0 cache (claim "b")));
+  OUnit2.assert_bool "c evicts a"
+    (not (Xrpc.remember_jti ~now:1_700_000_010.0 cache (claim "c")));
+  OUnit2.assert_bool "a evicted" (not (Xrpc.jti_seen cache "a"));
+  OUnit2.assert_bool "b kept" (Xrpc.jti_seen cache "b");
+  OUnit2.assert_bool "c kept" (Xrpc.jti_seen cache "c")
+
 let suite =
   "xrpc"
   >::: [
@@ -225,6 +253,7 @@ let suite =
          "test_service_jwt_p256_roundtrip" >:: test_service_jwt_p256_roundtrip;
          "test_service_jwt_k256_roundtrip" >:: test_service_jwt_k256_roundtrip;
          "test_service_jwt_rejects" >:: test_service_jwt_rejects;
+         "test_jti_cache_eviction" >:: test_jti_cache_eviction;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

PRs #70–#79 already cover protocol core and the current-lexicon AppView/chat/ozone clients. This PR is a new branch off `main` for the remaining *library* leftovers versus public lexicons.

## What landed

- **chat.bsky.actor**: `getStatus`, `deleteAccount`, `exportAccountData`, declaration record builder/parser
- **chat.bsky.moderation**: `getActorMetadata`, `getConvo` / `getConvos` / `getConvoMembers`, `getMessageContext`, `updateActorAccess` (not `subscribeModEvents`)
- **app.bsky.video** multipart: `startUpload`, `uploadPart`, `finishUpload`, `abortUpload`, `getUploadStatus`, part-size / missing-part helpers
- **app.bsky.unspecced**: typed `getTaggedSuggestions`, age-assurance get/init, `getTrends` / `getTrendsSkeleton`, suggestion / feed / starter-pack / onboarding skeletons
- **Bookmarks**: `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union (incomplete items fall back to not-found instead of throwing)
- **Moderation**: reason-type constants + optional `modTool` on `createReport`
- **Actor preferences**: typed adult-content / content-label / saved-feeds-v2 / interests / hidden-posts kinds (`original` JSON kept)
- **Records**: `chat.bsky.actor.declaration` builder
- README/examples brought in line with #78/#79 and this slice
- Stronger XRPC JTI-cache eviction test

`dune build` and `dune runtest` pass locally. Action majors are unchanged (`actions/checkout@v4`, `ocaml/setup-ocaml@v3`, `actions/cache@v4`, `actions/upload-artifact@v4`).

## Remaining leftovers (explicit)

- Hosted OAuth metadata, browser login, PDS, Tap, transcoder, Jetstream archive operator token (product work; skipped)
- Permissioned data / spaces / LtHash (no stable public spec)
- `app.bsky.unspecced.getPostThreadV2` / `getPostThreadOtherV2` and the many discover/explore/seeMore suggestion variants
- `chat.bsky.moderation.subscribeModEvents`
- `app.bsky.draft` / `app.bsky.contact` / `app.bsky.ageassurance`
- Actor preference kinds beyond the five typed above
- `Http_client` H2 stub and unused `Request`/`Response` types

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a28db948-3538-401f-8cd2-5041ab0dad72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a28db948-3538-401f-8cd2-5041ab0dad72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

