### PR TITLE
Add thread v2, draft/contact/ageassurance, and remaining preference kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Area | Module | Notes |
 | --- | --- | --- |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
-| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences |
+| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds) |
 | AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts), generators, `searchPosts`, quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
-| Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, age-assurance state, suggestion / feed / starter-pack skeletons, config |
+| Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, unspecced age-assurance state, suggestion / feed / starter-pack / onboarding / discover / explore / seeMore skeletons, `getPostThreadV2` / `getPostThreadOtherV2`, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `chat.bsky.group` add/remove/edit, `chat.bsky.notification.getPreferences` / `putPreferences`, `chat.bsky.actor.getStatus` / declaration / export / delete, `chat.bsky.moderation.*` actor metadata + convo/message-context views (not `subscribeModEvents`); `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `chat.bsky.group` add/remove/edit, `chat.bsky.notification.getPreferences` / `putPreferences`, `chat.bsky.actor.getStatus` / declaration / export / delete, `chat.bsky.moderation.*` actor metadata + convo/message-context views + `subscribeModEvents` frame decode (private operator firehose); `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions (repoRef / strongRef / messageRef / convoRef), subjects/repos/records, account timeline, reporter stats, scheduled actions + `getConfig`; requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile |
@@ -62,6 +62,9 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit; service-auth JWT mint/verify (ES256/ES256K, `kid`/`jti`/`iat`/`lxm`, `did#service` aud, replay cache) |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
+| Drafts | `Draft` | `app.bsky.draft` create/get/update/delete + typed draft / embed / threadgate / postgate builders |
+| Contacts | `Contact` | `app.bsky.contact` phone verify, import, matches, dismiss, sync status, remove data |
+| Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union |
 | Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video, **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
@@ -82,10 +85,6 @@ Service-auth JWT mint/verify, TAP-like `Repo_sync`, Sync 1.1 pre-order CAR encod
 
 Still thin vs current lexicons (library leftovers, not product work):
 
-- `app.bsky.unspecced.getPostThreadV2` / `getPostThreadOtherV2` and the many onboarding/discover/explore/seeMore suggestion variants
-- `chat.bsky.moderation.subscribeModEvents` (operator firehose)
-- `app.bsky.draft` / `app.bsky.contact` / `app.bsky.ageassurance` namespaces
-- Actor preference kinds beyond adult-content / content-label / saved-feeds-v2 / interests / hidden-posts (`original` JSON is kept)
 - `Http_client` H2 stub and unused `Request`/`Response` types
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -256,9 +256,20 @@ let () =
   in
   assert (List.length thread_v2.thread = 1);
   let draft_body =
-    Draft.draft_json ~posts:[ { text = "draft"; labels = None; embed_images = [];
-        embed_gallery = None; embed_videos = []; embed_externals = [];
-        embed_records = [] } ] ()
+    Draft.draft_json
+      ~posts:
+        [
+          {
+            text = "draft";
+            labels = None;
+            embed_images = [];
+            embed_gallery = None;
+            embed_videos = [];
+            embed_externals = [];
+            embed_records = [];
+          };
+        ]
+      ()
   in
   assert (
     match Yojson.Safe.Util.member "posts" draft_body with
@@ -288,8 +299,7 @@ let () =
    with
   | { preferences = [ { kind = `Muted_words _; _ } ]; _ } -> ()
   | _ -> assert false);
-  assert (
-    String.length (Chat.subscribe_mod_events_url ()) > 20);
+  assert (String.length (Chat.subscribe_mod_events_url ()) > 20);
   (match
      Ozone.parse_subject
        (`Assoc

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -17,6 +17,10 @@ open Atproto.Oauth
 open Atproto.Xrpc
 open Atproto.Jetstream
 open Atproto.Unspecced
+open Atproto.Draft
+open Atproto.Contact
+open Atproto.Ageassurance
+open Atproto.Actor
 open Atproto.Oauth_scope
 open Atproto.Repo_sync
 open Atproto.Cid
@@ -224,6 +228,68 @@ let () =
         ])
   in
   assert (List.length tagged.suggestions = 1);
+  let thread_v2 =
+    Unspecced.parse_thread_v2
+      (`Assoc
+        [
+          ("hasOtherReplies", `Bool false);
+          ( "thread",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+                    );
+                    ("depth", `Int 0);
+                    ( "value",
+                      `Assoc
+                        [
+                          ( "$type",
+                            `String "app.bsky.unspecced.defs#threadItemNotFound"
+                          );
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  assert (List.length thread_v2.thread = 1);
+  let draft_body =
+    Draft.draft_json ~posts:[ { text = "draft"; labels = None; embed_images = [];
+        embed_gallery = None; embed_videos = []; embed_externals = [];
+        embed_records = [] } ] ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "posts" draft_body with
+    | `List xs -> List.length xs = 1
+    | _ -> false);
+  let aa =
+    Ageassurance.parse_state
+      (`Assoc [ ("status", `String "unknown"); ("access", `String "unknown") ])
+  in
+  assert (aa.status = "unknown");
+  let contact_status = Contact.parse_sync_status_opt (`Assoc []) in
+  assert (contact_status.sync_status = None);
+  (match
+     Actor.parse_preferences
+       (`Assoc
+         [
+           ( "preferences",
+             `List
+               [
+                 `Assoc
+                   [
+                     ("$type", `String "app.bsky.actor.defs#mutedWordsPref");
+                     ("items", `List []);
+                   ];
+               ] );
+         ])
+   with
+  | { preferences = [ { kind = `Muted_words _; _ } ]; _ } -> ()
+  | _ -> assert false);
+  assert (
+    String.length (Chat.subscribe_mod_events_url ()) > 20);
   (match
      Ozone.parse_subject
        (`Assoc

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -474,9 +474,7 @@ module Actor = struct
 
   let parse_threadgate_rule json : threadgate_rule =
     let ty =
-      match Yojson.Safe.Util.member "$type" json with
-      | `String s -> s
-      | _ -> ""
+      match Yojson.Safe.Util.member "$type" json with `String s -> s | _ -> ""
     in
     if ends_with "mentionRule" ty then `Mention
     else if ends_with "followerRule" ty then `Follower
@@ -487,9 +485,7 @@ module Actor = struct
 
   let parse_postgate_rule json : postgate_rule =
     let ty =
-      match Yojson.Safe.Util.member "$type" json with
-      | `String s -> s
-      | _ -> ""
+      match Yojson.Safe.Util.member "$type" json with `String s -> s | _ -> ""
     in
     if ends_with "disableRule" ty then `Disable else `Unknown json
 

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -336,15 +336,98 @@ module Actor = struct
   }
 
   type saved_feeds_v2_pref = { items : saved_feed list }
+
+  type saved_feeds_pref = {
+    pinned : string list;
+    saved : string list;
+    timeline_index : int option;
+  }
+
+  type personal_details_pref = { birth_date : string option }
+
+  type declared_age_pref = {
+    is_over_age_13 : bool option;
+    is_over_age_16 : bool option;
+    is_over_age_18 : bool option;
+  }
+
+  type feed_view_pref = {
+    feed : string;
+    hide_replies : bool option;
+    hide_replies_by_unfollowed : bool option;
+    hide_replies_by_like_count : int option;
+    hide_reposts : bool option;
+    hide_quote_posts : bool option;
+  }
+
+  type thread_view_pref = { sort : string option }
   type interests_pref = { tags : string list }
+
+  type muted_word = {
+    id : string option;
+    value : string;
+    targets : string list;
+    actor_target : string option;
+    expires_at : string option;
+  }
+
+  type muted_words_pref = { items : muted_word list }
   type hidden_posts_pref = { items : string list }
+  type labeler_pref_item = { did : string }
+  type labelers_pref = { labelers : labeler_pref_item list }
+
+  type nux = {
+    id : string;
+    completed : bool;
+    data : string option;
+    expires_at : string option;
+  }
+
+  type bsky_app_state_pref = {
+    active_progress_guide : string option;
+    is_beta_user : bool option;
+    queued_nudges : string list;
+    nuxs : nux list;
+  }
+
+  type threadgate_rule =
+    [ `Mention
+    | `Follower
+    | `Following
+    | `List of string
+    | `Unknown of Yojson.Safe.t ]
+
+  type postgate_rule = [ `Disable | `Unknown of Yojson.Safe.t ]
+
+  type post_interaction_pref = {
+    threadgate_allow_rules : threadgate_rule list option;
+    postgate_embedding_rules : postgate_rule list option;
+  }
+
+  type verification_pref = { hide_badges : bool }
+
+  type live_event_pref = {
+    hidden_feed_ids : string list;
+    hide_all_feeds : bool;
+  }
 
   type preference_kind =
     [ `Adult_content of adult_content_pref
     | `Content_label of content_label_pref
+    | `Saved_feeds of saved_feeds_pref
     | `Saved_feeds_v2 of saved_feeds_v2_pref
+    | `Personal_details of personal_details_pref
+    | `Declared_age of declared_age_pref
+    | `Feed_view of feed_view_pref
+    | `Thread_view of thread_view_pref
     | `Interests of interests_pref
+    | `Muted_words of muted_words_pref
     | `Hidden_posts of hidden_posts_pref
+    | `Bsky_app_state of bsky_app_state_pref
+    | `Labelers of labelers_pref
+    | `Post_interaction of post_interaction_pref
+    | `Verification of verification_pref
+    | `Live_event of live_event_pref
     | `Other ]
 
   type preference = {
@@ -367,6 +450,49 @@ module Actor = struct
       pinned = Client.Client.bool_member json "pinned";
     }
 
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.Client.list_member json field)
+
+  let parse_muted_word json : muted_word =
+    {
+      id = Client.Client.string_opt json "id";
+      value = Client.Client.string_member json "value";
+      targets = string_list json "targets";
+      actor_target = Client.Client.string_opt json "actorTarget";
+      expires_at = Client.Client.string_opt json "expiresAt";
+    }
+
+  let parse_nux json : nux =
+    {
+      id = Client.Client.string_member json "id";
+      completed = Client.Client.bool_member json "completed";
+      data = Client.Client.string_opt json "data";
+      expires_at = Client.Client.string_opt json "expiresAt";
+    }
+
+  let parse_threadgate_rule json : threadgate_rule =
+    let ty =
+      match Yojson.Safe.Util.member "$type" json with
+      | `String s -> s
+      | _ -> ""
+    in
+    if ends_with "mentionRule" ty then `Mention
+    else if ends_with "followerRule" ty then `Follower
+    else if ends_with "followingRule" ty then `Following
+    else if ends_with "listRule" ty then
+      `List (Client.Client.string_member json "list")
+    else `Unknown json
+
+  let parse_postgate_rule json : postgate_rule =
+    let ty =
+      match Yojson.Safe.Util.member "$type" json with
+      | `String s -> s
+      | _ -> ""
+    in
+    if ends_with "disableRule" ty then `Disable else `Unknown json
+
   let parse_preference_kind ~type_ json : preference_kind =
     if ends_with "adultContentPref" type_ then
       `Adult_content { enabled = Client.Client.bool_member json "enabled" }
@@ -383,21 +509,87 @@ module Actor = struct
           items =
             List.map parse_saved_feed (Client.Client.list_member json "items");
         }
-    else if ends_with "interestsPref" type_ then
-      `Interests
+    else if ends_with "savedFeedsPref" type_ then
+      `Saved_feeds
         {
-          tags =
-            List.filter_map
-              (function `String s -> Some s | _ -> None)
-              (Client.Client.list_member json "tags");
+          pinned = string_list json "pinned";
+          saved = string_list json "saved";
+          timeline_index = Client.Client.int_opt json "timelineIndex";
         }
-    else if ends_with "hiddenPostsPref" type_ then
-      `Hidden_posts
+    else if ends_with "personalDetailsPref" type_ then
+      `Personal_details
+        { birth_date = Client.Client.string_opt json "birthDate" }
+    else if ends_with "declaredAgePref" type_ then
+      `Declared_age
+        {
+          is_over_age_13 = Client.Client.bool_opt json "isOverAge13";
+          is_over_age_16 = Client.Client.bool_opt json "isOverAge16";
+          is_over_age_18 = Client.Client.bool_opt json "isOverAge18";
+        }
+    else if ends_with "feedViewPref" type_ then
+      `Feed_view
+        {
+          feed = Client.Client.string_member json "feed";
+          hide_replies = Client.Client.bool_opt json "hideReplies";
+          hide_replies_by_unfollowed =
+            Client.Client.bool_opt json "hideRepliesByUnfollowed";
+          hide_replies_by_like_count =
+            Client.Client.int_opt json "hideRepliesByLikeCount";
+          hide_reposts = Client.Client.bool_opt json "hideReposts";
+          hide_quote_posts = Client.Client.bool_opt json "hideQuotePosts";
+        }
+    else if ends_with "threadViewPref" type_ then
+      `Thread_view { sort = Client.Client.string_opt json "sort" }
+    else if ends_with "interestsPref" type_ then
+      `Interests { tags = string_list json "tags" }
+    else if ends_with "mutedWordsPref" type_ then
+      `Muted_words
         {
           items =
-            List.filter_map
-              (function `String s -> Some s | _ -> None)
-              (Client.Client.list_member json "items");
+            List.map parse_muted_word (Client.Client.list_member json "items");
+        }
+    else if ends_with "hiddenPostsPref" type_ then
+      `Hidden_posts { items = string_list json "items" }
+    else if ends_with "bskyAppStatePref" type_ then
+      `Bsky_app_state
+        {
+          active_progress_guide =
+            (match Yojson.Safe.Util.member "activeProgressGuide" json with
+            | `Assoc _ as g -> Client.Client.string_opt g "guide"
+            | `String s -> Some s
+            | _ -> None);
+          is_beta_user = Client.Client.bool_opt json "isBetaUser";
+          queued_nudges = string_list json "queuedNudges";
+          nuxs = List.map parse_nux (Client.Client.list_member json "nuxs");
+        }
+    else if ends_with "labelersPref" type_ then
+      `Labelers
+        {
+          labelers =
+            List.map
+              (fun item -> { did = Client.Client.string_member item "did" })
+              (Client.Client.list_member json "labelers");
+        }
+    else if ends_with "postInteractionSettingsPref" type_ then
+      `Post_interaction
+        {
+          threadgate_allow_rules =
+            (match Yojson.Safe.Util.member "threadgateAllowRules" json with
+            | `List xs -> Some (List.map parse_threadgate_rule xs)
+            | _ -> None);
+          postgate_embedding_rules =
+            (match Yojson.Safe.Util.member "postgateEmbeddingRules" json with
+            | `List xs -> Some (List.map parse_postgate_rule xs)
+            | _ -> None);
+        }
+    else if ends_with "verificationPrefs" type_ then
+      `Verification
+        { hide_badges = Client.Client.bool_member json "hideBadges" }
+    else if ends_with "liveEventPreferences" type_ then
+      `Live_event
+        {
+          hidden_feed_ids = string_list json "hiddenFeedIds";
+          hide_all_feeds = Client.Client.bool_member json "hideAllFeeds";
         }
     else `Other
 

--- a/src/bsky/ageassurance.ml
+++ b/src/bsky/ageassurance.ml
@@ -106,7 +106,9 @@ module Ageassurance = struct
     }
 
   let parse_config json : config =
-    { regions = List.map parse_config_region (Client.list_member json "regions") }
+    {
+      regions = List.map parse_config_region (Client.list_member json "regions");
+    }
 
   let parse_event json : event =
     {
@@ -142,7 +144,8 @@ module Ageassurance = struct
   let get_state (s : Session.session) ~country_code ?region_code () :
       state_bundle =
     Client.get_json ~session:s "app.bsky.ageassurance.getState"
-      ([ ("countryCode", country_code) ] @ Client.opt_pair "regionCode" region_code)
+      ([ ("countryCode", country_code) ]
+      @ Client.opt_pair "regionCode" region_code)
     |> parse_state_bundle
 
   let begin_assurance (s : Session.session) ~email ~language ~country_code

--- a/src/bsky/ageassurance.ml
+++ b/src/bsky/ageassurance.ml
@@ -1,0 +1,154 @@
+open Session
+open Client
+
+(** app.bsky.ageassurance — dedicated Age Assurance namespace (current lexicons). *)
+module Ageassurance = struct
+  type state = {
+    status : string;
+    access : string;
+    last_initiated_at : string option;
+  }
+
+  type state_metadata = { account_created_at : string option }
+  type state_bundle = { state : state; metadata : state_metadata }
+
+  type region_rule =
+    [ `Default of string
+    | `Declared_over of int * string
+    | `Declared_under of int * string
+    | `Assured_over of int * string
+    | `Assured_under of int * string
+    | `Account_newer of string * string
+    | `Account_older of string * string
+    | `Unknown of Yojson.Safe.t ]
+
+  type config_region = {
+    platforms : string list;
+    country_code : string;
+    region_code : string option;
+    min_access_age : int;
+    additional_verification_methods : string list;
+    rules : region_rule list;
+  }
+
+  type config = { regions : config_region list }
+
+  type event = {
+    created_at : string;
+    attempt_id : string;
+    status : string;
+    access : string;
+    country_code : string;
+    region_code : string option;
+    email : string option;
+    original : Yojson.Safe.t;
+  }
+
+  let ends_with suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.list_member json field)
+
+  let parse_state json : state =
+    {
+      status = Client.string_member json "status";
+      access = Client.string_member json "access";
+      last_initiated_at = Client.string_opt json "lastInitiatedAt";
+    }
+
+  let parse_state_metadata json : state_metadata =
+    { account_created_at = Client.string_opt json "accountCreatedAt" }
+
+  let parse_state_bundle json : state_bundle =
+    let state =
+      match Yojson.Safe.Util.member "state" json with
+      | `Assoc _ as s -> parse_state s
+      | _ -> parse_state json
+    in
+    let metadata =
+      match Yojson.Safe.Util.member "metadata" json with
+      | `Assoc _ as m -> parse_state_metadata m
+      | _ -> { account_created_at = None }
+    in
+    { state; metadata }
+
+  let parse_region_rule json : region_rule =
+    let ty = Client.string_opt json "$type" |> Option.value ~default:"" in
+    let access = Client.string_member json "access" in
+    if ends_with "configRegionRuleDefault" ty then `Default access
+    else if ends_with "configRegionRuleIfDeclaredOverAge" ty then
+      `Declared_over (Client.int_member json "age", access)
+    else if ends_with "configRegionRuleIfDeclaredUnderAge" ty then
+      `Declared_under (Client.int_member json "age", access)
+    else if ends_with "configRegionRuleIfAssuredOverAge" ty then
+      `Assured_over (Client.int_member json "age", access)
+    else if ends_with "configRegionRuleIfAssuredUnderAge" ty then
+      `Assured_under (Client.int_member json "age", access)
+    else if ends_with "configRegionRuleIfAccountNewerThan" ty then
+      `Account_newer (Client.string_member json "date", access)
+    else if ends_with "configRegionRuleIfAccountOlderThan" ty then
+      `Account_older (Client.string_member json "date", access)
+    else `Unknown json
+
+  let parse_config_region json : config_region =
+    {
+      platforms = string_list json "platforms";
+      country_code = Client.string_member json "countryCode";
+      region_code = Client.string_opt json "regionCode";
+      min_access_age = Client.int_member json "minAccessAge";
+      additional_verification_methods =
+        string_list json "additionalVerificationMethods";
+      rules = List.map parse_region_rule (Client.list_member json "rules");
+    }
+
+  let parse_config json : config =
+    { regions = List.map parse_config_region (Client.list_member json "regions") }
+
+  let parse_event json : event =
+    {
+      created_at = Client.string_member json "createdAt";
+      attempt_id = Client.string_member json "attemptId";
+      status = Client.string_member json "status";
+      access = Client.string_member json "access";
+      country_code = Client.string_member json "countryCode";
+      region_code = Client.string_opt json "regionCode";
+      email = Client.string_opt json "email";
+      original = json;
+    }
+
+  let begin_body ~email ~language ~country_code ?region_code () : Yojson.Safe.t
+      =
+    let fields =
+      [
+        ("email", `String email);
+        ("language", `String language);
+        ("countryCode", `String country_code);
+      ]
+      @
+      match region_code with
+      | Some r -> [ ("regionCode", `String r) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let get_config ?session ?host () : config =
+    Client.get_json ?session ?host "app.bsky.ageassurance.getConfig" []
+    |> parse_config
+
+  let get_state (s : Session.session) ~country_code ?region_code () :
+      state_bundle =
+    Client.get_json ~session:s "app.bsky.ageassurance.getState"
+      ([ ("countryCode", country_code) ] @ Client.opt_pair "regionCode" region_code)
+    |> parse_state_bundle
+
+  let begin_assurance (s : Session.session) ~email ~language ~country_code
+      ?region_code () : state =
+    Client.post_json ~session:s "app.bsky.ageassurance.begin"
+      (Yojson.Safe.to_string
+         (begin_body ~email ~language ~country_code ?region_code ()))
+    |> parse_state
+end

--- a/src/bsky/contact.ml
+++ b/src/bsky/contact.ml
@@ -1,0 +1,109 @@
+open Session
+open Client
+open Actor
+
+(** app.bsky.contact — phone-verified contact import / match (current lexicons). *)
+module Contact = struct
+  type match_and_index = {
+    match_ : Actor.short_profile;
+    contact_index : int;
+  }
+
+  type import_result = { matches : match_and_index list }
+  type sync_status = { synced_at : string; matches_count : int }
+  type sync_status_opt = { sync_status : sync_status option }
+  type matches_page = { cursor : string option; matches : Actor.short_profile list }
+
+  let parse_match_and_index json : match_and_index =
+    let match_ =
+      match Yojson.Safe.Util.member "match" json with
+      | `Assoc _ as p -> Actor.parse_short_profile p
+      | _ -> Actor.parse_short_profile json
+    in
+    { match_; contact_index = Client.int_member json "contactIndex" }
+
+  let parse_import_result json : import_result =
+    {
+      matches =
+        List.map parse_match_and_index
+          (Client.list_member json "matchesAndContactIndexes");
+    }
+
+  let parse_sync_status json : sync_status =
+    {
+      synced_at = Client.string_member json "syncedAt";
+      matches_count = Client.int_member json "matchesCount";
+    }
+
+  let parse_sync_status_opt json : sync_status_opt =
+    {
+      sync_status =
+        (match Yojson.Safe.Util.member "syncStatus" json with
+        | `Assoc _ as s -> Some (parse_sync_status s)
+        | _ -> None);
+    }
+
+  let parse_matches_page json : matches_page =
+    {
+      cursor = Client.string_opt json "cursor";
+      matches =
+        List.map Actor.parse_short_profile (Client.list_member json "matches");
+    }
+
+  let import_contacts_body ~token ~contacts : Yojson.Safe.t =
+    `Assoc
+      [
+        ("token", `String token);
+        ("contacts", `List (List.map (fun p -> `String p) contacts));
+      ]
+
+  let dismiss_match_body ~subject : Yojson.Safe.t =
+    `Assoc [ ("subject", `String subject) ]
+
+  let start_phone_verification_body ~phone : Yojson.Safe.t =
+    `Assoc [ ("phone", `String phone) ]
+
+  let verify_phone_body ~phone ~code : Yojson.Safe.t =
+    `Assoc [ ("phone", `String phone); ("code", `String code) ]
+
+  let send_notification_body ~from ~to_ : Yojson.Safe.t =
+    `Assoc [ ("from", `String from); ("to", `String to_) ]
+
+  let get_matches (s : Session.session) ?limit ?cursor () : matches_page =
+    Client.get_json ~session:s "app.bsky.contact.getMatches"
+      (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
+    |> parse_matches_page
+
+  let get_sync_status (s : Session.session) : sync_status_opt =
+    Client.get_json ~session:s "app.bsky.contact.getSyncStatus" []
+    |> parse_sync_status_opt
+
+  let import_contacts (s : Session.session) ~token ~contacts () : import_result
+      =
+    Client.post_json ~session:s "app.bsky.contact.importContacts"
+      (Yojson.Safe.to_string (import_contacts_body ~token ~contacts))
+    |> parse_import_result
+
+  let dismiss_match (s : Session.session) ~subject () : unit =
+    ignore
+      (Client.post_json ~session:s "app.bsky.contact.dismissMatch"
+         (Yojson.Safe.to_string (dismiss_match_body ~subject)))
+
+  let remove_data (s : Session.session) : unit =
+    ignore (Client.post_json ~session:s "app.bsky.contact.removeData" "{}")
+
+  let start_phone_verification (s : Session.session) ~phone () : unit =
+    ignore
+      (Client.post_json ~session:s "app.bsky.contact.startPhoneVerification"
+         (Yojson.Safe.to_string (start_phone_verification_body ~phone)))
+
+  let verify_phone (s : Session.session) ~phone ~code () : string =
+    Client.post_json ~session:s "app.bsky.contact.verifyPhone"
+      (Yojson.Safe.to_string (verify_phone_body ~phone ~code))
+    |> fun json -> Client.string_member json "token"
+
+  let send_notification (s : Session.session) ~from ~to_ () : unit =
+    ignore
+      (Client.post_json ~session:s "app.bsky.contact.sendNotification"
+         (Yojson.Safe.to_string (send_notification_body ~from ~to_)))
+end

--- a/src/bsky/contact.ml
+++ b/src/bsky/contact.ml
@@ -4,15 +4,15 @@ open Actor
 
 (** app.bsky.contact — phone-verified contact import / match (current lexicons). *)
 module Contact = struct
-  type match_and_index = {
-    match_ : Actor.short_profile;
-    contact_index : int;
-  }
-
+  type match_and_index = { match_ : Actor.short_profile; contact_index : int }
   type import_result = { matches : match_and_index list }
   type sync_status = { synced_at : string; matches_count : int }
   type sync_status_opt = { sync_status : sync_status option }
-  type matches_page = { cursor : string option; matches : Actor.short_profile list }
+
+  type matches_page = {
+    cursor : string option;
+    matches : Actor.short_profile list;
+  }
 
   let parse_match_and_index json : match_and_index =
     let match_ =

--- a/src/bsky/draft.ml
+++ b/src/bsky/draft.ml
@@ -18,7 +18,11 @@ module Draft = struct
   type embed_gallery = { items : embed_image list }
 
   type threadgate_rule =
-    [ `Mention | `Follower | `Following | `List of string | `Unknown of Yojson.Safe.t ]
+    [ `Mention
+    | `Follower
+    | `Following
+    | `List of string
+    | `Unknown of Yojson.Safe.t ]
 
   type postgate_rule = [ `Disable | `Unknown of Yojson.Safe.t ]
 
@@ -110,7 +114,8 @@ module Draft = struct
     let items =
       match Yojson.Safe.Util.member "items" json with
       | `List xs -> List.map parse_embed_image xs
-      | `Assoc _ as g -> List.map parse_embed_image (Client.list_member g "items")
+      | `Assoc _ as g ->
+          List.map parse_embed_image (Client.list_member g "items")
       | _ -> List.map parse_embed_image (Client.list_member json "items")
     in
     { items }
@@ -131,7 +136,8 @@ module Draft = struct
   let parse_draft_post json : draft_post =
     {
       text = Client.string_member json "text";
-      labels = Label.Label.parse_self_labels (Yojson.Safe.Util.member "labels" json);
+      labels =
+        Label.Label.parse_self_labels (Yojson.Safe.Util.member "labels" json);
       embed_images =
         List.map parse_embed_image (Client.list_member json "embedImages");
       embed_gallery =
@@ -156,7 +162,8 @@ module Draft = struct
         List.map parse_postgate_rule
           (Client.list_member json "postgateEmbeddingRules");
       threadgate_allow =
-        List.map parse_threadgate_rule (Client.list_member json "threadgateAllow");
+        List.map parse_threadgate_rule
+          (Client.list_member json "threadgateAllow");
       original = json;
     }
 
@@ -233,8 +240,8 @@ module Draft = struct
         | Some g ->
             [
               ( "embedGallery",
-                `Assoc
-                  [ ("items", `List (List.map embed_image_json g.items)) ] );
+                `Assoc [ ("items", `List (List.map embed_image_json g.items)) ]
+              );
             ]
         | None -> [])
       @ (match p.embed_videos with
@@ -290,14 +297,12 @@ module Draft = struct
         | [] -> []
         | xs ->
             [
-              ( "postgateEmbeddingRules",
-                `List (List.map postgate_rule_json xs) );
+              ("postgateEmbeddingRules", `List (List.map postgate_rule_json xs));
             ])
       @
       match threadgate_allow with
       | [] -> []
-      | xs ->
-          [ ("threadgateAllow", `List (List.map threadgate_rule_json xs)) ]
+      | xs -> [ ("threadgateAllow", `List (List.map threadgate_rule_json xs)) ]
     in
     `Assoc fields
 

--- a/src/bsky/draft.ml
+++ b/src/bsky/draft.ml
@@ -1,0 +1,330 @@
+open Session
+open Client
+
+(** app.bsky.draft — private stash drafts (current lexicons). *)
+module Draft = struct
+  type local_ref = { path : string }
+  type caption = { lang : string; content : string }
+  type embed_image = { local_ref : local_ref; alt : string option }
+
+  type embed_video = {
+    local_ref : local_ref;
+    alt : string option;
+    captions : caption list;
+  }
+
+  type embed_external = { uri : string }
+  type embed_record = { uri : string; cid : string }
+  type embed_gallery = { items : embed_image list }
+
+  type threadgate_rule =
+    [ `Mention | `Follower | `Following | `List of string | `Unknown of Yojson.Safe.t ]
+
+  type postgate_rule = [ `Disable | `Unknown of Yojson.Safe.t ]
+
+  type draft_post = {
+    text : string;
+    labels : string list option;
+    embed_images : embed_image list;
+    embed_gallery : embed_gallery option;
+    embed_videos : embed_video list;
+    embed_externals : embed_external list;
+    embed_records : embed_record list;
+  }
+
+  type draft = {
+    device_id : string option;
+    device_name : string option;
+    posts : draft_post list;
+    langs : string list;
+    postgate_embedding_rules : postgate_rule list;
+    threadgate_allow : threadgate_rule list;
+    original : Yojson.Safe.t;
+  }
+
+  type draft_view = {
+    id : string;
+    draft : draft;
+    created_at : string;
+    updated_at : string;
+  }
+
+  type drafts_page = { cursor : string option; drafts : draft_view list }
+  type create_result = { id : string }
+
+  let ends_with suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.list_member json field)
+
+  let parse_local_ref json : local_ref =
+    match json with
+    | `Assoc _ -> { path = Client.string_member json "path" }
+    | `String s -> { path = s }
+    | _ -> { path = "" }
+
+  let parse_caption json : caption =
+    {
+      lang = Client.string_member json "lang";
+      content = Client.string_member json "content";
+    }
+
+  let parse_embed_image json : embed_image =
+    {
+      local_ref =
+        (match Yojson.Safe.Util.member "localRef" json with
+        | `Null -> { path = "" }
+        | v -> parse_local_ref v);
+      alt = Client.string_opt json "alt";
+    }
+
+  let parse_embed_video json : embed_video =
+    {
+      local_ref =
+        (match Yojson.Safe.Util.member "localRef" json with
+        | `Null -> { path = "" }
+        | v -> parse_local_ref v);
+      alt = Client.string_opt json "alt";
+      captions = List.map parse_caption (Client.list_member json "captions");
+    }
+
+  let parse_embed_external json : embed_external =
+    { uri = Client.string_member json "uri" }
+
+  let parse_embed_record json : embed_record =
+    let record =
+      match Yojson.Safe.Util.member "record" json with
+      | `Assoc _ as r -> r
+      | _ -> json
+    in
+    {
+      uri = Client.string_member record "uri";
+      cid = Client.string_member record "cid";
+    }
+
+  let parse_embed_gallery json : embed_gallery =
+    let items =
+      match Yojson.Safe.Util.member "items" json with
+      | `List xs -> List.map parse_embed_image xs
+      | `Assoc _ as g -> List.map parse_embed_image (Client.list_member g "items")
+      | _ -> List.map parse_embed_image (Client.list_member json "items")
+    in
+    { items }
+
+  let parse_threadgate_rule json : threadgate_rule =
+    let ty = Client.string_opt json "$type" |> Option.value ~default:"" in
+    if ends_with "mentionRule" ty then `Mention
+    else if ends_with "followerRule" ty then `Follower
+    else if ends_with "followingRule" ty then `Following
+    else if ends_with "listRule" ty then
+      `List (Client.string_member json "list")
+    else `Unknown json
+
+  let parse_postgate_rule json : postgate_rule =
+    let ty = Client.string_opt json "$type" |> Option.value ~default:"" in
+    if ends_with "disableRule" ty then `Disable else `Unknown json
+
+  let parse_draft_post json : draft_post =
+    {
+      text = Client.string_member json "text";
+      labels = Label.Label.parse_self_labels (Yojson.Safe.Util.member "labels" json);
+      embed_images =
+        List.map parse_embed_image (Client.list_member json "embedImages");
+      embed_gallery =
+        (match Yojson.Safe.Util.member "embedGallery" json with
+        | `Assoc _ as g -> Some (parse_embed_gallery g)
+        | _ -> None);
+      embed_videos =
+        List.map parse_embed_video (Client.list_member json "embedVideos");
+      embed_externals =
+        List.map parse_embed_external (Client.list_member json "embedExternals");
+      embed_records =
+        List.map parse_embed_record (Client.list_member json "embedRecords");
+    }
+
+  let parse_draft json : draft =
+    {
+      device_id = Client.string_opt json "deviceId";
+      device_name = Client.string_opt json "deviceName";
+      posts = List.map parse_draft_post (Client.list_member json "posts");
+      langs = string_list json "langs";
+      postgate_embedding_rules =
+        List.map parse_postgate_rule
+          (Client.list_member json "postgateEmbeddingRules");
+      threadgate_allow =
+        List.map parse_threadgate_rule (Client.list_member json "threadgateAllow");
+      original = json;
+    }
+
+  let parse_draft_view json : draft_view =
+    {
+      id = Client.string_member json "id";
+      draft =
+        (match Yojson.Safe.Util.member "draft" json with
+        | `Assoc _ as d -> parse_draft d
+        | _ -> parse_draft json);
+      created_at = Client.string_member json "createdAt";
+      updated_at = Client.string_member json "updatedAt";
+    }
+
+  let parse_drafts_page json : drafts_page =
+    {
+      cursor = Client.string_opt json "cursor";
+      drafts = List.map parse_draft_view (Client.list_member json "drafts");
+    }
+
+  let local_ref_json (r : local_ref) : Yojson.Safe.t =
+    `Assoc [ ("path", `String r.path) ]
+
+  let caption_json (c : caption) : Yojson.Safe.t =
+    `Assoc [ ("lang", `String c.lang); ("content", `String c.content) ]
+
+  let embed_image_json (i : embed_image) : Yojson.Safe.t =
+    let fields =
+      ("localRef", local_ref_json i.local_ref)
+      :: (match i.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+    in
+    `Assoc fields
+
+  let embed_video_json (v : embed_video) : Yojson.Safe.t =
+    let fields =
+      [ ("localRef", local_ref_json v.local_ref) ]
+      @ (match v.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+      @
+      match v.captions with
+      | [] -> []
+      | cs -> [ ("captions", `List (List.map caption_json cs)) ]
+    in
+    `Assoc fields
+
+  let threadgate_rule_json (r : threadgate_rule) : Yojson.Safe.t =
+    match r with
+    | `Mention ->
+        `Assoc [ ("$type", `String "app.bsky.feed.threadgate#mentionRule") ]
+    | `Follower ->
+        `Assoc [ ("$type", `String "app.bsky.feed.threadgate#followerRule") ]
+    | `Following ->
+        `Assoc [ ("$type", `String "app.bsky.feed.threadgate#followingRule") ]
+    | `List uri ->
+        `Assoc
+          [
+            ("$type", `String "app.bsky.feed.threadgate#listRule");
+            ("list", `String uri);
+          ]
+    | `Unknown j -> j
+
+  let postgate_rule_json (r : postgate_rule) : Yojson.Safe.t =
+    match r with
+    | `Disable ->
+        `Assoc [ ("$type", `String "app.bsky.feed.postgate#disableRule") ]
+    | `Unknown j -> j
+
+  let draft_post_json (p : draft_post) : Yojson.Safe.t =
+    let fields =
+      [ ("text", `String p.text) ]
+      @ (match p.embed_images with
+        | [] -> []
+        | xs -> [ ("embedImages", `List (List.map embed_image_json xs)) ])
+      @ (match p.embed_gallery with
+        | Some g ->
+            [
+              ( "embedGallery",
+                `Assoc
+                  [ ("items", `List (List.map embed_image_json g.items)) ] );
+            ]
+        | None -> [])
+      @ (match p.embed_videos with
+        | [] -> []
+        | xs -> [ ("embedVideos", `List (List.map embed_video_json xs)) ])
+      @ (match p.embed_externals with
+        | [] -> []
+        | xs ->
+            [
+              ( "embedExternals",
+                `List
+                  (List.map
+                     (fun (e : embed_external) ->
+                       `Assoc [ ("uri", `String e.uri) ])
+                     xs) );
+            ])
+      @
+      match p.embed_records with
+      | [] -> []
+      | xs ->
+          [
+            ( "embedRecords",
+              `List
+                (List.map
+                   (fun (r : embed_record) ->
+                     `Assoc
+                       [
+                         ( "record",
+                           `Assoc
+                             [ ("uri", `String r.uri); ("cid", `String r.cid) ]
+                         );
+                       ])
+                   xs) );
+          ]
+    in
+    `Assoc fields
+
+  let draft_json ?(device_id : string option) ?(device_name : string option)
+      ?(langs = []) ?(postgate_embedding_rules = []) ?(threadgate_allow = [])
+      ~posts () : Yojson.Safe.t =
+    let fields =
+      [ ("posts", `List (List.map draft_post_json posts)) ]
+      @ (match device_id with
+        | Some id -> [ ("deviceId", `String id) ]
+        | None -> [])
+      @ (match device_name with
+        | Some n -> [ ("deviceName", `String n) ]
+        | None -> [])
+      @ (match langs with
+        | [] -> []
+        | xs -> [ ("langs", `List (List.map (fun s -> `String s) xs)) ])
+      @ (match postgate_embedding_rules with
+        | [] -> []
+        | xs ->
+            [
+              ( "postgateEmbeddingRules",
+                `List (List.map postgate_rule_json xs) );
+            ])
+      @
+      match threadgate_allow with
+      | [] -> []
+      | xs ->
+          [ ("threadgateAllow", `List (List.map threadgate_rule_json xs)) ]
+    in
+    `Assoc fields
+
+  let create_draft_body draft : Yojson.Safe.t = `Assoc [ ("draft", draft) ]
+
+  let update_draft_body ~id draft : Yojson.Safe.t =
+    `Assoc [ ("draft", `Assoc [ ("id", `String id); ("draft", draft) ]) ]
+
+  let delete_draft_body ~id : Yojson.Safe.t = `Assoc [ ("id", `String id) ]
+
+  let get_drafts (s : Session.session) ?limit ?cursor () : drafts_page =
+    Client.get_json ~session:s "app.bsky.draft.getDrafts"
+      (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
+    |> parse_drafts_page
+
+  let create_draft (s : Session.session) draft : create_result =
+    Client.post_json ~session:s "app.bsky.draft.createDraft"
+      (Yojson.Safe.to_string (create_draft_body draft))
+    |> fun json -> { id = Client.string_member json "id" }
+
+  let update_draft (s : Session.session) ~id draft : unit =
+    ignore
+      (Client.post_json ~session:s "app.bsky.draft.updateDraft"
+         (Yojson.Safe.to_string (update_draft_body ~id draft)))
+
+  let delete_draft (s : Session.session) ~id () : unit =
+    ignore
+      (Client.post_json ~session:s "app.bsky.draft.deleteDraft"
+         (Yojson.Safe.to_string (delete_draft_body ~id)))
+end

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -2,6 +2,7 @@ open Session
 open Client
 open Actor
 open Graph
+open Feed
 
 (** app.bsky.unspecced — public search skeletons, popular feeds, trends. *)
 module Unspecced = struct
@@ -258,7 +259,43 @@ module Unspecced = struct
 
   type suggested_feeds = { feeds : generator_view list }
   type uri_skeleton = { uris : string list }
-  type did_skeleton = { dids : string list; rec_id_str : string option }
+  type did_skeleton = {
+    dids : string list;
+    rec_id : string option;
+    rec_id_str : string option;
+  }
+
+  type thread_item_post = {
+    post : Feed.post;
+    more_parents : bool;
+    more_replies : int;
+    op_thread : bool;
+    op_thread_post_index : int option;
+    op_thread_post_count : int option;
+    hidden_by_threadgate : bool;
+    muted_by_viewer : bool;
+  }
+
+  type thread_item_value =
+    [ `Post of thread_item_post
+    | `No_unauthenticated
+    | `Not_found
+    | `Blocked of { author_did : string option }
+    | `Unknown of Yojson.Safe.t ]
+
+  type thread_item = {
+    uri : string;
+    depth : int;
+    value : thread_item_value;
+  }
+
+  type thread_v2 = {
+    thread : thread_item list;
+    threadgate : Yojson.Safe.t option;
+    has_other_replies : bool;
+  }
+
+  type thread_other_v2 = { thread : thread_item list }
 
   let parse_tagged_suggestion json : tagged_suggestion =
     {
@@ -360,8 +397,76 @@ module Unspecced = struct
   let parse_did_skeleton json : did_skeleton =
     {
       dids = string_list json "dids";
+      rec_id =
+        (match Yojson.Safe.Util.member "recId" json with
+        | `String s -> Some s
+        | `Int n -> Some (string_of_int n)
+        | _ -> None);
       rec_id_str = Client.string_opt json "recIdStr";
     }
+
+  let ends_with suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+
+  let parse_thread_item_post json : thread_item_post =
+    let post =
+      match Yojson.Safe.Util.member "post" json with
+      | `Assoc _ as p -> Feed.parse_post p
+      | _ -> Feed.parse_post json
+    in
+    {
+      post;
+      more_parents = Client.bool_member json "moreParents";
+      more_replies = Client.int_member json "moreReplies";
+      op_thread = Client.bool_member json "opThread";
+      op_thread_post_index = Client.int_opt json "opThreadPostIndex";
+      op_thread_post_count = Client.int_opt json "opThreadPostCount";
+      hidden_by_threadgate = Client.bool_member json "hiddenByThreadgate";
+      muted_by_viewer = Client.bool_member json "mutedByViewer";
+    }
+
+  let parse_thread_item_value json : thread_item_value =
+    let ty = Client.string_opt json "$type" |> Option.value ~default:"" in
+    if ends_with "threadItemPost" ty then `Post (parse_thread_item_post json)
+    else if ends_with "threadItemNoUnauthenticated" ty then `No_unauthenticated
+    else if ends_with "threadItemNotFound" ty then `Not_found
+    else if ends_with "threadItemBlocked" ty then
+      let author_did =
+        match Yojson.Safe.Util.member "author" json with
+        | `Assoc _ as a -> Client.string_opt a "did"
+        | _ -> None
+      in
+      `Blocked { author_did }
+    else if
+      match Yojson.Safe.Util.member "post" json with
+      | `Assoc _ -> true
+      | _ -> false
+    then `Post (parse_thread_item_post json)
+    else `Unknown json
+
+  let parse_thread_item json : thread_item =
+    {
+      uri = Client.string_member json "uri";
+      depth = Client.int_member json "depth";
+      value =
+        (match Yojson.Safe.Util.member "value" json with
+        | `Assoc _ as v -> parse_thread_item_value v
+        | _ -> parse_thread_item_value json);
+    }
+
+  let parse_thread_v2 json : thread_v2 =
+    {
+      thread = List.map parse_thread_item (Client.list_member json "thread");
+      threadgate =
+        (match Yojson.Safe.Util.member "threadgate" json with
+        | `Assoc _ as g -> Some g
+        | _ -> None);
+      has_other_replies = Client.bool_member json "hasOtherReplies";
+    }
+
+  let parse_thread_other_v2 json : thread_other_v2 =
+    { thread = List.map parse_thread_item (Client.list_member json "thread") }
 
   let get_tagged_suggestions ?session ?host () : tagged_suggestions =
     Client.get_json ?session ?host "app.bsky.unspecced.getTaggedSuggestions" []
@@ -459,4 +564,81 @@ module Unspecced = struct
       "app.bsky.unspecced.getOnboardingSuggestedStarterPacksSkeleton"
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> fun json -> parse_uri_list json "starterPacks"
+
+  let get_suggested_onboarding_users ?session ?host ?category ?limit () :
+      suggested_users =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedOnboardingUsers"
+      (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
+    |> parse_suggested_users
+
+  let get_onboarding_suggested_users_skeleton ?session ?host ?viewer ?category
+      ?limit () : did_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getOnboardingSuggestedUsersSkeleton"
+      (Client.opt_pair "viewer" viewer
+      @ Client.opt_pair "category" category
+      @ Client.opt_int "limit" limit)
+    |> parse_did_skeleton
+
+  let get_suggested_users_for_discover ?session ?host ?limit () : suggested_users
+      =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForDiscover"
+      (Client.opt_int "limit" limit)
+    |> parse_suggested_users
+
+  let get_suggested_users_for_discover_skeleton ?session ?host ?viewer ?limit ()
+      : did_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForDiscoverSkeleton"
+      (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
+    |> parse_did_skeleton
+
+  let get_suggested_users_for_explore ?session ?host ?category ?limit () :
+      suggested_users =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForExplore"
+      (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
+    |> parse_suggested_users
+
+  let get_suggested_users_for_explore_skeleton ?session ?host ?viewer ?category
+      ?limit () : did_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForExploreSkeleton"
+      (Client.opt_pair "viewer" viewer
+      @ Client.opt_pair "category" category
+      @ Client.opt_int "limit" limit)
+    |> parse_did_skeleton
+
+  let get_suggested_users_for_see_more ?session ?host ?category ?limit () :
+      suggested_users =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForSeeMore"
+      (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
+    |> parse_suggested_users
+
+  let get_suggested_users_for_see_more_skeleton ?session ?host ?viewer ?category
+      ?limit () : did_skeleton =
+    Client.get_json ?session ?host
+      "app.bsky.unspecced.getSuggestedUsersForSeeMoreSkeleton"
+      (Client.opt_pair "viewer" viewer
+      @ Client.opt_pair "category" category
+      @ Client.opt_int "limit" limit)
+    |> parse_did_skeleton
+
+  let get_post_thread_v2 ?session ?host ~anchor ?above ?below ?branching_factor
+      ?sort () : thread_v2 =
+    Client.get_json ?session ?host "app.bsky.unspecced.getPostThreadV2"
+      ([ ("anchor", anchor) ]
+      @ Client.opt_bool "above" above
+      @ Client.opt_int "below" below
+      @ Client.opt_int "branchingFactor" branching_factor
+      @ Client.opt_pair "sort" sort)
+    |> parse_thread_v2
+
+  let get_post_thread_other_v2 ?session ?host ~anchor () : thread_other_v2 =
+    Client.get_json ?session ?host "app.bsky.unspecced.getPostThreadOtherV2"
+      [ ("anchor", anchor) ]
+    |> parse_thread_other_v2
 end

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -259,6 +259,7 @@ module Unspecced = struct
 
   type suggested_feeds = { feeds : generator_view list }
   type uri_skeleton = { uris : string list }
+
   type did_skeleton = {
     dids : string list;
     rec_id : string option;
@@ -285,11 +286,7 @@ module Unspecced = struct
     | `Blocked of thread_item_blocked
     | `Unknown of Yojson.Safe.t ]
 
-  type thread_item = {
-    uri : string;
-    depth : int;
-    value : thread_item_value;
-  }
+  type thread_item = { uri : string; depth : int; value : thread_item_value }
 
   type thread_v2 = {
     thread : thread_item list;
@@ -583,8 +580,8 @@ module Unspecced = struct
       @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
-  let get_suggested_users_for_discover ?session ?host ?limit () : suggested_users
-      =
+  let get_suggested_users_for_discover ?session ?host ?limit () :
+      suggested_users =
     Client.get_json ?session ?host
       "app.bsky.unspecced.getSuggestedUsersForDiscover"
       (Client.opt_int "limit" limit)

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -276,11 +276,13 @@ module Unspecced = struct
     muted_by_viewer : bool;
   }
 
+  type thread_item_blocked = { author_did : string option }
+
   type thread_item_value =
     [ `Post of thread_item_post
     | `No_unauthenticated
     | `Not_found
-    | `Blocked of { author_did : string option }
+    | `Blocked of thread_item_blocked
     | `Unknown of Yojson.Safe.t ]
 
   type thread_item = {

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -850,7 +850,7 @@ module Chat = struct
     convo_created_at : string;
     convo_id : string;
     created_at : string;
-    method : string;
+    method_ : string;
     rev : string;
     group_member_count : int option;
     group_name : string option;
@@ -1001,7 +1001,7 @@ module Chat = struct
       convo_created_at = Client.string_member json "convoCreatedAt";
       convo_id = Client.string_member json "convoId";
       created_at = Client.string_member json "createdAt";
-      method = Client.string_member json "method";
+      method_ = Client.string_member json "method";
       rev = Client.string_member json "rev";
       group_member_count = Client.int_opt json "groupMemberCount";
       group_name = Client.string_opt json "groupName";

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -3,6 +3,10 @@ open Client
 open Xrpc
 open Facet
 open Embed
+open Cid
+open Firehose
+open Dag_cbor
+open Websocket
 
 (** chat.bsky.convo — DMs. Requests must include atproto-proxy for the chat service. *)
 module Chat = struct
@@ -776,4 +780,378 @@ module Chat = struct
          "chat.bsky.moderation.updateActorAccess"
          (Yojson.Safe.to_string
             (update_actor_access_body ~actor ~allow_access ?ref ())))
+
+  (* chat.bsky.moderation.subscribeModEvents — private operator firehose. *)
+
+  type mod_event_convo_first_message = {
+    convo_id : string;
+    created_at : string;
+    rev : string;
+    user : string;
+    recipients : string list;
+    message_id : string option;
+  }
+
+  type mod_event_group_created = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    initial_member_dids : string list;
+    owner_did : string;
+    rev : string;
+  }
+
+  type mod_event_member_added = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    owner_did : string;
+    request_members_count : int;
+    rev : string;
+    subject_did : string;
+    subject_follows_owner : bool;
+  }
+
+  type mod_event_member_joined = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    join_link_code : string;
+    owner_did : string;
+    rev : string;
+    subject_follows_owner : bool;
+  }
+
+  type mod_event_join_request = mod_event_member_joined
+
+  type mod_event_join_decision = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    owner_did : string;
+    rev : string;
+    subject_did : string;
+  }
+
+  type mod_event_chat_accepted = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    method : string;
+    rev : string;
+    group_member_count : int option;
+    group_name : string option;
+    owner_did : string option;
+  }
+
+  type mod_event_member_left = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    leave_method : string;
+    owner_did : string;
+    rev : string;
+    subject_did : string;
+  }
+
+  type mod_event_group_updated = {
+    actor_did : string;
+    convo_created_at : string;
+    convo_id : string;
+    created_at : string;
+    group_member_count : int;
+    group_name : string;
+    owner_did : string;
+    rev : string;
+    update_type : string;
+    join_link_code : string option;
+    join_link_followers_only : bool option;
+    join_link_requires_approval : bool option;
+    lock_reason : string option;
+    new_name : string option;
+    old_name : string option;
+  }
+
+  type mod_event_rate_limit = {
+    actor_did : string;
+    created_at : string;
+    endpoint : string;
+    rev : string;
+  }
+
+  type mod_event =
+    [ `Convo_first_message of mod_event_convo_first_message
+    | `Group_chat_created of mod_event_group_created
+    | `Group_chat_member_added of mod_event_member_added
+    | `Group_chat_member_joined of mod_event_member_joined
+    | `Group_chat_join_request of mod_event_join_request
+    | `Group_chat_join_request_approved of mod_event_join_decision
+    | `Group_chat_join_request_rejected of mod_event_join_decision
+    | `Chat_accepted of mod_event_chat_accepted
+    | `Group_chat_member_left of mod_event_member_left
+    | `Group_chat_updated of mod_event_group_updated
+    | `Rate_limit_exceeded of mod_event_rate_limit
+    | `Error of string * string option
+    | `Unknown of string * Yojson.Safe.t ]
+
+  let default_mod_events_host = "api.bsky.chat"
+
+  let subscribe_mod_events_url ?(host = default_mod_events_host) ?cursor () =
+    let base =
+      Printf.sprintf "wss://%s/xrpc/chat.bsky.moderation.subscribeModEvents"
+        host
+    in
+    match cursor with
+    | None -> base
+    | Some c -> base ^ "?cursor=" ^ Uri.pct_encode c
+
+  let string_list json field =
+    List.filter_map
+      (function `String s -> Some s | _ -> None)
+      (Client.list_member json field)
+
+  let ends_with_event suffix ty =
+    let n = String.length ty and m = String.length suffix in
+    n >= m && String.sub ty (n - m) m = suffix
+
+  let parse_convo_first_message json : mod_event_convo_first_message =
+    {
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      rev = Client.string_member json "rev";
+      user = Client.string_member json "user";
+      recipients = string_list json "recipients";
+      message_id = Client.string_opt json "messageId";
+    }
+
+  let parse_group_created json : mod_event_group_created =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      initial_member_dids = string_list json "initialMemberDids";
+      owner_did = Client.string_member json "ownerDid";
+      rev = Client.string_member json "rev";
+    }
+
+  let parse_member_added json : mod_event_member_added =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      owner_did = Client.string_member json "ownerDid";
+      request_members_count = Client.int_member json "requestMembersCount";
+      rev = Client.string_member json "rev";
+      subject_did = Client.string_member json "subjectDid";
+      subject_follows_owner = Client.bool_member json "subjectFollowsOwner";
+    }
+
+  let parse_member_joined json : mod_event_member_joined =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      join_link_code = Client.string_member json "joinLinkCode";
+      owner_did = Client.string_member json "ownerDid";
+      rev = Client.string_member json "rev";
+      subject_follows_owner = Client.bool_member json "subjectFollowsOwner";
+    }
+
+  let parse_join_decision json : mod_event_join_decision =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      owner_did = Client.string_member json "ownerDid";
+      rev = Client.string_member json "rev";
+      subject_did = Client.string_member json "subjectDid";
+    }
+
+  let parse_chat_accepted json : mod_event_chat_accepted =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      method = Client.string_member json "method";
+      rev = Client.string_member json "rev";
+      group_member_count = Client.int_opt json "groupMemberCount";
+      group_name = Client.string_opt json "groupName";
+      owner_did = Client.string_opt json "ownerDid";
+    }
+
+  let parse_member_left json : mod_event_member_left =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      leave_method = Client.string_member json "leaveMethod";
+      owner_did = Client.string_member json "ownerDid";
+      rev = Client.string_member json "rev";
+      subject_did = Client.string_member json "subjectDid";
+    }
+
+  let parse_group_updated json : mod_event_group_updated =
+    {
+      actor_did = Client.string_member json "actorDid";
+      convo_created_at = Client.string_member json "convoCreatedAt";
+      convo_id = Client.string_member json "convoId";
+      created_at = Client.string_member json "createdAt";
+      group_member_count = Client.int_member json "groupMemberCount";
+      group_name = Client.string_member json "groupName";
+      owner_did = Client.string_member json "ownerDid";
+      rev = Client.string_member json "rev";
+      update_type = Client.string_member json "updateType";
+      join_link_code = Client.string_opt json "joinLinkCode";
+      join_link_followers_only = Client.bool_opt json "joinLinkFollowersOnly";
+      join_link_requires_approval =
+        Client.bool_opt json "joinLinkRequiresApproval";
+      lock_reason = Client.string_opt json "lockReason";
+      new_name = Client.string_opt json "newName";
+      old_name = Client.string_opt json "oldName";
+    }
+
+  let parse_rate_limit json : mod_event_rate_limit =
+    {
+      actor_did = Client.string_member json "actorDid";
+      created_at = Client.string_member json "createdAt";
+      endpoint = Client.string_member json "endpoint";
+      rev = Client.string_member json "rev";
+    }
+
+  let parse_mod_event_type ~type_ json : mod_event =
+    if ends_with_event "eventConvoFirstMessage" type_ then
+      `Convo_first_message (parse_convo_first_message json)
+    else if ends_with_event "eventGroupChatCreated" type_ then
+      `Group_chat_created (parse_group_created json)
+    else if ends_with_event "eventGroupChatMemberAdded" type_ then
+      `Group_chat_member_added (parse_member_added json)
+    else if ends_with_event "eventGroupChatMemberJoined" type_ then
+      `Group_chat_member_joined (parse_member_joined json)
+    else if ends_with_event "eventGroupChatJoinRequestApproved" type_ then
+      `Group_chat_join_request_approved (parse_join_decision json)
+    else if ends_with_event "eventGroupChatJoinRequestRejected" type_ then
+      `Group_chat_join_request_rejected (parse_join_decision json)
+    else if ends_with_event "eventGroupChatJoinRequest" type_ then
+      `Group_chat_join_request (parse_member_joined json)
+    else if ends_with_event "eventChatAccepted" type_ then
+      `Chat_accepted (parse_chat_accepted json)
+    else if ends_with_event "eventGroupChatMemberLeft" type_ then
+      `Group_chat_member_left (parse_member_left json)
+    else if ends_with_event "eventGroupChatUpdated" type_ then
+      `Group_chat_updated (parse_group_updated json)
+    else if ends_with_event "eventRateLimitExceeded" type_ then
+      `Rate_limit_exceeded (parse_rate_limit json)
+    else `Unknown (type_, json)
+
+  let parse_mod_event json : mod_event =
+    let type_ =
+      match Client.string_opt json "$type" with
+      | Some s -> s
+      | None -> Option.value ~default:"" (Client.string_opt json "t")
+    in
+    parse_mod_event_type ~type_ json
+
+  let rec cbor_to_json (v : Dag_cbor.value) : Yojson.Safe.t =
+    match v with
+    | Dag_cbor.Null -> `Null
+    | Dag_cbor.Bool b -> `Bool b
+    | Dag_cbor.Int n -> `Int n
+    | Dag_cbor.Int64 n -> `Intlit (Int64.to_string n)
+    | Dag_cbor.Text s -> `String s
+    | Dag_cbor.Bytes b -> `String b
+    | Dag_cbor.Array xs -> `List (List.map cbor_to_json xs)
+    | Dag_cbor.Map fields ->
+        `Assoc (List.map (fun (k, x) -> (k, cbor_to_json x)) fields)
+    | Dag_cbor.Tag (_, inner) -> cbor_to_json inner
+    | Dag_cbor.Cid c -> `String (Cid.to_string c)
+
+  let decode_mod_event_frame (bytes : string) : Firehose.header * mod_event =
+    match Dag_cbor.decode_sequence bytes with
+    | header_v :: body :: _ ->
+        let header = Firehose.parse_header header_v in
+        let json = cbor_to_json body in
+        let event =
+          if header.op = -1 then
+            let err =
+              match Yojson.Safe.Util.member "error" json with
+              | `String s -> s
+              | _ -> "error"
+            in
+            let msg =
+              match Yojson.Safe.Util.member "message" json with
+              | `String s -> Some s
+              | _ -> None
+            in
+            `Error (err, msg)
+          else
+            let type_ =
+              match header.t with
+              | Some t ->
+                  if String.length t > 0 && t.[0] = '#' then
+                    String.sub t 1 (String.length t - 1)
+                  else t
+              | None -> ""
+            in
+            parse_mod_event_type ~type_ json
+        in
+        (header, event)
+    | _ ->
+        failwith
+          "Chat.decode_mod_event_frame: expected header and body CBOR values"
+
+  let subscribe_mod_events ?session ?proxy ?(host = default_mod_events_host)
+      ?cursor ?max_messages f =
+    let extra =
+      proxy_headers ?proxy ()
+      @
+      match session with
+      | Some s -> [ Session.bearer_token_from_session s ]
+      | None -> []
+    in
+    let url = subscribe_mod_events_url ~host ?cursor () in
+    Websocket.with_connection ~extra_headers:extra url (fun ws ->
+        let rec loop n =
+          match max_messages with
+          | Some m when n >= m -> ()
+          | _ -> (
+              match Websocket.recv_message ws with
+              | Websocket.Binary payload | Websocket.Text payload ->
+                  f (decode_mod_event_frame payload);
+                  loop (n + 1)
+              | Websocket.Close _ -> ()
+              | Websocket.Ping _ | Websocket.Pong _ -> loop n)
+        in
+        loop 0)
 end

--- a/src/dune
+++ b/src/dune
@@ -27,6 +27,7 @@
   (pps ppx_jane))
  (modules
   Admin
+  Ageassurance
   App
   Actor
   At_uri
@@ -40,10 +41,12 @@
   Cid
   Client
   Cohttp_client
+  Contact
   Dag_cbor
   Did_key
   Did_plc
   Did_web
+  Draft
   Embed
   Error
   Facet

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -316,6 +316,18 @@ module Lexicon = struct
   let official_get_post_thread =
     {|{"lexicon":1,"id":"app.bsky.feed.getPostThread","defs":{"main":{"type":"query","description":"Get posts in a thread.","parameters":{"type":"params","required":["uri"],"properties":{"uri":{"type":"string","format":"at-uri"},"depth":{"type":"integer"},"parentHeight":{"type":"integer"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["thread"],"properties":{"thread":{"type":"union","refs":["app.bsky.feed.defs#threadViewPost","app.bsky.feed.defs#notFoundPost","app.bsky.feed.defs#blockedPost"]},"threadgate":{"type":"ref","ref":"app.bsky.feed.defs#threadgateView"}}}}}}}|}
 
+  let official_get_post_thread_v2 =
+    {|{"lexicon":1,"id":"app.bsky.unspecced.getPostThreadV2","defs":{"main":{"type":"query","description":"Get posts in a thread (unspecced v2).","parameters":{"type":"params","required":["anchor"],"properties":{"anchor":{"type":"string","format":"at-uri"},"above":{"type":"boolean"},"below":{"type":"integer"},"branchingFactor":{"type":"integer"},"sort":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["thread","hasOtherReplies"],"properties":{"thread":{"type":"array"},"threadgate":{"type":"ref","ref":"app.bsky.feed.defs#threadgateView"},"hasOtherReplies":{"type":"boolean"}}}}}}}|}
+
+  let official_subscribe_mod_events =
+    {|{"lexicon":1,"id":"chat.bsky.moderation.subscribeModEvents","defs":{"main":{"type":"subscription","description":"Subscribe to stream of chat events targeted to moderation.","parameters":{"type":"params","properties":{"cursor":{"type":"string"}}},"message":{"schema":{"type":"union","refs":["#eventConvoFirstMessage","#eventGroupChatCreated","#eventGroupChatMemberAdded","#eventGroupChatMemberJoined","#eventGroupChatJoinRequest","#eventGroupChatJoinRequestApproved","#eventGroupChatJoinRequestRejected","#eventChatAccepted","#eventGroupChatMemberLeft","#eventGroupChatUpdated","#eventRateLimitExceeded"]}}},"eventConvoFirstMessage":{"type":"object","required":["createdAt","rev","convoId","user","recipients"],"properties":{"convoId":{"type":"string"},"createdAt":{"type":"string"},"rev":{"type":"string"},"user":{"type":"string"},"recipients":{"type":"array"}}}}}|}
+
+  let official_ageassurance_get_state =
+    {|{"lexicon":1,"id":"app.bsky.ageassurance.getState","defs":{"main":{"type":"query","description":"Returns server-computed Age Assurance state.","parameters":{"type":"params","required":["countryCode"],"properties":{"countryCode":{"type":"string"},"regionCode":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["state","metadata"],"properties":{"state":{"type":"ref","ref":"app.bsky.ageassurance.defs#state"},"metadata":{"type":"ref","ref":"app.bsky.ageassurance.defs#stateMetadata"}}}}}}}|}
+
+  let official_draft_create =
+    {|{"lexicon":1,"id":"app.bsky.draft.createDraft","defs":{"main":{"type":"procedure","description":"Inserts a draft using private storage.","input":{"encoding":"application/json","schema":{"type":"object","required":["draft"],"properties":{"draft":{"type":"ref","ref":"app.bsky.draft.defs#draft"}}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["id"],"properties":{"id":{"type":"string","format":"tid"}}}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -323,6 +335,10 @@ module Lexicon = struct
       ("app.bsky.graph.list", official_list);
       ("chat.bsky.notification.defs", official_chat_notification_defs);
       ("app.bsky.feed.getPostThread", official_get_post_thread);
+      ("app.bsky.unspecced.getPostThreadV2", official_get_post_thread_v2);
+      ("chat.bsky.moderation.subscribeModEvents", official_subscribe_mod_events);
+      ("app.bsky.ageassurance.getState", official_ageassurance_get_state);
+      ("app.bsky.draft.createDraft", official_draft_create);
     ]
 
   let official_documents () : document list =

--- a/src/websocket.ml
+++ b/src/websocket.ml
@@ -220,7 +220,11 @@ module Websocket = struct
     in
     find headers
 
-  let connect ?(tls_verify = false) (url : string) : t =
+  let extra_header_lines (extra : (string * string) list) : string =
+    String.concat ""
+      (List.map (fun (k, v) -> Printf.sprintf "%s: %s\r\n" k v) extra)
+
+  let connect ?(tls_verify = false) ?(extra_headers = []) (url : string) : t =
     Random.self_init ();
     let host, port, path = parse_wss_url url in
     Ssl.init ();
@@ -245,8 +249,8 @@ module Websocket = struct
          Connection: Upgrade\r\n\
          Sec-WebSocket-Key: %s\r\n\
          Sec-WebSocket-Version: 13\r\n\
-         \r\n"
-        path host key
+         %s\r\n"
+        path host key (extra_header_lines extra_headers)
     in
     write_all ssl req;
     let resp = read_handshake_response ssl in
@@ -267,7 +271,7 @@ module Websocket = struct
     (try send_close ws with _ -> ());
     try Ssl.shutdown ws.ssl with _ -> ()
 
-  let with_connection ?tls_verify url f =
-    let ws = connect ?tls_verify url in
+  let with_connection ?tls_verify ?(extra_headers = []) url f =
+    let ws = connect ?tls_verify ~extra_headers url in
     Fun.protect ~finally:(fun () -> close ws) (fun () -> f ws)
 end

--- a/src/websocket.ml
+++ b/src/websocket.ml
@@ -250,7 +250,8 @@ module Websocket = struct
          Sec-WebSocket-Key: %s\r\n\
          Sec-WebSocket-Version: 13\r\n\
          %s\r\n"
-        path host key (extra_header_lines extra_headers)
+        path host key
+        (extra_header_lines extra_headers)
     in
     write_all ssl req;
     let resp = read_handshake_response ssl in

--- a/test/dune
+++ b/test/dune
@@ -3,6 +3,7 @@
   test_app
   test_actor
   test_admin
+  test_ageassurance
   test_at_uri
   test_auth
   test_base32
@@ -12,9 +13,11 @@
   test_chat
   test_cid
   test_cohttp_client
+  test_contact
   test_did_key
   test_did_plc
   test_did_web
+  test_draft
   test_embed
   test_error
   test_facet
@@ -80,6 +83,7 @@
   test_app
   test_actor
   test_admin
+  test_ageassurance
   test_at_uri
   test_auth
   test_base32
@@ -89,9 +93,11 @@
   test_chat
   test_cid
   test_cohttp_client
+  test_contact
   test_did_key
   test_did_plc
   test_did_web
+  test_draft
   test_embed
   test_error
   test_facet

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -80,20 +80,164 @@ let test_parse_preferences _ =
                   ("$type", `String "app.bsky.actor.defs#savedFeedsPrefV2");
                   ("items", `List []);
                 ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#savedFeedsPref");
+                  ( "pinned",
+                    `List
+                      [
+                        `String
+                          "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot";
+                      ] );
+                  ("saved", `List []);
+                  ("timelineIndex", `Int 0);
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#personalDetailsPref");
+                  ("birthDate", `String "2000-01-01T00:00:00.000Z");
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#declaredAgePref");
+                  ("isOverAge18", `Bool true);
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#feedViewPref");
+                  ("feed", `String "home");
+                  ("hideReplies", `Bool true);
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#threadViewPref");
+                  ("sort", `String "hotness");
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#mutedWordsPref");
+                  ( "items",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ("value", `String "spam");
+                            ("targets", `List [ `String "content" ]);
+                          ];
+                      ] );
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#bskyAppStatePref");
+                  ("isBetaUser", `Bool true);
+                  ( "nuxs",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ("id", `String "welcome");
+                            ("completed", `Bool true);
+                          ];
+                      ] );
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#labelersPref");
+                  ( "labelers",
+                    `List
+                      [
+                        `Assoc
+                          [ ("did", `String "did:plc:ar7c4by46qjdydhdevvrndac") ];
+                      ] );
+                ];
+              `Assoc
+                [
+                  ( "$type",
+                    `String "app.bsky.actor.defs#postInteractionSettingsPref" );
+                  ( "threadgateAllowRules",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ( "$type",
+                              `String "app.bsky.feed.threadgate#mentionRule" );
+                          ];
+                      ] );
+                  ( "postgateEmbeddingRules",
+                    `List
+                      [
+                        `Assoc
+                          [
+                            ( "$type",
+                              `String "app.bsky.feed.postgate#disableRule" );
+                          ];
+                      ] );
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#verificationPrefs");
+                  ("hideBadges", `Bool true);
+                ];
+              `Assoc
+                [
+                  ("$type", `String "app.bsky.actor.defs#liveEventPreferences");
+                  ("hiddenFeedIds", `List [ `String "live-1" ]);
+                  ("hideAllFeeds", `Bool false);
+                ];
             ] );
       ]
   in
   let prefs = Actor.parse_preferences json in
-  OUnit2.assert_equal 2 (List.length prefs.preferences);
+  OUnit2.assert_equal 13 (List.length prefs.preferences);
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "app.bsky.actor.defs#adultContentPref" (List.hd prefs.preferences).type_;
   (match (List.hd prefs.preferences).kind with
   | `Adult_content a -> OUnit2.assert_equal false a.enabled
   | _ -> OUnit2.assert_failure "expected adultContentPref");
-  match (List.nth prefs.preferences 1).kind with
+  (match (List.nth prefs.preferences 1).kind with
   | `Saved_feeds_v2 s -> OUnit2.assert_equal 0 (List.length s.items)
-  | _ -> OUnit2.assert_failure "expected savedFeedsPrefV2"
+  | _ -> OUnit2.assert_failure "expected savedFeedsPrefV2");
+  (match (List.nth prefs.preferences 2).kind with
+  | `Saved_feeds s -> OUnit2.assert_equal (Some 0) s.timeline_index
+  | _ -> OUnit2.assert_failure "expected savedFeedsPref");
+  (match (List.nth prefs.preferences 3).kind with
+  | `Personal_details p ->
+      OUnit2.assert_equal (Some "2000-01-01T00:00:00.000Z") p.birth_date
+  | _ -> OUnit2.assert_failure "expected personalDetailsPref");
+  (match (List.nth prefs.preferences 4).kind with
+  | `Declared_age d -> OUnit2.assert_equal (Some true) d.is_over_age_18
+  | _ -> OUnit2.assert_failure "expected declaredAgePref");
+  (match (List.nth prefs.preferences 5).kind with
+  | `Feed_view f -> OUnit2.assert_equal (Some true) f.hide_replies
+  | _ -> OUnit2.assert_failure "expected feedViewPref");
+  (match (List.nth prefs.preferences 6).kind with
+  | `Thread_view t -> OUnit2.assert_equal (Some "hotness") t.sort
+  | _ -> OUnit2.assert_failure "expected threadViewPref");
+  (match (List.nth prefs.preferences 7).kind with
+  | `Muted_words m ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "spam" (List.hd m.items).value
+  | _ -> OUnit2.assert_failure "expected mutedWordsPref");
+  (match (List.nth prefs.preferences 8).kind with
+  | `Bsky_app_state s ->
+      OUnit2.assert_equal (Some true) s.is_beta_user;
+      OUnit2.assert_equal 1 (List.length s.nuxs)
+  | _ -> OUnit2.assert_failure "expected bskyAppStatePref");
+  (match (List.nth prefs.preferences 9).kind with
+  | `Labelers l -> OUnit2.assert_equal 1 (List.length l.labelers)
+  | _ -> OUnit2.assert_failure "expected labelersPref");
+  (match (List.nth prefs.preferences 10).kind with
+  | `Post_interaction p -> (
+      match p.threadgate_allow_rules with
+      | Some (`Mention :: _) -> ()
+      | _ -> OUnit2.assert_failure "expected mention rule")
+  | _ -> OUnit2.assert_failure "expected postInteractionSettingsPref");
+  (match (List.nth prefs.preferences 11).kind with
+  | `Verification v -> OUnit2.assert_equal true v.hide_badges
+  | _ -> OUnit2.assert_failure "expected verificationPrefs");
+  match (List.nth prefs.preferences 12).kind with
+  | `Live_event e -> OUnit2.assert_equal [ "live-1" ] e.hidden_feed_ids
+  | _ -> OUnit2.assert_failure "expected liveEventPreferences"
 
 let test_get_preferences_auth_skipped _ =
   skip_if

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -135,8 +135,7 @@ let test_parse_preferences _ =
                       [
                         `Assoc
                           [
-                            ("id", `String "welcome");
-                            ("completed", `Bool true);
+                            ("id", `String "welcome"); ("completed", `Bool true);
                           ];
                       ] );
                 ];
@@ -147,7 +146,9 @@ let test_parse_preferences _ =
                     `List
                       [
                         `Assoc
-                          [ ("did", `String "did:plc:ar7c4by46qjdydhdevvrndac") ];
+                          [
+                            ("did", `String "did:plc:ar7c4by46qjdydhdevvrndac");
+                          ];
                       ] );
                 ];
               `Assoc

--- a/test/test_ageassurance.ml
+++ b/test/test_ageassurance.ml
@@ -1,0 +1,127 @@
+open OUnit2
+open Atproto.Ageassurance
+open Atproto.Auth
+
+let test_parse_state_and_config _ =
+  let bundle =
+    Ageassurance.parse_state_bundle
+      (`Assoc
+        [
+          ( "state",
+            `Assoc
+              [
+                ("status", `String "pending");
+                ("access", `String "safe");
+                ("lastInitiatedAt", `String "2026-01-01T00:00:00.000Z");
+              ] );
+          ( "metadata",
+            `Assoc [ ("accountCreatedAt", `String "2020-01-01T00:00:00.000Z") ]
+          );
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "pending" bundle.state.status;
+  OUnit2.assert_equal ~printer:(fun x -> x) "safe" bundle.state.access;
+  OUnit2.assert_equal (Some "2020-01-01T00:00:00.000Z")
+    bundle.metadata.account_created_at;
+  let cfg =
+    Ageassurance.parse_config
+      (`Assoc
+        [
+          ( "regions",
+            `List
+              [
+                `Assoc
+                  [
+                    ("countryCode", `String "GB");
+                    ("minAccessAge", `Int 18);
+                    ("platforms", `List [ `String "ios"; `String "android" ]);
+                    ( "additionalVerificationMethods",
+                      `List [ `String "device" ] );
+                    ( "rules",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ( "$type",
+                                `String
+                                  "app.bsky.ageassurance.defs#configRegionRuleIfDeclaredOverAge"
+                              );
+                              ("age", `Int 18);
+                              ("access", `String "full");
+                            ];
+                          `Assoc
+                            [
+                              ( "$type",
+                                `String
+                                  "app.bsky.ageassurance.defs#configRegionRuleDefault"
+                              );
+                              ("access", `String "none");
+                            ];
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length cfg.regions);
+  OUnit2.assert_equal 18 (List.hd cfg.regions).min_access_age;
+  (match (List.hd cfg.regions).rules with
+  | `Declared_over (18, "full") :: `Default "none" :: _ -> ()
+  | _ -> OUnit2.assert_failure "expected declared-over then default rules");
+  let body =
+    Ageassurance.begin_body ~email:"user@example.com" ~language:"en"
+      ~country_code:"GB" ~region_code:"ENG" ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "GB"
+    (body |> member "countryCode" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "ENG"
+    (body |> member "regionCode" |> to_string)
+
+let test_parse_event _ =
+  let ev =
+    Ageassurance.parse_event
+      (`Assoc
+        [
+          ("createdAt", `String "2026-01-01T00:00:00.000Z");
+          ("attemptId", `String "11111111-1111-1111-1111-111111111111");
+          ("status", `String "assured");
+          ("access", `String "full");
+          ("countryCode", `String "US");
+          ("email", `String "user@example.com");
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "assured" ev.status;
+  OUnit2.assert_equal ~printer:(fun x -> x) "full" ev.access
+
+let test_get_config_live _ =
+  try
+    let cfg = Ageassurance.get_config () in
+    OUnit2.assert_bool "regions list parsed" (List.length cfg.regions >= 0)
+  with exn ->
+    skip_if true ("ageassurance.getConfig skipped: " ^ Printexc.to_string exn)
+
+let test_get_state_auth_skipped _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let username, password = Auth.username_and_password_from_env in
+  let s = Atproto.Session.Session.create_session username password in
+  try
+    let bundle = Ageassurance.get_state s ~country_code:"US" () in
+    OUnit2.assert_bool "status present" (String.length bundle.state.status > 0)
+  with exn -> skip_if true ("getState skipped: " ^ Printexc.to_string exn)
+
+let suite =
+  "ageassurance"
+  >::: [
+         "test_parse_state_and_config" >:: test_parse_state_and_config;
+         "test_parse_event" >:: test_parse_event;
+         "test_get_config_live" >:: test_get_config_live;
+         "test_get_state_auth_skipped" >:: test_get_state_auth_skipped;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_ageassurance.ml
+++ b/test/test_ageassurance.ml
@@ -2,6 +2,17 @@ open OUnit2
 open Atproto.Ageassurance
 open Atproto.Auth
 
+let with_public_timeout ?(seconds = 20) f =
+  let old =
+    Sys.signal Sys.sigalrm (Sys.Signal_handle (fun _ -> failwith "timeout"))
+  in
+  ignore (Unix.alarm seconds);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Unix.alarm 0);
+      Sys.set_signal Sys.sigalrm old)
+    f
+
 let test_parse_state_and_config _ =
   let bundle =
     Ageassurance.parse_state_bundle
@@ -35,8 +46,7 @@ let test_parse_state_and_config _ =
                     ("countryCode", `String "GB");
                     ("minAccessAge", `Int 18);
                     ("platforms", `List [ `String "ios"; `String "android" ]);
-                    ( "additionalVerificationMethods",
-                      `List [ `String "device" ] );
+                    ("additionalVerificationMethods", `List [ `String "device" ]);
                     ( "rules",
                       `List
                         [
@@ -99,8 +109,9 @@ let test_parse_event _ =
 
 let test_get_config_live _ =
   try
-    let cfg = Ageassurance.get_config () in
-    OUnit2.assert_bool "regions list parsed" (List.length cfg.regions >= 0)
+    with_public_timeout (fun () ->
+        let cfg = Ageassurance.get_config () in
+        OUnit2.assert_bool "regions list parsed" (List.length cfg.regions >= 0))
   with exn ->
     skip_if true ("ageassurance.getConfig skipped: " ^ Printexc.to_string exn)
 

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -315,6 +315,100 @@ let test_moderation_parsers _ =
     "ticket-1"
     (body |> member "ref" |> to_string)
 
+let test_subscribe_mod_events _ =
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "wss://api.bsky.chat/xrpc/chat.bsky.moderation.subscribeModEvents"
+    (Chat.subscribe_mod_events_url ());
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "wss://chat.example/xrpc/chat.bsky.moderation.subscribeModEvents?cursor=2222222222222"
+    (Chat.subscribe_mod_events_url ~host:"chat.example" ~cursor:"2222222222222"
+       ());
+  let first =
+    Chat.parse_mod_event
+      (`Assoc
+        [
+          ( "$type",
+            `String "chat.bsky.moderation.subscribeModEvents#eventConvoFirstMessage"
+          );
+          ("convoId", `String "c1");
+          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+          ("rev", `String "r1");
+          ("user", `String "did:plc:abc123xyz0001112223333");
+          ("recipients", `List [ `String "did:plc:def456xyz0001112223333" ]);
+          ("messageId", `String "m1");
+        ])
+  in
+  (match first with
+  | `Convo_first_message e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "c1" e.convo_id;
+      OUnit2.assert_equal 1 (List.length e.recipients)
+  | _ -> OUnit2.assert_failure "expected first-message event");
+  let created =
+    Chat.parse_mod_event
+      (`Assoc
+        [
+          ( "$type",
+            `String "chat.bsky.moderation.subscribeModEvents#eventGroupChatCreated"
+          );
+          ("actorDid", `String "did:plc:abc123xyz0001112223333");
+          ("convoCreatedAt", `String "2024-01-01T00:00:00.000Z");
+          ("convoId", `String "g1");
+          ("createdAt", `String "2024-01-01T00:00:01.000Z");
+          ("groupMemberCount", `Int 3);
+          ("groupName", `String "mods");
+          ( "initialMemberDids",
+            `List [ `String "did:plc:def456xyz0001112223333" ] );
+          ("ownerDid", `String "did:plc:abc123xyz0001112223333");
+          ("rev", `String "r2");
+        ])
+  in
+  (match created with
+  | `Group_chat_created e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "mods" e.group_name
+  | _ -> OUnit2.assert_failure "expected group created");
+  let approved =
+    Chat.parse_mod_event
+      (`Assoc
+        [
+          ( "$type",
+            `String
+              "chat.bsky.moderation.subscribeModEvents#eventGroupChatJoinRequestApproved"
+          );
+          ("actorDid", `String "did:plc:abc123xyz0001112223333");
+          ("convoCreatedAt", `String "2024-01-01T00:00:00.000Z");
+          ("convoId", `String "g1");
+          ("createdAt", `String "2024-01-01T00:00:02.000Z");
+          ("groupMemberCount", `Int 4);
+          ("groupName", `String "mods");
+          ("ownerDid", `String "did:plc:abc123xyz0001112223333");
+          ("rev", `String "r3");
+          ("subjectDid", `String "did:plc:ghi789xyz0001112223333");
+        ])
+  in
+  (match approved with
+  | `Group_chat_join_request_approved e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "g1" e.convo_id
+  | _ -> OUnit2.assert_failure "expected join approved, not bare join request");
+  let header = Atproto.Firehose.Firehose.encode_header
+      { op = 1; t = Some "#eventRateLimitExceeded" }
+  in
+  let body =
+    Atproto.Dag_cbor.Dag_cbor.encode
+      (Atproto.Dag_cbor.Dag_cbor.Map
+         [
+           ("actorDid", Atproto.Dag_cbor.Dag_cbor.Text "did:plc:abc123xyz0001112223333");
+           ("createdAt", Atproto.Dag_cbor.Dag_cbor.Text "2024-01-01T00:00:00.000Z");
+           ("endpoint", Atproto.Dag_cbor.Dag_cbor.Text "chat.bsky.convo.sendMessage");
+           ("rev", Atproto.Dag_cbor.Dag_cbor.Text "r9");
+         ])
+  in
+  match Chat.decode_mod_event_frame (header ^ body) with
+  | _, `Rate_limit_exceeded e ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "r9" e.rev
+  | _ -> OUnit2.assert_failure "expected rate-limit CBOR frame"
+
 let test_list_convos_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -340,6 +434,7 @@ let suite =
          "test_actor_status_and_declaration"
          >:: test_actor_status_and_declaration;
          "test_moderation_parsers" >:: test_moderation_parsers;
+         "test_subscribe_mod_events" >:: test_subscribe_mod_events;
          "test_list_convos_auth_skipped" >:: test_list_convos_auth_skipped;
        ]
 

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -330,7 +330,8 @@ let test_subscribe_mod_events _ =
       (`Assoc
         [
           ( "$type",
-            `String "chat.bsky.moderation.subscribeModEvents#eventConvoFirstMessage"
+            `String
+              "chat.bsky.moderation.subscribeModEvents#eventConvoFirstMessage"
           );
           ("convoId", `String "c1");
           ("createdAt", `String "2024-01-01T00:00:00.000Z");
@@ -350,8 +351,8 @@ let test_subscribe_mod_events _ =
       (`Assoc
         [
           ( "$type",
-            `String "chat.bsky.moderation.subscribeModEvents#eventGroupChatCreated"
-          );
+            `String
+              "chat.bsky.moderation.subscribeModEvents#eventGroupChatCreated" );
           ("actorDid", `String "did:plc:abc123xyz0001112223333");
           ("convoCreatedAt", `String "2024-01-01T00:00:00.000Z");
           ("convoId", `String "g1");
@@ -391,16 +392,20 @@ let test_subscribe_mod_events _ =
   | `Group_chat_join_request_approved e ->
       OUnit2.assert_equal ~printer:(fun x -> x) "g1" e.convo_id
   | _ -> OUnit2.assert_failure "expected join approved, not bare join request");
-  let header = Atproto.Firehose.Firehose.encode_header
+  let header =
+    Atproto.Firehose.Firehose.encode_header
       { op = 1; t = Some "#eventRateLimitExceeded" }
   in
   let body =
     Atproto.Dag_cbor.Dag_cbor.encode
       (Atproto.Dag_cbor.Dag_cbor.Map
          [
-           ("actorDid", Atproto.Dag_cbor.Dag_cbor.Text "did:plc:abc123xyz0001112223333");
-           ("createdAt", Atproto.Dag_cbor.Dag_cbor.Text "2024-01-01T00:00:00.000Z");
-           ("endpoint", Atproto.Dag_cbor.Dag_cbor.Text "chat.bsky.convo.sendMessage");
+           ( "actorDid",
+             Atproto.Dag_cbor.Dag_cbor.Text "did:plc:abc123xyz0001112223333" );
+           ( "createdAt",
+             Atproto.Dag_cbor.Dag_cbor.Text "2024-01-01T00:00:00.000Z" );
+           ( "endpoint",
+             Atproto.Dag_cbor.Dag_cbor.Text "chat.bsky.convo.sendMessage" );
            ("rev", Atproto.Dag_cbor.Dag_cbor.Text "r9");
          ])
   in

--- a/test/test_contact.ml
+++ b/test/test_contact.ml
@@ -96,8 +96,7 @@ let test_get_sync_status_auth_skipped _ =
     let st = Contact.get_sync_status s in
     OUnit2.assert_bool "sync status parsed"
       (match st.sync_status with Some _ | None -> true)
-  with exn ->
-    skip_if true ("getSyncStatus skipped: " ^ Printexc.to_string exn)
+  with exn -> skip_if true ("getSyncStatus skipped: " ^ Printexc.to_string exn)
 
 let suite =
   "contact"

--- a/test/test_contact.ml
+++ b/test/test_contact.ml
@@ -1,0 +1,110 @@
+open OUnit2
+open Atproto.Contact
+open Atproto.Auth
+
+let test_parse_and_bodies _ =
+  let matches =
+    Contact.parse_matches_page
+      (`Assoc
+        [
+          ("cursor", `String "c1");
+          ( "matches",
+            `List
+              [
+                `Assoc
+                  [
+                    ("did", `String "did:plc:abc123xyz0001112223333");
+                    ("handle", `String "alice.test");
+                    ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+                    ("viewer", `Null);
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal (Some "c1") matches.cursor;
+  OUnit2.assert_equal 1 (List.length matches.matches);
+  let imported =
+    Contact.parse_import_result
+      (`Assoc
+        [
+          ( "matchesAndContactIndexes",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "match",
+                      `Assoc
+                        [
+                          ("did", `String "did:plc:abc123xyz0001112223333");
+                          ("handle", `String "alice.test");
+                          ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+                          ("viewer", `Null);
+                        ] );
+                    ("contactIndex", `Int 2);
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 2 (List.hd imported.matches).contact_index;
+  let status =
+    Contact.parse_sync_status_opt
+      (`Assoc
+        [
+          ( "syncStatus",
+            `Assoc
+              [
+                ("syncedAt", `String "2024-01-01T00:00:00.000Z");
+                ("matchesCount", `Int 4);
+              ] );
+        ])
+  in
+  (match status.sync_status with
+  | Some s -> OUnit2.assert_equal 4 s.matches_count
+  | None -> OUnit2.assert_failure "expected sync status");
+  let empty = Contact.parse_sync_status_opt (`Assoc []) in
+  OUnit2.assert_equal None empty.sync_status;
+  let open Yojson.Safe.Util in
+  let import_body =
+    Contact.import_contacts_body ~token:"jwt" ~contacts:[ "+12125550123" ]
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "jwt"
+    (import_body |> member "token" |> to_string);
+  OUnit2.assert_equal 1
+    (import_body |> member "contacts" |> to_list |> List.length);
+  let dismiss =
+    Contact.dismiss_match_body ~subject:"did:plc:abc123xyz0001112223333"
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:abc123xyz0001112223333"
+    (dismiss |> member "subject" |> to_string);
+  let verify = Contact.verify_phone_body ~phone:"+12125550123" ~code:"123456" in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "123456"
+    (verify |> member "code" |> to_string)
+
+let test_get_sync_status_auth_skipped _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let username, password = Auth.username_and_password_from_env in
+  let s = Atproto.Session.Session.create_session username password in
+  try
+    let st = Contact.get_sync_status s in
+    OUnit2.assert_bool "sync status parsed"
+      (match st.sync_status with Some _ | None -> true)
+  with exn ->
+    skip_if true ("getSyncStatus skipped: " ^ Printexc.to_string exn)
+
+let suite =
+  "contact"
+  >::: [
+         "test_parse_and_bodies" >:: test_parse_and_bodies;
+         "test_get_sync_status_auth_skipped"
+         >:: test_get_sync_status_auth_skipped;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_draft.ml
+++ b/test/test_draft.ml
@@ -55,8 +55,7 @@ let test_parse_and_build _ =
                   [
                     `Assoc
                       [
-                        ( "$type",
-                          `String "app.bsky.feed.threadgate#mentionRule" );
+                        ("$type", `String "app.bsky.feed.threadgate#mentionRule");
                       ];
                   ] );
               ( "postgateEmbeddingRules",
@@ -87,8 +86,17 @@ let test_parse_and_build _ =
     Draft.draft_json ~device_id:"device-1" ~langs:[ "en" ]
       ~threadgate_allow:[ `Following ]
       ~posts:
-        [ { text = "hi"; labels = None; embed_images = []; embed_gallery = None;
-            embed_videos = []; embed_externals = []; embed_records = [] } ]
+        [
+          {
+            text = "hi";
+            labels = None;
+            embed_images = [];
+            embed_gallery = None;
+            embed_videos = [];
+            embed_externals = [];
+            embed_records = [];
+          };
+        ]
       ()
   in
   let open Yojson.Safe.Util in

--- a/test/test_draft.ml
+++ b/test/test_draft.ml
@@ -1,0 +1,130 @@
+open OUnit2
+open Atproto.Draft
+open Atproto.Auth
+
+let test_parse_and_build _ =
+  let json =
+    `Assoc
+      [
+        ("id", `String "3jzfcijpj2z2a");
+        ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ("updatedAt", `String "2024-01-02T00:00:00.000Z");
+        ( "draft",
+          `Assoc
+            [
+              ("deviceId", `String "device-1");
+              ("deviceName", `String "iphone");
+              ("langs", `List [ `String "en" ]);
+              ( "posts",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ("text", `String "hello draft");
+                        ( "embedImages",
+                          `List
+                            [
+                              `Assoc
+                                [
+                                  ( "localRef",
+                                    `Assoc [ ("path", `String "/tmp/pic.png") ]
+                                  );
+                                  ("alt", `String "pic");
+                                ];
+                            ] );
+                        ( "embedRecords",
+                          `List
+                            [
+                              `Assoc
+                                [
+                                  ( "record",
+                                    `Assoc
+                                      [
+                                        ( "uri",
+                                          `String
+                                            "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+                                        );
+                                        ("cid", `String "bafyreihdummy");
+                                      ] );
+                                ];
+                            ] );
+                      ];
+                  ] );
+              ( "threadgateAllow",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ( "$type",
+                          `String "app.bsky.feed.threadgate#mentionRule" );
+                      ];
+                  ] );
+              ( "postgateEmbeddingRules",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ("$type", `String "app.bsky.feed.postgate#disableRule");
+                      ];
+                  ] );
+            ] );
+      ]
+  in
+  let view = Draft.parse_draft_view json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "3jzfcijpj2z2a" view.id;
+  OUnit2.assert_equal 1 (List.length view.draft.posts);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "hello draft" (List.hd view.draft.posts).text;
+  OUnit2.assert_equal 1 (List.length (List.hd view.draft.posts).embed_images);
+  (match view.draft.threadgate_allow with
+  | `Mention :: _ -> ()
+  | _ -> OUnit2.assert_failure "expected mention rule");
+  (match view.draft.postgate_embedding_rules with
+  | `Disable :: _ -> ()
+  | _ -> OUnit2.assert_failure "expected disable rule");
+  let built =
+    Draft.draft_json ~device_id:"device-1" ~langs:[ "en" ]
+      ~threadgate_allow:[ `Following ]
+      ~posts:
+        [ { text = "hi"; labels = None; embed_images = []; embed_gallery = None;
+            embed_videos = []; embed_externals = []; embed_records = [] } ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal 1 (built |> member "posts" |> to_list |> List.length);
+  let create = Draft.create_draft_body built in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "device-1"
+    (create |> member "draft" |> member "deviceId" |> to_string);
+  let update = Draft.update_draft_body ~id:"3jzfcijpj2z2a" built in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "3jzfcijpj2z2a"
+    (update |> member "draft" |> member "id" |> to_string);
+  let delete = Draft.delete_draft_body ~id:"3jzfcijpj2z2a" in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "3jzfcijpj2z2a"
+    (delete |> member "id" |> to_string)
+
+let test_get_drafts_auth_skipped _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let username, password = Auth.username_and_password_from_env in
+  let s = Atproto.Session.Session.create_session username password in
+  try
+    let page = Draft.get_drafts s ~limit:5 () in
+    OUnit2.assert_bool "drafts parsed" (List.length page.drafts >= 0)
+  with exn -> skip_if true ("getDrafts skipped: " ^ Printexc.to_string exn)
+
+let suite =
+  "draft"
+  >::: [
+         "test_parse_and_build" >:: test_parse_and_build;
+         "test_get_drafts_auth_skipped" >:: test_get_drafts_auth_skipped;
+       ]
+
+let () = run_test_tt_main suite

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -141,7 +141,17 @@ let test_validate_errors _ =
 
 let test_union_codegen_and_official_bundle _ =
   let docs = Lexicon.official_documents () in
-  OUnit2.assert_bool "bundled lexicons" (List.length docs >= 5);
+  OUnit2.assert_bool "bundled lexicons" (List.length docs >= 9);
+  OUnit2.assert_bool "getPostThreadV2 bundled"
+    (List.exists
+       (fun (d : Lexicon.document) ->
+         d.id = "app.bsky.unspecced.getPostThreadV2")
+       docs);
+  OUnit2.assert_bool "subscribeModEvents bundled"
+    (List.exists
+       (fun (d : Lexicon.document) ->
+         d.id = "chat.bsky.moderation.subscribeModEvents")
+       docs);
   List.iter
     (fun (doc : Lexicon.document) ->
       OUnit2.assert_equal 1 doc.lexicon;

--- a/test/test_unspecced.ml
+++ b/test/test_unspecced.ml
@@ -198,6 +198,134 @@ let test_parse_trends_and_skeletons _ =
   in
   OUnit2.assert_equal (Some "r2") dids.rec_id_str
 
+let test_parse_thread_v2 _ =
+  let item =
+    `Assoc
+      [
+        ( "uri",
+          `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
+        ("depth", `Int 0);
+        ( "value",
+          `Assoc
+            [
+              ("$type", `String "app.bsky.unspecced.defs#threadItemPost");
+              ( "post",
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+                    );
+                    ("cid", `String "bafyreihdummy");
+                    ( "author",
+                      `Assoc
+                        [
+                          ("did", `String "did:plc:abc123xyz0001112223333");
+                          ("handle", `String "alice.test");
+                        ] );
+                    ( "record",
+                      `Assoc
+                        [
+                          ("$type", `String "app.bsky.feed.post");
+                          ("text", `String "hello");
+                          ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                        ] );
+                    ("indexedAt", `String "2024-01-01T00:00:01.000Z");
+                  ] );
+              ("moreParents", `Bool false);
+              ("moreReplies", `Int 2);
+              ("opThread", `Bool true);
+              ("opThreadPostIndex", `Int 1);
+              ("opThreadPostCount", `Int 1);
+              ("hiddenByThreadgate", `Bool false);
+              ("mutedByViewer", `Bool false);
+            ] );
+      ]
+  in
+  let parsed = Unspecced.parse_thread_v2
+      (`Assoc
+        [
+          ("thread", `List [ item ]);
+          ("hasOtherReplies", `Bool true);
+          ( "threadgate",
+            `Assoc
+              [
+                ( "uri",
+                  `String
+                    "at://did:plc:abc123xyz0001112223333/app.bsky.feed.threadgate/3k"
+                );
+              ] );
+        ])
+  in
+  OUnit2.assert_equal true parsed.has_other_replies;
+  OUnit2.assert_equal 1 (List.length parsed.thread);
+  OUnit2.assert_equal 0 (List.hd parsed.thread).depth;
+  (match (List.hd parsed.thread).value with
+  | `Post p ->
+      OUnit2.assert_equal 2 p.more_replies;
+      OUnit2.assert_equal true p.op_thread;
+      OUnit2.assert_equal (Some 1) p.op_thread_post_index
+  | _ -> OUnit2.assert_failure "expected threadItemPost");
+  let blocked =
+    Unspecced.parse_thread_item
+      (`Assoc
+        [
+          ( "uri",
+            `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3m"
+          );
+          ("depth", `Int 1);
+          ( "value",
+            `Assoc
+              [
+                ("$type", `String "app.bsky.unspecced.defs#threadItemBlocked");
+                ( "author",
+                  `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
+                );
+              ] );
+        ])
+  in
+  (match blocked.value with
+  | `Blocked b ->
+      OUnit2.assert_equal (Some "did:plc:abc123xyz0001112223333") b.author_did
+  | _ -> OUnit2.assert_failure "expected blocked thread item");
+  let other =
+    Unspecced.parse_thread_other_v2 (`Assoc [ ("thread", `List [ item ]) ])
+  in
+  OUnit2.assert_equal 1 (List.length other.thread)
+
+let test_parse_discover_explore_see_more _ =
+  let users =
+    Unspecced.parse_suggested_users
+      (`Assoc
+        [
+          ( "actors",
+            `List
+              [
+                `Assoc
+                  [
+                    ("did", `String "did:plc:abc123xyz0001112223333");
+                    ("handle", `String "alice.test");
+                    ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+                    ("viewer", `Null);
+                  ];
+              ] );
+          ("recIdStr", `String "disc-1");
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length users.actors);
+  OUnit2.assert_equal (Some "disc-1") users.rec_id_str;
+  let skel =
+    Unspecced.parse_did_skeleton
+      (`Assoc
+        [
+          ("dids", `List [ `String "did:plc:abc123xyz0001112223333" ]);
+          ("recId", `String "old");
+          ("recIdStr", `String "new");
+        ])
+  in
+  OUnit2.assert_equal (Some "old") skel.rec_id;
+  OUnit2.assert_equal (Some "new") skel.rec_id_str
+
 let test_popular_live _ =
   try
     with_public_timeout (fun () ->
@@ -207,6 +335,22 @@ let test_popular_live _ =
           && String.length (List.hd gens.feeds).uri > 8))
   with exn ->
     skip_if true ("getPopularFeedGenerators skipped: " ^ Printexc.to_string exn)
+
+let test_get_post_thread_v2_live _ =
+  try
+    with_public_timeout (fun () ->
+        let page = Unspecced.search_posts_skeleton ~q:"atproto" ~limit:1 () in
+        match page.posts with
+        | [] -> skip_if true "no skeleton posts to thread"
+        | hd :: _ ->
+            let thread =
+              Unspecced.get_post_thread_v2 ~anchor:hd.uri ~below:2
+                ~branching_factor:3 ()
+            in
+            OUnit2.assert_bool "thread v2 items"
+              (List.length thread.thread >= 0))
+  with exn ->
+    skip_if true ("getPostThreadV2 skipped: " ^ Printexc.to_string exn)
 
 let test_search_posts_skeleton_live _ =
   try
@@ -229,7 +373,11 @@ let suite =
          "test_parse_popular" >:: test_parse_popular;
          "test_parse_tagged_and_age" >:: test_parse_tagged_and_age;
          "test_parse_trends_and_skeletons" >:: test_parse_trends_and_skeletons;
+         "test_parse_thread_v2" >:: test_parse_thread_v2;
+         "test_parse_discover_explore_see_more"
+         >:: test_parse_discover_explore_see_more;
          "test_popular_live" >:: test_popular_live;
+         "test_get_post_thread_v2_live" >:: test_get_post_thread_v2_live;
          "test_search_posts_skeleton_live" >:: test_search_posts_skeleton_live;
        ]
 

--- a/test/test_unspecced.ml
+++ b/test/test_unspecced.ml
@@ -242,7 +242,8 @@ let test_parse_thread_v2 _ =
             ] );
       ]
   in
-  let parsed = Unspecced.parse_thread_v2
+  let parsed =
+    Unspecced.parse_thread_v2
       (`Assoc
         [
           ("thread", `List [ item ]);
@@ -347,8 +348,7 @@ let test_get_post_thread_v2_live _ =
               Unspecced.get_post_thread_v2 ~anchor:hd.uri ~below:2
                 ~branching_factor:3 ()
             in
-            OUnit2.assert_bool "thread v2 items"
-              (List.length thread.thread >= 0))
+            OUnit2.assert_bool "thread v2 items" (List.length thread.thread >= 0))
   with exn ->
     skip_if true ("getPostThreadV2 skipped: " ^ Printexc.to_string exn)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Stacks the next library leftovers on PR #80 (`cursor/library-lexicon-gaps-ad72`) against current public lexicons. New branch — does not push to #80.

## What landed

- **`app.bsky.unspecced.getPostThreadV2` / `getPostThreadOtherV2`**: flat thread items with `#threadItemPost` / `#threadItemNoUnauthenticated` / `#threadItemNotFound` / `#threadItemBlocked` unions, `hasOtherReplies`, optional threadgate
- **Discover / explore / seeMore / onboarding suggestion variants** still missing after #80: `getSuggestedOnboardingUsers`, `getOnboardingSuggestedUsersSkeleton`, `getSuggestedUsersForDiscover` (+ skeleton), `getSuggestedUsersForExplore` (+ skeleton), `getSuggestedUsersForSeeMore` (+ skeleton)
- **`chat.bsky.moderation.subscribeModEvents`**: URL builder, JSON parsers for all 11 event kinds, framed-CBOR decode, optional authenticated subscribe (private operator firehose; no invented credentials)
- **`app.bsky.draft`**: create / get / update / delete + typed draft / embed / threadgate / postgate builders
- **`app.bsky.contact`**: phone verify, import, matches, dismiss, sync status, remove data, system notification body
- **`app.bsky.ageassurance`**: begin / getConfig / getState + region-rule union (distinct from the older unspecced AA endpoints)
- **Actor preferences**: remaining current-lexicon kinds (`savedFeedsPref`, personal details, declared age, feed/thread view, muted words, bsky app state, labelers, post-interaction rules, verification, live events). `original` JSON is still kept.

`Websocket` accepts optional extra handshake headers so the chat operator stream can send `Authorization` + `atproto-proxy`. Bundled official lexicon documents include the new NSIDs.

## Tests

`dune build` and `dune runtest` pass locally. Live/auth paths skip without `ATP_AUTH` (no invented credentials). Hosted OAuth/PDS/Tap/transcoder/LtHash remain skipped.

Action majors are unchanged (`actions/checkout@v4`, `ocaml/setup-ocaml@v3`, `actions/cache@v4`, `actions/upload-artifact@v4`).

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc2c03c7-7fc5-4117-82f3-ccd732af237c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc2c03c7-7fc5-4117-82f3-ccd732af237c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

