### PR TITLE
Add Ozone queue/report clients and remaining temp XRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, unspecced age-assurance state, suggestion / feed / starter-pack / onboarding / discover / explore / seeMore skeletons, `getPostThreadV2` / `getPostThreadOtherV2`, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
 | Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `getConvoMembers`; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
-| Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; requires `atproto-proxy` |
+| Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; `tools.ozone.queue.*` (list/create/update/delete, moderator assign, `routeReports`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration |
 | Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status, `getServiceAuth` (aud may be `did#service`) |
@@ -56,7 +56,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
 | AT URI | `At_uri` | `at://` parse / serialize |
 | Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas), `to_ocaml` codegen (unions emit polymorphic variants), JSON validate, `resolveLexicon` client, small bundled official lexicon documents |
-| Temp | `Temp` | `com.atproto.temp.checkHandleAvailability` (available / suggestions union) |
+| Temp | `Temp` | `com.atproto.temp.checkHandleAvailability` (available / suggestions union), `checkSignupQueue`, `dereferenceScope`, plus privileged `addReservedHandle` / `requestPhoneVerification` / `revokeAccountCredentials` clients (no invented operator session). Deprecated `fetchLabels` remains `Label.query_labels` |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
 | OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
 | Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) + `#selfLabels` |
@@ -84,12 +84,11 @@ These are product-level, not missing protocol cores:
 
 #70–#81 covered protocol core, AppView/chat/ozone, Jetstream, video, OAuth scopes, and thread v2 / drafts / contacts / remaining preference kinds.
 
-This PR fills remaining *library* gaps vs current public lexicons: `searchPostsV2` / `searchStarterPacksV2`, list/starter-pack membership queries, remaining `chat.bsky.group` join-link APIs + `getConvoMembers`, leftover record builders, `refreshIdentity`, `resolveLexicon`, `checkHandleAvailability`, and remaining Ozone operator namespaces (communication / set / setting / team / safelink / signature / verification / hosting).
+This stack fills remaining *library* XRPC vs current public lexicons: `tools.ozone.queue.*`, `tools.ozone.report.*`, and the remaining testable `com.atproto.temp.*` procedures/queries (`checkSignupQueue`, `dereferenceScope`, reserved-handle / phone-verification / revoke-credentials clients). Privileged Ozone/temp writes still need a real operator session and are not invented here.
 
 Still leftover vs current lexicons (not invented here):
 
-- `tools.ozone.queue.*` and `tools.ozone.report.*` operator workflows
-- `com.atproto.temp.*` besides `checkHandleAvailability` (reserved handles, signup queue, dereferenceScope, phone verification, revoke credentials)
+- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`)
 - `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (OAuth scope tokens, not XRPC clients)
 - `Http_client` H2 stub and unused `Request`/`Response` types
 

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -189,6 +189,29 @@ let () =
         ])
   in
   (match handle_check.result with `Available -> () | _ -> assert false);
+  let signup =
+    Temp.parse_signup_queue
+      (`Assoc [ ("activated", `Bool true); ("placeInQueue", `Int 1) ])
+  in
+  assert signup.activated;
+  let reserved = Temp.add_reserved_handle_body ~handle:"admin.bsky.social" () in
+  assert (
+    match Yojson.Safe.Util.member "handle" reserved with
+    | `String "admin.bsky.social" -> true
+    | _ -> false);
+  let queue_body =
+    Ozone.create_queue_body ~name:"spam" ~subject_types:[ "account" ] ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "name" queue_body with
+    | `String "spam" -> true
+    | _ -> false);
+  (match
+     Ozone.parse_report_activity
+       (`Assoc [ ("$type", `String "tools.ozone.report.defs#noteActivity") ])
+   with
+  | `Note -> ()
+  | _ -> assert false);
   let resolved =
     Lexicon.parse_resolved_lexicon
       (`Assoc

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -369,6 +369,24 @@ module Lexicon = struct
   let official_create_group =
     {|{"lexicon":1,"id":"chat.bsky.group.createGroup","defs":{"main":{"type":"procedure","description":"Creates a group convo.","input":{"encoding":"application/json","schema":{"type":"object","required":["members","name"],"properties":{"members":{"type":"array"},"name":{"type":"string"}}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["convo"],"properties":{"convo":{"type":"ref","ref":"chat.bsky.convo.defs#convoView"}}}}}}}|}
 
+  let official_list_queues =
+    {|{"lexicon":1,"id":"tools.ozone.queue.listQueues","defs":{"main":{"type":"query","description":"List all configured moderation queues with statistics.","parameters":{"type":"params","properties":{"enabled":{"type":"boolean"},"limit":{"type":"integer"},"cursor":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["queues"],"properties":{"queues":{"type":"array"},"cursor":{"type":"string"}}}}}}}|}
+
+  let official_create_queue =
+    {|{"lexicon":1,"id":"tools.ozone.queue.createQueue","defs":{"main":{"type":"procedure","description":"Create a new moderation queue.","input":{"encoding":"application/json","schema":{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"subjectTypes":{"type":"array"},"reportTypes":{"type":"array"}}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["queue"],"properties":{"queue":{"type":"ref","ref":"tools.ozone.queue.defs#queueView"}}}}}}}|}
+
+  let official_query_reports =
+    {|{"lexicon":1,"id":"tools.ozone.report.queryReports","defs":{"main":{"type":"query","description":"View moderation reports.","parameters":{"type":"params","required":["status"],"properties":{"status":{"type":"string"},"queueId":{"type":"integer"},"limit":{"type":"integer"},"cursor":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["reports"],"properties":{"reports":{"type":"array"},"cursor":{"type":"string"}}}}}}}|}
+
+  let official_check_signup =
+    {|{"lexicon":1,"id":"com.atproto.temp.checkSignupQueue","defs":{"main":{"type":"query","description":"Check accounts location in signup queue.","output":{"encoding":"application/json","schema":{"type":"object","required":["activated"],"properties":{"activated":{"type":"boolean"},"placeInQueue":{"type":"integer"},"estimatedTimeMs":{"type":"integer"}}}}}}}|}
+
+  let official_deref_scope =
+    {|{"lexicon":1,"id":"com.atproto.temp.dereferenceScope","defs":{"main":{"type":"query","description":"Allows finding the oauth permission scope from a reference.","parameters":{"type":"params","required":["scope"],"properties":{"scope":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["scope"],"properties":{"scope":{"type":"string"}}}}}}}|}
+
+  let official_revoke_creds =
+    {|{"lexicon":1,"id":"com.atproto.temp.revokeAccountCredentials","defs":{"main":{"type":"procedure","description":"Revoke sessions, password, and app passwords associated with account.","input":{"encoding":"application/json","schema":{"type":"object","required":["account"],"properties":{"account":{"type":"string"}}}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -385,6 +403,12 @@ module Lexicon = struct
       ("com.atproto.lexicon.resolveLexicon", official_resolve_lexicon);
       ("com.atproto.temp.checkHandleAvailability", official_check_handle);
       ("chat.bsky.group.createGroup", official_create_group);
+      ("tools.ozone.queue.listQueues", official_list_queues);
+      ("tools.ozone.queue.createQueue", official_create_queue);
+      ("tools.ozone.report.queryReports", official_query_reports);
+      ("com.atproto.temp.checkSignupQueue", official_check_signup);
+      ("com.atproto.temp.dereferenceScope", official_deref_scope);
+      ("com.atproto.temp.revokeAccountCredentials", official_revoke_creds);
     ]
 
   let official_documents () : document list =

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -697,9 +697,6 @@ module Ozone = struct
       (Yojson.Safe.to_string (`Assoc fields))
     |> parse_batch_result
 
-  (* Remaining operator namespaces: communication, set, setting, team,
-     safelink, signature, verification, hosting. *)
-
   type template = {
     id : string;
     name : string;
@@ -1258,4 +1255,644 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor
       @ Client.opt_int "limit" limit)
     |> parse_account_history
+
+  (* tools.ozone.queue.* and tools.ozone.report.* operator workflows. *)
+
+  let int_list json field =
+    List.filter_map
+      (function
+        | `Int n -> Some n
+        | `Intlit s -> ( try Some (int_of_string s) with _ -> None)
+        | _ -> None)
+      (Client.list_member json field)
+
+  let repeat_int key values =
+    Client.repeat_param key (List.map string_of_int values)
+
+  let opt_json_int k = function Some n -> [ (k, `Int n) ] | None -> []
+  let opt_json_str k = function Some s -> [ (k, `String s) ] | None -> []
+  let opt_json_bool k = function Some b -> [ (k, `Bool b) ] | None -> []
+  let json_strings xs = `List (List.map (fun s -> `String s) xs)
+  let json_ints xs = `List (List.map (fun n -> `Int n) xs)
+
+  type queue_stats = {
+    pending_count : int option;
+    actioned_count : int option;
+    escalated_count : int option;
+    inbound_count : int option;
+    action_rate : int option;
+    avg_handling_time_sec : int option;
+    last_updated : string option;
+  }
+
+  type queue_view = {
+    id : int;
+    name : string;
+    subject_types : string list;
+    collection : string option;
+    report_types : string list;
+    description : string option;
+    recommended_policies : string list;
+    created_by : string option;
+    created_at : string option;
+    updated_at : string option;
+    enabled : bool option;
+    deleted_at : string option;
+    stats : queue_stats option;
+    original : Yojson.Safe.t;
+  }
+
+  type queues = { cursor : string option; queues : queue_view list }
+
+  type assignment_view = {
+    id : int option;
+    did : string;
+    report_id : int option;
+    start_at : string option;
+    end_at : string option;
+    queue : queue_view option;
+    original : Yojson.Safe.t;
+  }
+
+  type assignments = {
+    cursor : string option;
+    assignments : assignment_view list;
+  }
+
+  type delete_queue_result = { deleted : bool; reports_migrated : int option }
+  type route_reports_result = { assigned : int; unmatched : int }
+
+  let parse_queue_stats json : queue_stats =
+    {
+      pending_count = Client.int_opt json "pendingCount";
+      actioned_count = Client.int_opt json "actionedCount";
+      escalated_count = Client.int_opt json "escalatedCount";
+      inbound_count = Client.int_opt json "inboundCount";
+      action_rate = Client.int_opt json "actionRate";
+      avg_handling_time_sec = Client.int_opt json "avgHandlingTimeSec";
+      last_updated = Client.string_opt json "lastUpdated";
+    }
+
+  let parse_queue_view json : queue_view =
+    {
+      id = Client.int_member json "id";
+      name = Client.string_member json "name";
+      subject_types = string_list json "subjectTypes";
+      collection = Client.string_opt json "collection";
+      report_types = string_list json "reportTypes";
+      description = Client.string_opt json "description";
+      recommended_policies = string_list json "recommendedPolicies";
+      created_by = Client.string_opt json "createdBy";
+      created_at = Client.string_opt json "createdAt";
+      updated_at = Client.string_opt json "updatedAt";
+      enabled = Client.bool_opt json "enabled";
+      deleted_at = Client.string_opt json "deletedAt";
+      stats =
+        (match Yojson.Safe.Util.member "stats" json with
+        | `Assoc _ as s -> Some (parse_queue_stats s)
+        | _ -> None);
+      original = json;
+    }
+
+  let parse_queue_result json : queue_view =
+    match Yojson.Safe.Util.member "queue" json with
+    | `Assoc _ as q -> parse_queue_view q
+    | _ -> parse_queue_view json
+
+  let parse_queues json : queues =
+    {
+      cursor = Client.string_opt json "cursor";
+      queues = List.map parse_queue_view (Client.list_member json "queues");
+    }
+
+  let parse_assignment_view json : assignment_view =
+    {
+      id = Client.int_opt json "id";
+      did = Client.string_member json "did";
+      report_id = Client.int_opt json "reportId";
+      start_at = Client.string_opt json "startAt";
+      end_at = Client.string_opt json "endAt";
+      queue =
+        (match Yojson.Safe.Util.member "queue" json with
+        | `Assoc _ as q -> Some (parse_queue_view q)
+        | _ -> None);
+      original = json;
+    }
+
+  let parse_assignments json : assignments =
+    {
+      cursor = Client.string_opt json "cursor";
+      assignments =
+        List.map parse_assignment_view (Client.list_member json "assignments");
+    }
+
+  let parse_delete_queue_result json : delete_queue_result =
+    {
+      deleted = Client.bool_member json "deleted";
+      reports_migrated = Client.int_opt json "reportsMigrated";
+    }
+
+  let parse_route_reports_result json : route_reports_result =
+    {
+      assigned = Client.int_member json "assigned";
+      unmatched = Client.int_member json "unmatched";
+    }
+
+  let create_queue_body ~name ?(subject_types = []) ?collection
+      ?(report_types = []) ?description ?(recommended_policies = []) () :
+      Yojson.Safe.t =
+    `Assoc
+      (("name", `String name)
+       ::
+       (match subject_types with
+       | [] -> []
+       | xs -> [ ("subjectTypes", json_strings xs) ])
+      @ opt_json_str "collection" collection
+      @ (match report_types with
+        | [] -> []
+        | xs -> [ ("reportTypes", json_strings xs) ])
+      @ opt_json_str "description" description
+      @
+      match recommended_policies with
+      | [] -> []
+      | xs -> [ ("recommendedPolicies", json_strings xs) ])
+
+  let update_queue_body ~queue_id ?name ?enabled ?description
+      ?recommended_policies () : Yojson.Safe.t =
+    `Assoc
+      ((("queueId", `Int queue_id) :: opt_json_str "name" name)
+      @ opt_json_bool "enabled" enabled
+      @ opt_json_str "description" description
+      @
+      match recommended_policies with
+      | Some xs -> [ ("recommendedPolicies", json_strings xs) ]
+      | None -> [])
+
+  let delete_queue_body ~queue_id ?migrate_to_queue_id () : Yojson.Safe.t =
+    `Assoc
+      (("queueId", `Int queue_id)
+      :: opt_json_int "migrateToQueueId" migrate_to_queue_id)
+
+  let list_queues (s : Session.session) ~proxy ?enabled ?subject_type
+      ?collection ?(report_types = []) ?limit ?cursor () : queues =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.listQueues"
+      (Client.opt_bool "enabled" enabled
+      @ Client.opt_pair "subjectType" subject_type
+      @ Client.opt_pair "collection" collection
+      @ Client.repeat_param "reportTypes" report_types
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_queues
+
+  let create_queue (s : Session.session) ~proxy ~name ?subject_types ?collection
+      ?report_types ?description ?recommended_policies () : queue_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.createQueue"
+      (Yojson.Safe.to_string
+         (create_queue_body ~name ?subject_types ?collection ?report_types
+            ?description ?recommended_policies ()))
+    |> parse_queue_result
+
+  let update_queue (s : Session.session) ~proxy ~queue_id ?name ?enabled
+      ?description ?recommended_policies () : queue_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.updateQueue"
+      (Yojson.Safe.to_string
+         (update_queue_body ~queue_id ?name ?enabled ?description
+            ?recommended_policies ()))
+    |> parse_queue_result
+
+  let delete_queue (s : Session.session) ~proxy ~queue_id ?migrate_to_queue_id
+      () : delete_queue_result =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.deleteQueue"
+      (Yojson.Safe.to_string
+         (delete_queue_body ~queue_id ?migrate_to_queue_id ()))
+    |> parse_delete_queue_result
+
+  let assign_queue_moderator (s : Session.session) ~proxy ~queue_id ~did () :
+      assignment_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.assignModerator"
+      (Yojson.Safe.to_string
+         (`Assoc [ ("queueId", `Int queue_id); ("did", `String did) ]))
+    |> parse_assignment_view
+
+  let unassign_queue_moderator (s : Session.session) ~proxy ~queue_id ~did () :
+      unit =
+    ignore
+      (Client.post_json ~session:s ~extra:(proxy_headers proxy)
+         "tools.ozone.queue.unassignModerator"
+         (Yojson.Safe.to_string
+            (`Assoc [ ("queueId", `Int queue_id); ("did", `String did) ])))
+
+  let get_queue_assignments (s : Session.session) ~proxy ?only_active
+      ?(queue_ids = []) ?(dids = []) ?limit ?cursor () : assignments =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.getAssignments"
+      (Client.opt_bool "onlyActive" only_active
+      @ repeat_int "queueIds" queue_ids
+      @ Client.repeat_param "dids" dids
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_assignments
+
+  let route_reports (s : Session.session) ~proxy ~start_report_id ~end_report_id
+      () : route_reports_result =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.queue.routeReports"
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("startReportId", `Int start_report_id);
+             ("endReportId", `Int end_report_id);
+           ]))
+    |> parse_route_reports_result
+
+  type report_activity =
+    [ `Queue of string option
+    | `Assignment of string option
+    | `Escalation of string option
+    | `Close of string option
+    | `Reopen of string option
+    | `Note
+    | `Unknown of unknown_event ]
+
+  type report_assignment = {
+    did : string;
+    assigned_at : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type report_view = {
+    id : int;
+    event_id : int option;
+    status : string;
+    subject : Yojson.Safe.t;
+    report_type : string;
+    reported_by : string option;
+    comment : string option;
+    created_at : string option;
+    updated_at : string option;
+    queued_at : string option;
+    action_event_ids : int list;
+    action_note : string option;
+    related_report_count : int option;
+    assignment : report_assignment option;
+    queue : queue_view option;
+    is_muted : bool option;
+    is_automated : bool option;
+    original : Yojson.Safe.t;
+  }
+
+  type reports = { cursor : string option; reports : report_view list }
+
+  type report_activity_view = {
+    id : int option;
+    report_id : int option;
+    activity : report_activity;
+    internal_note : string option;
+    public_note : string option;
+    meta : Yojson.Safe.t option;
+    is_automated : bool option;
+    created_by : string option;
+    created_at : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type report_activities = {
+    cursor : string option;
+    activities : report_activity_view list;
+  }
+
+  type report_stats = {
+    date : string option;
+    pending_count : int option;
+    actioned_count : int option;
+    escalated_count : int option;
+    inbound_count : int option;
+    action_rate : int option;
+    avg_handling_time_sec : int option;
+    last_updated : string option;
+    computed_at : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type historical_stats = { cursor : string option; stats : report_stats list }
+  type close_reports_result = { closed_count : int; report_ids : int list }
+
+  let report_reason name = "tools.ozone.report.defs#" ^ name
+  let reason_appeal = report_reason "reasonAppeal"
+  let reason_other = report_reason "reasonOther"
+  let reason_violence_threats = report_reason "reasonViolenceThreats"
+  let reason_misleading_spam = report_reason "reasonMisleadingSpam"
+
+  let parse_report_activity json : report_activity =
+    let t = type_name json in
+    let previous = Client.string_opt json "previousStatus" in
+    if ends_with "queueActivity" t then `Queue previous
+    else if ends_with "assignmentActivity" t then `Assignment previous
+    else if ends_with "escalationActivity" t then `Escalation previous
+    else if ends_with "closeActivity" t then `Close previous
+    else if ends_with "reopenActivity" t then `Reopen previous
+    else if ends_with "noteActivity" t then `Note
+    else `Unknown { type_ = t; original = json }
+
+  let parse_report_assignment json : report_assignment =
+    {
+      did = Client.string_member json "did";
+      assigned_at = Client.string_opt json "assignedAt";
+      original = json;
+    }
+
+  let parse_report_view json : report_view =
+    {
+      id = Client.int_member json "id";
+      event_id = Client.int_opt json "eventId";
+      status = Client.string_member json "status";
+      subject = Yojson.Safe.Util.member "subject" json;
+      report_type = Client.string_member json "reportType";
+      reported_by = Client.string_opt json "reportedBy";
+      comment = Client.string_opt json "comment";
+      created_at = Client.string_opt json "createdAt";
+      updated_at = Client.string_opt json "updatedAt";
+      queued_at = Client.string_opt json "queuedAt";
+      action_event_ids = int_list json "actionEventIds";
+      action_note = Client.string_opt json "actionNote";
+      related_report_count = Client.int_opt json "relatedReportCount";
+      assignment =
+        (match Yojson.Safe.Util.member "assignment" json with
+        | `Assoc _ as a -> Some (parse_report_assignment a)
+        | _ -> None);
+      queue =
+        (match Yojson.Safe.Util.member "queue" json with
+        | `Assoc _ as q -> Some (parse_queue_view q)
+        | _ -> None);
+      is_muted = Client.bool_opt json "isMuted";
+      is_automated = Client.bool_opt json "isAutomated";
+      original = json;
+    }
+
+  let parse_report_result json : report_view =
+    match Yojson.Safe.Util.member "report" json with
+    | `Assoc _ as r -> parse_report_view r
+    | _ -> parse_report_view json
+
+  let parse_reports json : reports =
+    {
+      cursor = Client.string_opt json "cursor";
+      reports = List.map parse_report_view (Client.list_member json "reports");
+    }
+
+  let parse_report_activity_view json : report_activity_view =
+    {
+      id = Client.int_opt json "id";
+      report_id = Client.int_opt json "reportId";
+      activity =
+        (match Yojson.Safe.Util.member "activity" json with
+        | `Assoc _ as a -> parse_report_activity a
+        | other -> `Unknown { type_ = ""; original = other });
+      internal_note = Client.string_opt json "internalNote";
+      public_note = Client.string_opt json "publicNote";
+      meta =
+        (match Yojson.Safe.Util.member "meta" json with
+        | `Null -> None
+        | other -> Some other);
+      is_automated = Client.bool_opt json "isAutomated";
+      created_by = Client.string_opt json "createdBy";
+      created_at = Client.string_opt json "createdAt";
+      original = json;
+    }
+
+  let parse_activity_result json : report_activity_view =
+    match Yojson.Safe.Util.member "activity" json with
+    | `Assoc _ as a -> parse_report_activity_view a
+    | _ -> parse_report_activity_view json
+
+  let parse_report_activities json : report_activities =
+    {
+      cursor = Client.string_opt json "cursor";
+      activities =
+        List.map parse_report_activity_view
+          (Client.list_member json "activities");
+    }
+
+  let parse_report_stats json : report_stats =
+    {
+      date = Client.string_opt json "date";
+      pending_count = Client.int_opt json "pendingCount";
+      actioned_count = Client.int_opt json "actionedCount";
+      escalated_count = Client.int_opt json "escalatedCount";
+      inbound_count = Client.int_opt json "inboundCount";
+      action_rate = Client.int_opt json "actionRate";
+      avg_handling_time_sec = Client.int_opt json "avgHandlingTimeSec";
+      last_updated = Client.string_opt json "lastUpdated";
+      computed_at = Client.string_opt json "computedAt";
+      original = json;
+    }
+
+  let parse_live_stats json : report_stats =
+    match Yojson.Safe.Util.member "stats" json with
+    | `Assoc _ as s -> parse_report_stats s
+    | _ -> parse_report_stats json
+
+  let parse_historical_stats json : historical_stats =
+    {
+      cursor = Client.string_opt json "cursor";
+      stats = List.map parse_report_stats (Client.list_member json "stats");
+    }
+
+  let parse_close_reports_result json : close_reports_result =
+    {
+      closed_count = Client.int_member json "closedCount";
+      report_ids = int_list json "reportIds";
+    }
+
+  let activity_json kind ?previous_status () : Yojson.Safe.t =
+    `Assoc
+      (("$type", `String ("tools.ozone.report.defs#" ^ kind))
+      :: opt_json_str "previousStatus" previous_status)
+
+  let queue_activity ?previous_status () =
+    activity_json "queueActivity" ?previous_status ()
+
+  let assignment_activity ?previous_status () =
+    activity_json "assignmentActivity" ?previous_status ()
+
+  let escalation_activity ?previous_status () =
+    activity_json "escalationActivity" ?previous_status ()
+
+  let close_activity ?previous_status () =
+    activity_json "closeActivity" ?previous_status ()
+
+  let reopen_activity ?previous_status () =
+    activity_json "reopenActivity" ?previous_status ()
+
+  let note_activity () = activity_json "noteActivity" ()
+
+  let create_activity_body ~activity ?report_id ?event_id ?internal_note
+      ?public_note ?is_automated () : Yojson.Safe.t =
+    `Assoc
+      ((("activity", activity) :: opt_json_int "reportId" report_id)
+      @ opt_json_int "eventId" event_id
+      @ opt_json_str "internalNote" internal_note
+      @ opt_json_str "publicNote" public_note
+      @ opt_json_bool "isAutomated" is_automated)
+
+  let query_reports (s : Session.session) ~proxy ~status ?queue_id
+      ?(report_types = []) ?subject ?did ?subject_type ?(collections = [])
+      ?reported_after ?reported_before ?is_muted ?assigned_to ?sort_field
+      ?sort_direction ?limit ?cursor () : reports =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.queryReports"
+      ((("status", status) :: Client.opt_int "queueId" queue_id)
+      @ Client.repeat_param "reportTypes" report_types
+      @ Client.opt_pair "subject" subject
+      @ Client.opt_pair "did" did
+      @ Client.opt_pair "subjectType" subject_type
+      @ Client.repeat_param "collections" collections
+      @ Client.opt_pair "reportedAfter" reported_after
+      @ Client.opt_pair "reportedBefore" reported_before
+      @ Client.opt_bool "isMuted" is_muted
+      @ Client.opt_pair "assignedTo" assigned_to
+      @ Client.opt_pair "sortField" sort_field
+      @ Client.opt_pair "sortDirection" sort_direction
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_reports
+
+  let get_report (s : Session.session) ~proxy ~id () : report_view =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.getReport"
+      [ ("id", string_of_int id) ]
+    |> parse_report_result
+
+  let get_latest_report (s : Session.session) ~proxy () : report_view =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.getLatestReport" []
+    |> parse_report_result
+
+  let assign_report_moderator (s : Session.session) ~proxy ~report_id ?queue_id
+      ?did ?is_permanent () : assignment_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.assignModerator"
+      (Yojson.Safe.to_string
+         (`Assoc
+           ((("reportId", `Int report_id) :: opt_json_int "queueId" queue_id)
+           @ opt_json_str "did" did
+           @ opt_json_bool "isPermanent" is_permanent)))
+    |> parse_assignment_view
+
+  let unassign_report_moderator (s : Session.session) ~proxy ~report_id () :
+      assignment_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.unassignModerator"
+      (Yojson.Safe.to_string (`Assoc [ ("reportId", `Int report_id) ]))
+    |> parse_assignment_view
+
+  let get_report_assignments (s : Session.session) ~proxy ?only_active
+      ?(report_ids = []) ?(dids = []) ?limit ?cursor () : assignments =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.getAssignments"
+      (Client.opt_bool "onlyActive" only_active
+      @ repeat_int "reportIds" report_ids
+      @ Client.repeat_param "dids" dids
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_assignments
+
+  let create_activity (s : Session.session) ~proxy ~activity ?report_id
+      ?event_id ?internal_note ?public_note ?is_automated () :
+      report_activity_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.createActivity"
+      (Yojson.Safe.to_string
+         (create_activity_body ~activity ?report_id ?event_id ?internal_note
+            ?public_note ?is_automated ()))
+    |> parse_activity_result
+
+  let list_activities (s : Session.session) ~proxy ~report_id ?limit ?cursor ()
+      : report_activities =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.listActivities"
+      ((("reportId", string_of_int report_id) :: Client.opt_int "limit" limit)
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_report_activities
+
+  let query_activities (s : Session.session) ~proxy ?(activity_types = [])
+      ?created_after ?created_before ?sort_direction ?limit ?cursor () :
+      report_activities =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.queryActivities"
+      (Client.repeat_param "activityTypes" activity_types
+      @ Client.opt_pair "createdAfter" created_after
+      @ Client.opt_pair "createdBefore" created_before
+      @ Client.opt_pair "sortDirection" sort_direction
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_report_activities
+
+  let reassign_queue (s : Session.session) ~proxy ~report_id ~queue_id ?comment
+      () : report_view =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.reassignQueue"
+      (Yojson.Safe.to_string
+         (`Assoc
+           (("reportId", `Int report_id)
+           :: ("queueId", `Int queue_id)
+           :: opt_json_str "comment" comment)))
+    |> parse_report_result
+
+  let refresh_stats (s : Session.session) ~proxy ~start_date ~end_date
+      ?queue_ids () : unit =
+    ignore
+      (Client.post_json ~session:s ~extra:(proxy_headers proxy)
+         "tools.ozone.report.refreshStats"
+         (Yojson.Safe.to_string
+            (`Assoc
+              (("startDate", `String start_date)
+              :: ("endDate", `String end_date)
+              ::
+              (match queue_ids with
+              | Some xs -> [ ("queueIds", json_ints xs) ]
+              | None -> [])))))
+
+  let close_reports (s : Session.session) ~proxy ~subject ?(report_types = [])
+      ?internal_note ?is_automated () : close_reports_result =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.closeReports"
+      (Yojson.Safe.to_string
+         (`Assoc
+           (("subject", `String subject)
+            ::
+            (match report_types with
+            | [] -> []
+            | xs -> [ ("reportTypes", json_strings xs) ])
+           @ opt_json_str "internalNote" internal_note
+           @ opt_json_bool "isAutomated" is_automated)))
+    |> parse_close_reports_result
+
+  let get_live_stats (s : Session.session) ~proxy ?queue_id ?moderator_did
+      ?(report_types = []) () : report_stats =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.getLiveStats"
+      (Client.opt_int "queueId" queue_id
+      @ Client.opt_pair "moderatorDid" moderator_did
+      @ Client.repeat_param "reportTypes" report_types)
+    |> parse_live_stats
+
+  let get_historical_stats (s : Session.session) ~proxy ?queue_id ?moderator_did
+      ?(report_types = []) ?start_date ?end_date ?limit ?cursor () :
+      historical_stats =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.report.getHistoricalStats"
+      (Client.opt_int "queueId" queue_id
+      @ Client.opt_pair "moderatorDid" moderator_did
+      @ Client.repeat_param "reportTypes" report_types
+      @ Client.opt_pair "startDate" start_date
+      @ Client.opt_pair "endDate" end_date
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_historical_stats
 end

--- a/src/temp.ml
+++ b/src/temp.ml
@@ -54,4 +54,64 @@ module Temp = struct
       ((("handle", handle) :: Client.opt_pair "email" email)
       @ Client.opt_pair "birthDate" birth_date)
     |> parse_handle_check
+
+  type signup_queue = {
+    activated : bool;
+    place_in_queue : int option;
+    estimated_time_ms : int option;
+    original : Yojson.Safe.t;
+  }
+
+  type scope_deref = { scope : string; original : Yojson.Safe.t }
+
+  let parse_signup_queue json : signup_queue =
+    {
+      activated = Client.bool_member json "activated";
+      place_in_queue = Client.int_opt json "placeInQueue";
+      estimated_time_ms = Client.int_opt json "estimatedTimeMs";
+      original = json;
+    }
+
+  let parse_scope_deref json : scope_deref =
+    { scope = Client.string_member json "scope"; original = json }
+
+  let check_signup_queue ?session ?host () : signup_queue =
+    Client.get_json ?session ?host "com.atproto.temp.checkSignupQueue" []
+    |> parse_signup_queue
+
+  let dereference_scope ?session ?host ~scope () : scope_deref =
+    Client.get_json ?session ?host "com.atproto.temp.dereferenceScope"
+      [ ("scope", scope) ]
+    |> parse_scope_deref
+
+  let add_reserved_handle_body ~handle () : Yojson.Safe.t =
+    `Assoc [ ("handle", `String handle) ]
+
+  let request_phone_verification_body ~phone_number () : Yojson.Safe.t =
+    `Assoc [ ("phoneNumber", `String phone_number) ]
+
+  let revoke_account_credentials_body ~account () : Yojson.Safe.t =
+    `Assoc [ ("account", `String account) ]
+
+  (* Privileged / hosted-PDS flows: clients only. Live calls need a real
+     operator session and are not invented here. fetchLabels is deprecated
+     in favor of Label.query_labels. *)
+
+  let add_reserved_handle ?session ?host ~handle () : unit =
+    ignore
+      (Client.post_json ?session ?host "com.atproto.temp.addReservedHandle"
+         (Yojson.Safe.to_string (add_reserved_handle_body ~handle ())))
+
+  let request_phone_verification ?session ?host ~phone_number () : unit =
+    ignore
+      (Client.post_json ?session ?host
+         "com.atproto.temp.requestPhoneVerification"
+         (Yojson.Safe.to_string
+            (request_phone_verification_body ~phone_number ())))
+
+  let revoke_account_credentials ?session ?host ~account () : unit =
+    ignore
+      (Client.post_json ?session ?host
+         "com.atproto.temp.revokeAccountCredentials"
+         (Yojson.Safe.to_string (revoke_account_credentials_body ~account ())))
 end

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -141,7 +141,20 @@ let test_validate_errors _ =
 
 let test_union_codegen_and_official_bundle _ =
   let docs = Lexicon.official_documents () in
-  OUnit2.assert_bool "bundled lexicons" (List.length docs >= 14);
+  OUnit2.assert_bool "bundled lexicons" (List.length docs >= 20);
+  OUnit2.assert_bool "listQueues bundled"
+    (List.exists
+       (fun (d : Lexicon.document) -> d.id = "tools.ozone.queue.listQueues")
+       docs);
+  OUnit2.assert_bool "queryReports bundled"
+    (List.exists
+       (fun (d : Lexicon.document) -> d.id = "tools.ozone.report.queryReports")
+       docs);
+  OUnit2.assert_bool "checkSignupQueue bundled"
+    (List.exists
+       (fun (d : Lexicon.document) ->
+         d.id = "com.atproto.temp.checkSignupQueue")
+       docs);
   OUnit2.assert_bool "searchPostsV2 bundled"
     (List.exists
        (fun (d : Lexicon.document) -> d.id = "app.bsky.feed.searchPostsV2")

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -277,6 +277,137 @@ let test_operator_namespace_parsers _ =
     "Hello"
     (body |> member "name" |> to_string)
 
+let test_parse_queue_and_report _ =
+  let queues =
+    Ozone.parse_queues
+      (`Assoc
+        [
+          ( "queues",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `Int 7);
+                    ("name", `String "spam");
+                    ("subjectTypes", `List [ `String "account" ]);
+                    ( "reportTypes",
+                      `List [ `String Ozone.reason_misleading_spam ] );
+                    ("enabled", `Bool true);
+                    ( "stats",
+                      `Assoc
+                        [
+                          ("pendingCount", `Int 3);
+                          ("inboundCount", `Int 10);
+                          ("actionRate", `Int 40);
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length queues.queues);
+  OUnit2.assert_equal ~printer:(fun x -> x) "spam" (List.hd queues.queues).name;
+  OUnit2.assert_equal (Some 3)
+    (Option.bind (List.hd queues.queues).stats (fun s -> s.pending_count));
+  let body =
+    Ozone.create_queue_body ~name:"spam" ~subject_types:[ "account" ]
+      ~report_types:[ Ozone.reason_misleading_spam ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "spam"
+    (body |> member "name" |> to_string);
+  let routed =
+    Ozone.parse_route_reports_result
+      (`Assoc [ ("assigned", `Int 4); ("unmatched", `Int 1) ])
+  in
+  OUnit2.assert_equal 4 routed.assigned;
+  let report =
+    Ozone.parse_report_result
+      (`Assoc
+        [
+          ( "report",
+            `Assoc
+              [
+                ("id", `Int 11);
+                ("eventId", `Int 99);
+                ("status", `String "open");
+                ("reportType", `String Ozone.reason_violence_threats);
+                ("reportedBy", `String "did:plc:reporter000111222333444555");
+                ("comment", `String "threat");
+                ( "subject",
+                  `Assoc
+                    [
+                      ("$type", `String "com.atproto.admin.defs#repoRef");
+                      ("did", `String "did:plc:abc123xyz0001112223333");
+                    ] );
+                ( "assignment",
+                  `Assoc
+                    [
+                      ("did", `String "did:plc:mod000111222333444555666");
+                      ("assignedAt", `String "2024-01-01T00:00:00.000Z");
+                    ] );
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 11 report.id;
+  OUnit2.assert_equal ~printer:(fun x -> x) "open" report.status;
+  OUnit2.assert_equal (Some "did:plc:mod000111222333444555666")
+    (Option.map (fun (a : Ozone.report_assignment) -> a.did) report.assignment);
+  let activity =
+    Ozone.parse_report_activity
+      (`Assoc
+        [
+          ("$type", `String "tools.ozone.report.defs#closeActivity");
+          ("previousStatus", `String "assigned");
+        ])
+  in
+  (match activity with
+  | `Close (Some "assigned") -> ()
+  | _ -> OUnit2.assert_failure "expected closeActivity");
+  let create_body =
+    Ozone.create_activity_body ~activity:(Ozone.note_activity ()) ~report_id:11
+      ~internal_note:"looks resolved" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "tools.ozone.report.defs#noteActivity"
+    (create_body |> member "activity" |> member "$type" |> to_string);
+  let closed =
+    Ozone.parse_close_reports_result
+      (`Assoc
+        [ ("closedCount", `Int 2); ("reportIds", `List [ `Int 11; `Int 12 ]) ])
+  in
+  OUnit2.assert_equal 2 closed.closed_count;
+  let live =
+    Ozone.parse_live_stats
+      (`Assoc
+        [
+          ( "stats",
+            `Assoc [ ("pendingCount", `Int 5); ("inboundCount", `Int 9) ] );
+        ])
+  in
+  OUnit2.assert_equal (Some 5) live.pending_count;
+  let hist =
+    Ozone.parse_historical_stats
+      (`Assoc
+        [
+          ( "stats",
+            `List
+              [
+                `Assoc
+                  [ ("date", `String "2024-01-01"); ("actionedCount", `Int 8) ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal (Some "2024-01-01") (List.hd hist.stats).date;
+  let deleted =
+    Ozone.parse_delete_queue_result
+      (`Assoc [ ("deleted", `Bool true); ("reportsMigrated", `Int 2) ])
+  in
+  OUnit2.assert_equal true deleted.deleted
+
 let test_query_statuses_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -289,6 +420,18 @@ let test_query_statuses_auth_skipped _ =
     OUnit2.assert_bool "statuses parsed" (List.length page.subject_statuses >= 0)
   with exn -> skip_if true ("queryStatuses skipped: " ^ Printexc.to_string exn)
 
+let test_list_queues_auth_skipped _ =
+  skip_if
+    (not Auth.has_live_credentials)
+    "ATP_AUTH not configured; live Bluesky test skipped";
+  let username, password = Auth.username_and_password_from_env in
+  let s = Atproto.Session.Session.create_session username password in
+  try
+    let proxy = Ozone.labeler_proxy "did:plc:ar7c4by46qjdydhdevvrndac" in
+    let page = Ozone.list_queues s ~proxy ~limit:1 () in
+    OUnit2.assert_bool "queues parsed" (List.length page.queues >= 0)
+  with exn -> skip_if true ("listQueues skipped: " ^ Printexc.to_string exn)
+
 let suite =
   "ozone"
   >::: [
@@ -300,7 +443,9 @@ let suite =
          "test_parse_typed_event_and_subject"
          >:: test_parse_typed_event_and_subject;
          "test_query_statuses_auth_skipped" >:: test_query_statuses_auth_skipped;
+         "test_list_queues_auth_skipped" >:: test_list_queues_auth_skipped;
          "test_operator_namespace_parsers" >:: test_operator_namespace_parsers;
+         "test_parse_queue_and_report" >:: test_parse_queue_and_report;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_temp.ml
+++ b/test/test_temp.ml
@@ -63,6 +63,47 @@ let test_parse_unavailable _ =
       OUnit2.assert_equal ~printer:(fun x -> x) "jay2.bsky.social" s.handle
   | _ -> OUnit2.assert_failure "expected unavailable suggestions"
 
+let test_parse_signup_and_scope _ =
+  let queue =
+    Temp.parse_signup_queue
+      (`Assoc
+        [
+          ("activated", `Bool true);
+          ("placeInQueue", `Int 12);
+          ("estimatedTimeMs", `Int 45000);
+        ])
+  in
+  OUnit2.assert_equal true queue.activated;
+  OUnit2.assert_equal (Some 12) queue.place_in_queue;
+  let deref =
+    Temp.parse_scope_deref
+      (`Assoc [ ("scope", `String "atproto repo:app.bsky.feed.post") ])
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "atproto repo:app.bsky.feed.post" deref.scope;
+  let reserved = Temp.add_reserved_handle_body ~handle:"admin.bsky.social" () in
+  let phone =
+    Temp.request_phone_verification_body ~phone_number:"+15555550100" ()
+  in
+  let revoke =
+    Temp.revoke_account_credentials_body
+      ~account:"did:plc:abc123xyz0001112223333" ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "admin.bsky.social"
+    (reserved |> member "handle" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "+15555550100"
+    (phone |> member "phoneNumber" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:abc123xyz0001112223333"
+    (revoke |> member "account" |> to_string)
+
 let test_check_handle_live _ =
   try
     with_public_timeout (fun () ->
@@ -72,12 +113,33 @@ let test_check_handle_live _ =
   with exn ->
     skip_if true ("checkHandleAvailability skipped: " ^ Printexc.to_string exn)
 
+let test_check_signup_queue_live _ =
+  try
+    with_public_timeout (fun () ->
+        let queue = Temp.check_signup_queue ~host:"bsky.social" () in
+        OUnit2.assert_bool "activated parsed" (queue.activated || true))
+  with exn ->
+    skip_if true ("checkSignupQueue skipped: " ^ Printexc.to_string exn)
+
+let test_dereference_scope_live _ =
+  try
+    with_public_timeout (fun () ->
+        let deref =
+          Temp.dereference_scope ~host:"bsky.social" ~scope:"ref:example" ()
+        in
+        OUnit2.assert_bool "scope parsed" (String.length deref.scope > 0))
+  with exn ->
+    skip_if true ("dereferenceScope skipped: " ^ Printexc.to_string exn)
+
 let suite =
   "temp"
   >::: [
          "test_parse_available" >:: test_parse_available;
          "test_parse_unavailable" >:: test_parse_unavailable;
+         "test_parse_signup_and_scope" >:: test_parse_signup_and_scope;
          "test_check_handle_live" >:: test_check_handle_live;
+         "test_check_signup_queue_live" >:: test_check_signup_queue_live;
+         "test_dereference_scope_live" >:: test_dereference_scope_live;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #82 (`cursor/library-remaining-lexicons-e99f`). Verified leftover official lexicons in [bluesky-social/atproto](https://github.com/bluesky-social/atproto/tree/main/lexicons) and implemented the remaining **library** XRPC clients only — no hosted OAuth/PDS/Tap/transcoder/LtHash, no invented credentials, Action majors unchanged.

## New client surfaces

- **Ozone queues** (`tools.ozone.queue.*`): `listQueues`, `createQueue`, `updateQueue`, `deleteQueue`, assign/unassign moderator, `getAssignments`, `routeReports`, plus typed `queueView` / stats / assignment parsers and request bodies
- **Ozone reports** (`tools.ozone.report.*`): `queryReports`, `getReport`, `getLatestReport`, assign/unassign/reassign, `createActivity` + typed activity union, `listActivities` / `queryActivities`, `closeReports`, live/historical stats + `refreshStats`
- **Temp XRPC** (`com.atproto.temp.*`): `checkSignupQueue`, `dereferenceScope`, and privileged clients for `addReservedHandle` / `requestPhoneVerification` / `revokeAccountCredentials` (body builders + POST; no live SMS or operator session invented)
- Bundled official lexicon documents for the new NSIDs

Skipped on purpose:

- Deprecated `com.atproto.temp.fetchLabels` (use existing `Label.query_labels`)
- Hosted-PDS product flows that cannot be tested without operator credentials
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (not XRPC)

## Tests

Local `dune build` and `dune runtest` pass on this branch.

- `test_ozone`: 10 cases, 2 skipped (no `ATP_AUTH` / no live Ozone operator session)
- `test_temp`: 6 cases, 2 skipped (`checkSignupQueue` / `dereferenceScope` when the public call fails)
- `test_lexicon`: 7 cases, including the new bundled NSIDs
- `examples/offline` typechecks the new queue/report/temp fixtures

Fixture parsers/builders cover queue/report views, activity unions, stats, and temp request bodies. Privileged writes are not live-called.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-465b60a4-3fdc-402e-9e8b-4813da4dc48f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-465b60a4-3fdc-402e-9e8b-4813da4dc48f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

