### PR TITLE
Add site.standard/germnetwork records, leftover admin XRPC, and HTTP/2 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
 | Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
-| HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST, method enum |
+| HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST (Cohttp), **HTTP/2 TLS** GET/POST via `Http_client` that returns status + headers (rate-limit / `atproto-repo-rev`). Requires HTTPS + ALPN `h2` |
+| Sites | `Site` | Official `site.standard` records: document, publication, theme.basic/color, graph recommend + subscription |
+| Germ Network | `Germnetwork` | `com.germnetwork.declaration` record (`$bytes` keys, `messageMe` policy) |
 
 ## Remaining gaps
 
@@ -82,15 +84,18 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-#70–#81 covered protocol core, AppView/chat/ozone, Jetstream, video, OAuth scopes, and thread v2 / drafts / contacts / remaining preference kinds.
+#70–#83 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, and ozone queue/report.
 
-This stack fills remaining *library* XRPC vs current public lexicons: `tools.ozone.queue.*`, `tools.ozone.report.*`, and the remaining testable `com.atproto.temp.*` procedures/queries (`checkSignupQueue`, `dereferenceScope`, reserved-handle / phone-verification / revoke-credentials clients). Privileged Ozone/temp writes still need a real operator session and are not invented here.
+This stack fills remaining *library* gaps vs current public lexicons: `site.standard.*` records, `com.germnetwork.declaration`, leftover `com.atproto.admin` procedures (`getInviteCodes`, `disableInviteCodes`, `deleteAccount`, `updateAccountEmail` / `Handle` / `Password` / `SigningKey`), `tools.ozone.safelink.queryEvents`, and `chat.bsky.embed.joinLink`. `Http_client` is a real HTTP/2 TLS transport (not a stub) that keeps status and response headers.
+
+Privileged admin/ozone writes still need a real operator session and are not invented here.
 
 Still leftover vs current lexicons (not invented here):
 
 - Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`)
+- Deprecated `com.atproto.sync.getCheckout` / `getHead` (use `getRepo` / `getLatestCommit`)
 - `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (OAuth scope tokens, not XRPC clients)
-- `Http_client` H2 stub and unused `Request`/`Response` types
+- `internal.bsky.actor.getProfiles` (service-to-service AppView query, not a public client surface)
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 
@@ -174,4 +179,15 @@ let bookmarks = Bookmark.get_bookmarks session ~limit:10 ()
 (* chat + ozone always need atproto-proxy (defaults shown) *)
 let convos = Chat.list_convos session ~limit:10 ()
 let chat_status = Chat.get_actor_status session ()
+
+(* site.standard + germnetwork records — local builders, no network *)
+let article =
+  Site.document ~site:"https://standard.site" ~title:"hello"
+    ~published_at:"2026-01-01T00:00:00.000Z" ()
+let germ = Germnetwork.declaration ~version:"1.0.0" ~current_key:"key" ()
+
+(* HTTP/2 XRPC GET that keeps status + rate-limit headers (skips if ALPN h2 fails) *)
+let _h2 =
+  Http_client.xrpc_url ~host:"public.api.bsky.app"
+    "com.atproto.identity.resolveHandle" ~query:[ ("handle", "bsky.app") ] ()
 ```

--- a/atproto.opam
+++ b/atproto.opam
@@ -45,14 +45,17 @@ available: arch != "arm32" & arch != "x86_32"
 synopsis: "OCaml toolkit for the AT Protocol"
 description: """
 OCaml client and protocol library for the AT Protocol (XRPC, lexicons,
-repo sync, identity, AppView, Ozone, and chat).
+repo sync, identity, AppView, Ozone, chat, site.standard, and
+com.germnetwork records). An HTTP/2 TLS client is included for XRPC
+calls that need status and response headers.
 
 Public modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video,
 Unspecced, Labeler, Chat, Ozone, Admin, Repo, Repo_sync, Server, Identity,
 Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
 Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact,
-Ageassurance, and Moderation.
+Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and
+Response.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -32,6 +32,12 @@ open Atproto.Varint
 open Atproto.Syntax
 open Atproto.Temp
 open Atproto.Graph
+open Atproto.Site
+open Atproto.Germnetwork
+open Atproto.Admin
+open Atproto.Request
+open Atproto.Response
+open Atproto.Http_client
 
 let () =
   (* TID used as record keys and commit revs *)
@@ -510,6 +516,45 @@ let () =
   assert (Cid.is_blessed (Cid.create "{\"v\":1}"));
   let start, finish = Mst.collection_range "app.bsky.feed.post" in
   assert (start = "app.bsky.feed.post/" && finish = "app.bsky.feed.post0");
+  let site_doc =
+    Site.document ~site:"https://standard.site" ~title:"Notes"
+      ~published_at:"2026-01-01T00:00:00.000Z" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" site_doc with
+    | `String "site.standard.document" -> true
+    | _ -> false);
+  let germ =
+    Germnetwork.declaration ~version:"1.0.0" ~current_key:"key-bytes" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" germ with
+    | `String "com.germnetwork.declaration" -> true
+    | _ -> false);
+  let signing =
+    Admin.update_account_signing_key_body ~did:"did:plc:abc123xyz0001112223333"
+      ~signing_key:"did:key:z6Mkexample" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "did" signing with
+    | `String _ -> true
+    | _ -> false);
+  (match Embed.join_link ~code:"join-1" () with
+  | `JoinLink e -> assert (e.code = "join-1")
+  | _ -> assert false);
+  let req =
+    Request.get
+      (Http_client.xrpc_url ~host:"public.api.bsky.app"
+         "com.atproto.identity.resolveHandle"
+         ~query:[ ("handle", "bsky.app") ]
+         ())
+      ()
+  in
+  assert (req.url <> "");
+  let parsed = Http_client.parse_url req.url in
+  assert (parsed.host = "public.api.bsky.app");
+  let fake = Response.of_string ~status_code:200 "{}" in
+  assert fake.success;
   let jss_hdr =
     Jetstream.Jss.parse_header
       (Jetstream.Jss.encode_header

--- a/src/admin.ml
+++ b/src/admin.ml
@@ -207,4 +207,113 @@ module Admin = struct
     Client.post_json ~session:s "com.atproto.admin.sendEmail"
       (Yojson.Safe.to_string
          (send_email_body ~recipient_did ~content ?subject ?sender_did ()))
+
+  type invite_code_use = { used_by : string; used_at : string }
+
+  type invite_code = {
+    code : string;
+    available : int;
+    disabled : bool;
+    for_account : string;
+    created_by : string;
+    created_at : string;
+    uses : invite_code_use list;
+    original : Yojson.Safe.t;
+  }
+
+  type invite_codes = { cursor : string option; codes : invite_code list }
+
+  let parse_invite_code_use json : invite_code_use =
+    {
+      used_by = Client.string_member json "usedBy";
+      used_at = Client.string_member json "usedAt";
+    }
+
+  let parse_invite_code json : invite_code =
+    {
+      code = Client.string_member json "code";
+      available = Client.int_member json "available";
+      disabled = Client.bool_member json "disabled";
+      for_account = Client.string_member json "forAccount";
+      created_by = Client.string_member json "createdBy";
+      created_at = Client.string_member json "createdAt";
+      uses = List.map parse_invite_code_use (Client.list_member json "uses");
+      original = json;
+    }
+
+  let parse_invite_codes json : invite_codes =
+    {
+      cursor = Client.string_opt json "cursor";
+      codes = List.map parse_invite_code (Client.list_member json "codes");
+    }
+
+  let disable_invite_codes_body ?(codes = []) ?(accounts = []) () :
+      Yojson.Safe.t =
+    let fields =
+      (match codes with
+      | [] -> []
+      | xs -> [ ("codes", `List (List.map (fun s -> `String s) xs)) ])
+      @
+      match accounts with
+      | [] -> []
+      | xs -> [ ("accounts", `List (List.map (fun s -> `String s) xs)) ]
+    in
+    `Assoc fields
+
+  let delete_account_body ~did () : Yojson.Safe.t =
+    `Assoc [ ("did", `String did) ]
+
+  let update_account_email_body ~account ~email () : Yojson.Safe.t =
+    `Assoc [ ("account", `String account); ("email", `String email) ]
+
+  let update_account_handle_body ~did ~handle () : Yojson.Safe.t =
+    `Assoc [ ("did", `String did); ("handle", `String handle) ]
+
+  let update_account_password_body ~did ~password () : Yojson.Safe.t =
+    `Assoc [ ("did", `String did); ("password", `String password) ]
+
+  let update_account_signing_key_body ~did ~signing_key () : Yojson.Safe.t =
+    `Assoc [ ("did", `String did); ("signingKey", `String signing_key) ]
+
+  let get_invite_codes (s : Session.session) ?sort ?limit ?cursor () :
+      invite_codes =
+    Client.get_json ~session:s "com.atproto.admin.getInviteCodes"
+      (Client.opt_pair "sort" sort
+      @ Client.opt_int "limit" limit
+      @ Client.opt_pair "cursor" cursor)
+    |> parse_invite_codes
+
+  let disable_invite_codes (s : Session.session) ?(codes = []) ?(accounts = [])
+      () : unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.disableInviteCodes"
+         (Yojson.Safe.to_string (disable_invite_codes_body ~codes ~accounts ())))
+
+  let delete_account (s : Session.session) ~did () : unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.deleteAccount"
+         (Yojson.Safe.to_string (delete_account_body ~did ())))
+
+  let update_account_email (s : Session.session) ~account ~email () : unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.updateAccountEmail"
+         (Yojson.Safe.to_string (update_account_email_body ~account ~email ())))
+
+  let update_account_handle (s : Session.session) ~did ~handle () : unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.updateAccountHandle"
+         (Yojson.Safe.to_string (update_account_handle_body ~did ~handle ())))
+
+  let update_account_password (s : Session.session) ~did ~password () : unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.updateAccountPassword"
+         (Yojson.Safe.to_string
+            (update_account_password_body ~did ~password ())))
+
+  let update_account_signing_key (s : Session.session) ~did ~signing_key () :
+      unit =
+    ignore
+      (Client.post_json ~session:s "com.atproto.admin.updateAccountSigningKey"
+         (Yojson.Safe.to_string
+            (update_account_signing_key_body ~did ~signing_key ())))
 end

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -76,6 +76,12 @@ module Embed = struct
   }
 
   type gallery_embed = { embed_type : string; items : gallery_image list }
+  type join_link_embed = { embed_type : string; code : string }
+
+  type join_link_view_embed = {
+    embed_type : string;
+    join_link_preview : Yojson.Safe.t;
+  }
 
   type gallery_view_image = {
     thumbnail : string;
@@ -159,6 +165,8 @@ module Embed = struct
     | `VideoView of video_view_embed
     | `Gallery of gallery_embed
     | `GalleryView of gallery_view_embed
+    | `JoinLink of join_link_embed
+    | `JoinLinkView of join_link_view_embed
     | `Unknown of Yojson.Safe.t ]
 
   type embed_external_view = {
@@ -538,6 +546,20 @@ module Embed = struct
     then parse_to_correct_external_type json
     else if typ = "app.bsky.embed.external#view" then
       `ExternalView (parse_ext_view_embed json)
+    else if
+      typ = "chat.bsky.embed.joinLink" || typ = "chat.bsky.embed.joinLink#main"
+    then
+      `JoinLink
+        {
+          embed_type = (if typ = "" then "chat.bsky.embed.joinLink" else typ);
+          code = string_member json "code";
+        }
+    else if typ = "chat.bsky.embed.joinLink#view" then
+      `JoinLinkView
+        {
+          embed_type = typ;
+          join_link_preview = Yojson.Safe.Util.member "joinLinkPreview" json;
+        }
     else if check_for_field "images" json then parse_to_correct_image_type json
     else if check_for_field "items" json then parse_to_correct_gallery_type json
     else if check_for_field "external" json then
@@ -556,6 +578,9 @@ module Embed = struct
       then `RecordView (parse_record_view_embed json)
       else `Record (parse_record_embed json)
     else `Unknown json
+
+  let join_link ~code () : embed =
+    `JoinLink { embed_type = "chat.bsky.embed.joinLink"; code }
 
   let parse_embed_option json : embed option =
     let open Yojson.Safe.Util in
@@ -764,6 +789,24 @@ module Embed = struct
                      in
                      `Assoc fields)
                    e.items) );
+          ]
+    | `JoinLink (e : join_link_embed) ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "chat.bsky.embed.joinLink"
+                 else e.embed_type) );
+            ("code", `String e.code);
+          ]
+    | `JoinLinkView (e : join_link_view_embed) ->
+        `Assoc
+          [
+            ( "$type",
+              `String
+                (if e.embed_type = "" then "chat.bsky.embed.joinLink#view"
+                 else e.embed_type) );
+            ("joinLinkPreview", e.join_link_preview);
           ]
     | `Unknown json -> json
 

--- a/src/bsky/site.ml
+++ b/src/bsky/site.ml
@@ -1,0 +1,354 @@
+open Embed
+open Label
+
+(** Typed builders and parsers for official `site.standard.*` records. *)
+module Site = struct
+  let nsid_document = "site.standard.document"
+  let nsid_publication = "site.standard.publication"
+  let nsid_recommend = "site.standard.graph.recommend"
+  let nsid_subscription = "site.standard.graph.subscription"
+  let nsid_theme_basic = "site.standard.theme.basic"
+  let nsid_theme_color_rgb = "site.standard.theme.color#rgb"
+  let nsid_theme_color_rgba = "site.standard.theme.color#rgba"
+
+  type contributor = {
+    did : string;
+    display_name : string option;
+    role : string option;
+  }
+
+  type rgb = { r : int; g : int; b : int }
+  type rgba = { r : int; g : int; b : int; a : int }
+  type color = [ `Rgb of rgb | `Rgba of rgba | `Unknown of Yojson.Safe.t ]
+
+  type theme = {
+    background : color;
+    foreground : color;
+    accent : color;
+    accent_foreground : color;
+  }
+
+  type preferences = { show_in_discover : bool option }
+
+  type document = {
+    site : string;
+    title : string;
+    published_at : string;
+    path : string option;
+    description : string option;
+    text_content : string option;
+    tags : string list;
+    contributors : contributor list;
+    updated_at : string option;
+    bsky_post_ref : Embed.strong_ref option;
+    self_labels : string list option;
+    cover_image : Yojson.Safe.t option;
+    content : Yojson.Safe.t option;
+    links : Yojson.Safe.t option;
+  }
+
+  type publication = {
+    url : string;
+    name : string;
+    description : string option;
+    icon : Yojson.Safe.t option;
+    self_labels : string list option;
+    basic_theme : theme option;
+    preferences : preferences option;
+  }
+
+  type recommend = { document : string; created_at : string }
+  type subscription = { publication : string; created_at : string option }
+
+  let string_member json field =
+    match Yojson.Safe.Util.member field json with `String s -> s | _ -> ""
+
+  let string_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
+  let int_member json field =
+    match Yojson.Safe.Util.member field json with
+    | `Int n -> n
+    | `Intlit s -> ( try int_of_string s with _ -> 0)
+    | _ -> 0
+
+  let bool_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `Bool b -> Some b
+    | _ -> None
+
+  let list_member json field =
+    match Yojson.Safe.Util.member field json with `List xs -> xs | _ -> []
+
+  let contributor ~did ?display_name ?role () : contributor =
+    { did; display_name; role }
+
+  let contributor_to_json (c : contributor) : Yojson.Safe.t =
+    let fields =
+      ("did", `String c.did)
+      ::
+      (match c.display_name with
+      | Some s -> [ ("displayName", `String s) ]
+      | None -> [])
+      @ match c.role with Some s -> [ ("role", `String s) ] | None -> []
+    in
+    `Assoc fields
+
+  let parse_contributor json : contributor =
+    {
+      did = string_member json "did";
+      display_name = string_opt json "displayName";
+      role = string_opt json "role";
+    }
+
+  let rgb ~r ~g ~b : rgb = { r; g; b }
+  let rgba ~r ~g ~b ~a : rgba = { r; g; b; a }
+
+  let color_to_json (c : color) : Yojson.Safe.t =
+    match c with
+    | `Rgb c ->
+        `Assoc
+          [
+            ("$type", `String nsid_theme_color_rgb);
+            ("r", `Int c.r);
+            ("g", `Int c.g);
+            ("b", `Int c.b);
+          ]
+    | `Rgba c ->
+        `Assoc
+          [
+            ("$type", `String nsid_theme_color_rgba);
+            ("r", `Int c.r);
+            ("g", `Int c.g);
+            ("b", `Int c.b);
+            ("a", `Int c.a);
+          ]
+    | `Unknown json -> json
+
+  let parse_color (json : Yojson.Safe.t) : color =
+    let ty = string_opt json "$type" in
+    let has_a =
+      match Yojson.Safe.Util.member "a" json with
+      | `Int _ | `Intlit _ -> true
+      | _ -> false
+    in
+    match ty with
+    | Some t when t = nsid_theme_color_rgba || String.ends_with ~suffix:"rgba" t
+      ->
+        `Rgba
+          {
+            r = int_member json "r";
+            g = int_member json "g";
+            b = int_member json "b";
+            a = int_member json "a";
+          }
+    | Some t when t = nsid_theme_color_rgb || String.ends_with ~suffix:"rgb" t
+      ->
+        `Rgb
+          {
+            r = int_member json "r";
+            g = int_member json "g";
+            b = int_member json "b";
+          }
+    | _ when has_a ->
+        `Rgba
+          {
+            r = int_member json "r";
+            g = int_member json "g";
+            b = int_member json "b";
+            a = int_member json "a";
+          }
+    | _ -> (
+        match Yojson.Safe.Util.member "r" json with
+        | `Int _ | `Intlit _ ->
+            `Rgb
+              {
+                r = int_member json "r";
+                g = int_member json "g";
+                b = int_member json "b";
+              }
+        | _ -> `Unknown json)
+
+  let theme ~background ~foreground ~accent ~accent_foreground : theme =
+    { background; foreground; accent; accent_foreground }
+
+  let theme_to_json (t : theme) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String nsid_theme_basic);
+        ("background", color_to_json t.background);
+        ("foreground", color_to_json t.foreground);
+        ("accent", color_to_json t.accent);
+        ("accentForeground", color_to_json t.accent_foreground);
+      ]
+
+  let parse_theme json : theme =
+    {
+      background = parse_color (Yojson.Safe.Util.member "background" json);
+      foreground = parse_color (Yojson.Safe.Util.member "foreground" json);
+      accent = parse_color (Yojson.Safe.Util.member "accent" json);
+      accent_foreground =
+        parse_color (Yojson.Safe.Util.member "accentForeground" json);
+    }
+
+  let theme_basic ~background ~foreground ~accent ~accent_foreground () :
+      Yojson.Safe.t =
+    theme_to_json (theme ~background ~foreground ~accent ~accent_foreground)
+
+  let document ~site ~title ~published_at ?path ?description ?text_content
+      ?(tags = []) ?(contributors = []) ?updated_at ?bsky_post_ref ?self_labels
+      ?cover_image ?content ?links () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_document);
+        ("site", `String site);
+        ("title", `String title);
+        ("publishedAt", `String published_at);
+      ]
+      @ (match path with Some s -> [ ("path", `String s) ] | None -> [])
+      @ (match description with
+        | Some s -> [ ("description", `String s) ]
+        | None -> [])
+      @ (match text_content with
+        | Some s -> [ ("textContent", `String s) ]
+        | None -> [])
+      @ (match tags with
+        | [] -> []
+        | xs -> [ ("tags", `List (List.map (fun s -> `String s) xs)) ])
+      @ (match contributors with
+        | [] -> []
+        | xs -> [ ("contributors", `List (List.map contributor_to_json xs)) ])
+      @ (match updated_at with
+        | Some s -> [ ("updatedAt", `String s) ]
+        | None -> [])
+      @ (match bsky_post_ref with
+        | Some r -> [ ("bskyPostRef", Embed.strong_ref_to_json r) ]
+        | None -> [])
+      @ (match self_labels with
+        | Some xs -> [ ("labels", Label.self_labels_to_json xs) ]
+        | None -> [])
+      @ (match cover_image with Some b -> [ ("coverImage", b) ] | None -> [])
+      @ (match content with Some c -> [ ("content", c) ] | None -> [])
+      @ match links with Some l -> [ ("links", l) ] | None -> []
+    in
+    `Assoc fields
+
+  let parse_document json : document =
+    {
+      site = string_member json "site";
+      title = string_member json "title";
+      published_at = string_member json "publishedAt";
+      path = string_opt json "path";
+      description = string_opt json "description";
+      text_content = string_opt json "textContent";
+      tags =
+        List.filter_map
+          (function `String s -> Some s | _ -> None)
+          (list_member json "tags");
+      contributors =
+        List.map parse_contributor (list_member json "contributors");
+      updated_at = string_opt json "updatedAt";
+      bsky_post_ref =
+        (match Yojson.Safe.Util.member "bskyPostRef" json with
+        | `Assoc _ as r -> Some (Embed.parse_strong_ref r)
+        | _ -> None);
+      self_labels =
+        Label.parse_self_labels (Yojson.Safe.Util.member "labels" json);
+      cover_image =
+        (match Yojson.Safe.Util.member "coverImage" json with
+        | `Null | `Assoc [] -> None
+        | (`Assoc _ | `String _) as b -> Some b
+        | _ -> None);
+      content =
+        (match Yojson.Safe.Util.member "content" json with
+        | `Null -> None
+        | j -> Some j);
+      links =
+        (match Yojson.Safe.Util.member "links" json with
+        | `Null -> None
+        | j -> Some j);
+    }
+
+  let publication ~url ~name ?description ?icon ?self_labels ?basic_theme
+      ?show_in_discover () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_publication);
+        ("url", `String url);
+        ("name", `String name);
+      ]
+      @ (match description with
+        | Some s -> [ ("description", `String s) ]
+        | None -> [])
+      @ (match icon with Some b -> [ ("icon", b) ] | None -> [])
+      @ (match self_labels with
+        | Some xs -> [ ("labels", Label.self_labels_to_json xs) ]
+        | None -> [])
+      @ (match basic_theme with
+        | Some t -> [ ("basicTheme", theme_to_json t) ]
+        | None -> [])
+      @
+      match show_in_discover with
+      | Some b -> [ ("preferences", `Assoc [ ("showInDiscover", `Bool b) ]) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let parse_publication json : publication =
+    {
+      url = string_member json "url";
+      name = string_member json "name";
+      description = string_opt json "description";
+      icon =
+        (match Yojson.Safe.Util.member "icon" json with
+        | `Null | `Assoc [] -> None
+        | (`Assoc _ | `String _) as b -> Some b
+        | _ -> None);
+      self_labels =
+        Label.parse_self_labels (Yojson.Safe.Util.member "labels" json);
+      basic_theme =
+        (match Yojson.Safe.Util.member "basicTheme" json with
+        | `Assoc _ as t -> Some (parse_theme t)
+        | _ -> None);
+      preferences =
+        (match Yojson.Safe.Util.member "preferences" json with
+        | `Assoc _ as p ->
+            Some { show_in_discover = bool_opt p "showInDiscover" }
+        | _ -> None);
+    }
+
+  let recommend ~document ~created_at () : Yojson.Safe.t =
+    `Assoc
+      [
+        ("$type", `String nsid_recommend);
+        ("document", `String document);
+        ("createdAt", `String created_at);
+      ]
+
+  let parse_recommend json : recommend =
+    {
+      document = string_member json "document";
+      created_at = string_member json "createdAt";
+    }
+
+  let subscription ~publication ?created_at () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_subscription);
+        ("publication", `String publication);
+      ]
+      @
+      match created_at with
+      | Some s -> [ ("createdAt", `String s) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let parse_subscription json : subscription =
+    {
+      publication = string_member json "publication";
+      created_at = string_opt json "createdAt";
+    }
+end

--- a/src/dune
+++ b/src/dune
@@ -52,6 +52,7 @@
   Facet
   Feed
   Firehose
+  Germnetwork
   Graph
   Hash
   Http_client
@@ -75,6 +76,7 @@
   Response
   Server
   Session
+  Site
   Sync
   Syntax
   Temp

--- a/src/germnetwork.ml
+++ b/src/germnetwork.ml
@@ -1,0 +1,88 @@
+open Label
+open Base64url
+
+(** Typed builder/parser for `com.germnetwork.declaration`. *)
+module Germnetwork = struct
+  let nsid_declaration = "com.germnetwork.declaration"
+  let show_none = "none"
+  let show_users_i_follow = "usersIFollow"
+  let show_everyone = "everyone"
+
+  type message_me = { show_button_to : string; message_me_url : string }
+
+  type declaration = {
+    version : string;
+    current_key : string;
+    message_me : message_me option;
+    key_package : string option;
+    continuity_proofs : string list;
+  }
+
+  let bytes_to_json (raw : string) : Yojson.Safe.t =
+    `Assoc [ ("$bytes", `String (Base64url.encode_std raw)) ]
+
+  let bytes_of_json json : string option = Label.bytes_of_json json
+
+  let message_me ~show_button_to ~message_me_url : message_me =
+    { show_button_to; message_me_url }
+
+  let message_me_to_json (m : message_me) : Yojson.Safe.t =
+    `Assoc
+      [
+        ("showButtonTo", `String m.show_button_to);
+        ("messageMeUrl", `String m.message_me_url);
+      ]
+
+  let parse_message_me json : message_me =
+    {
+      show_button_to =
+        (match Yojson.Safe.Util.member "showButtonTo" json with
+        | `String s -> s
+        | _ -> show_none);
+      message_me_url =
+        (match Yojson.Safe.Util.member "messageMeUrl" json with
+        | `String s -> s
+        | _ -> "");
+    }
+
+  let declaration ~version ~current_key ?message_me ?key_package
+      ?(continuity_proofs = []) () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_declaration);
+        ("version", `String version);
+        ("currentKey", bytes_to_json current_key);
+      ]
+      @ (match message_me with
+        | Some m -> [ ("messageMe", message_me_to_json m) ]
+        | None -> [])
+      @ (match key_package with
+        | Some k -> [ ("keyPackage", bytes_to_json k) ]
+        | None -> [])
+      @
+      match continuity_proofs with
+      | [] -> []
+      | xs -> [ ("continuityProofs", `List (List.map bytes_to_json xs)) ]
+    in
+    `Assoc fields
+
+  let parse_declaration json : declaration =
+    {
+      version =
+        (match Yojson.Safe.Util.member "version" json with
+        | `String s -> s
+        | _ -> "");
+      current_key =
+        Option.value ~default:""
+          (bytes_of_json (Yojson.Safe.Util.member "currentKey" json));
+      message_me =
+        (match Yojson.Safe.Util.member "messageMe" json with
+        | `Assoc _ as m -> Some (parse_message_me m)
+        | _ -> None);
+      key_package = bytes_of_json (Yojson.Safe.Util.member "keyPackage" json);
+      continuity_proofs =
+        (match Yojson.Safe.Util.member "continuityProofs" json with
+        | `List xs -> List.filter_map bytes_of_json xs
+        | _ -> []);
+    }
+end

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -109,84 +109,82 @@ module Http_client = struct
           (H2.Error_code.to_string code)
           msg
 
-  let perform ~timeout (req : Request.request) : Response.response Lwt.t =
+  let close_socket socket =
+    Lwt.catch (fun () -> Lwt_unix.close socket) (fun _ -> Lwt.return_unit)
+
+  let ssl_connect ~host socket =
+    let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context in
+    Ssl.set_context_alpn_protos ctx [ "h2" ];
+    let uninit = Lwt_ssl.embed_uninitialized_socket socket ctx in
+    let ssl = Lwt_ssl.ssl_socket_of_uninitialized_socket uninit in
+    Ssl.set_client_SNI_hostname ssl host;
+    Lwt_ssl.ssl_perform_handshake uninit
+
+  let exchange ~host ~port (req : Request.request) parsed socket :
+      Response.response Lwt.t =
+    let error_p, error_w = Lwt.wait () in
+    let error_handler err =
+      if Lwt.is_sleeping error_p then
+        Lwt.wakeup_exn error_w (Error (error_message err))
+    in
+    ssl_connect ~host socket >>= fun ssl_socket ->
+    H2_lwt_unix.Client.SSL.create_connection ~error_handler ssl_socket
+    >>= fun connection ->
+    let response_p, response_w = Lwt.wait () in
+    let response_handler (response : H2.Response.t) body =
+      let buf = Buffer.create 4096 in
+      let rec read_response () =
+        H2.Body.Reader.schedule_read body
+          ~on_read:(fun bigstr ~off ~len ->
+            Buffer.add_string buf (Bigstringaf.substring bigstr ~off ~len);
+            read_response ())
+          ~on_eof:(fun () ->
+            if Lwt.is_sleeping response_p then
+              let status = H2.Status.to_code response.H2.Response.status in
+              Lwt.wakeup_later response_w
+                (Response.of_string ~status_code:status
+                   ~headers:(headers_to_list response.H2.Response.headers)
+                   (Buffer.contents buf)))
+      in
+      read_response ()
+    in
+    let h2_req =
+      H2.Request.create (h2_meth req.method_) parsed.path ~scheme:"https"
+        ~headers:(request_headers ~host ~port req.headers)
+    in
+    let writer =
+      H2_lwt_unix.Client.SSL.request connection h2_req ~error_handler
+        ~response_handler
+    in
+    (match req.body with
+    | Some data when data <> "" -> H2.Body.Writer.write_string writer data
+    | _ -> ());
+    H2.Body.Writer.close writer;
+    (* Do not wait on HTTP/2 GOAWAY — persistent connections never shut down
+       promptly and would block Lwt_main.run. *)
+    let _ = connection in
+    Lwt.pick [ response_p; error_p ]
+
+  let perform (req : Request.request) : Response.response Lwt.t =
     let parsed = parse_url req.url in
     get_addr_info parsed.host parsed.port >>= fun addrs ->
-    if addrs = [] then Lwt.fail (Error ("DNS lookup failed for " ^ parsed.host))
-    else
-      let rec try_addrs = function
-        | [] -> Lwt.fail (Error ("HTTP/2 connect failed for " ^ parsed.host))
-        | addr_info :: rest ->
-            let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-            Lwt.catch
-              (fun () ->
-                Lwt.pick
-                  [
-                    ( Lwt_unix.sleep timeout >>= fun () ->
-                      Lwt.fail (Error "HTTP/2 connect timed out") );
-                    ( Lwt_unix.connect socket addr_info.Unix.ai_addr
-                    >>= fun () ->
-                      let error_p, error_w = Lwt.wait () in
-                      let error_handler err =
-                        if Lwt.is_sleeping error_p then
-                          Lwt.wakeup_exn error_w (Error (error_message err))
-                      in
-                      H2_lwt_unix.Client.TLS.create_connection_with_default
-                        ~error_handler socket
-                      >>= fun connection ->
-                      let response_p, response_w = Lwt.wait () in
-                      let response_handler (response : H2.Response.t) body =
-                        let buf = Buffer.create 4096 in
-                        let rec read_response () =
-                          H2.Body.Reader.schedule_read body
-                            ~on_read:(fun bigstr ~off ~len ->
-                              Buffer.add_string buf
-                                (Bigstringaf.substring bigstr ~off ~len);
-                              read_response ())
-                            ~on_eof:(fun () ->
-                              if Lwt.is_sleeping response_p then
-                                let status =
-                                  H2.Status.to_code response.H2.Response.status
-                                in
-                                Lwt.wakeup_later response_w
-                                  (Response.of_string ~status_code:status
-                                     ~headers:
-                                       (headers_to_list
-                                          response.H2.Response.headers)
-                                     (Buffer.contents buf)))
-                        in
-                        read_response ()
-                      in
-                      let h2_req =
-                        H2.Request.create (h2_meth req.method_) parsed.path
-                          ~scheme:"https"
-                          ~headers:
-                            (request_headers ~host:parsed.host ~port:parsed.port
-                               req.headers)
-                      in
-                      let writer =
-                        H2_lwt_unix.Client.TLS.request connection h2_req
-                          ~error_handler ~response_handler
-                      in
-                      (match req.body with
-                      | Some data when data <> "" ->
-                          H2.Body.Writer.write_string writer data
-                      | _ -> ());
-                      H2.Body.Writer.close writer;
-                      Lwt.pick [ response_p; error_p ] );
-                  ])
-              (fun exn ->
-                Lwt.catch
-                  (fun () -> Lwt_unix.close socket)
-                  (fun _ -> Lwt.return_unit)
-                >>= fun () ->
-                match rest with [] -> Lwt.fail exn | _ -> try_addrs rest)
-      in
-      try_addrs addrs
+    match addrs with
+    | [] -> Lwt.fail (Error ("DNS lookup failed for " ^ parsed.host))
+    | addr_info :: _ ->
+        let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+        Lwt.finalize
+          (fun () ->
+            Lwt_unix.connect socket addr_info.Unix.ai_addr >>= fun () ->
+            exchange ~host:parsed.host ~port:parsed.port req parsed socket)
+          (fun () -> close_socket socket)
 
   let request ?(timeout = default_timeout) (req : Request.request) :
       Response.response Lwt.t =
-    perform ~timeout req
+    Lwt.catch
+      (fun () -> Lwt_unix.with_timeout timeout (fun () -> perform req))
+      (function
+        | Lwt_unix.Timeout -> Lwt.fail (Error "HTTP/2 request timed out")
+        | exn -> Lwt.fail exn)
 
   let get url ?(headers = []) ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.get url ~headers ())

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -1,7 +1,59 @@
+open Http_method
+open Request
+open Response
+open Lwt.Infix
+
+(** HTTP/2 TLS client. Useful as an XRPC transport that keeps status
+    and response headers (rate-limit, atproto-repo-rev) that the
+    Cohttp helpers currently discard. Requires HTTPS + ALPN `h2`. *)
 module Http_client = struct
-  open H2
-  module Client = H2_lwt_unix.Client
-  open Lwt.Infix
+  exception Error of string
+
+  let default_timeout = 15.0
+  let user_agent = Request.user_agent
+
+  type parsed_url = {
+    scheme : string;
+    host : string;
+    port : int;
+    path : string;
+  }
+
+  let fail msg = raise (Error msg)
+
+  let parse_url (url : string) : parsed_url =
+    let uri = Uri.of_string url in
+    let scheme =
+      match Uri.scheme uri with
+      | Some s -> String.lowercase_ascii s
+      | None -> ""
+    in
+    if scheme <> "https" then
+      fail "Http_client HTTP/2 transport requires an https URL";
+    let host =
+      match Uri.host uri with
+      | Some h when h <> "" -> h
+      | _ -> fail ("Http_client URL is missing a host: " ^ url)
+    in
+    let port = match Uri.port uri with Some p -> p | None -> 443 in
+    let path =
+      let p = Uri.path uri in
+      let p = if p = "" then "/" else p in
+      match Uri.verbatim_query uri with
+      | Some q when q <> "" -> p ^ "?" ^ q
+      | _ -> (
+          match Uri.query uri with
+          | [] -> p
+          | qs -> p ^ "?" ^ Uri.encoded_of_query qs)
+    in
+    { scheme; host; port; path }
+
+  let h2_meth = function
+    | Http_method.Get -> `GET
+    | Http_method.Post -> `POST
+    | Http_method.Put -> `PUT
+    | Http_method.Delete -> `DELETE
+    | Http_method.Patch -> `Other "PATCH"
 
   let print_addr_info (addr_info : Unix.addr_info) : unit =
     match addr_info.Unix.ai_addr with
@@ -16,98 +68,168 @@ module Http_client = struct
     | Unix.ADDR_UNIX _ -> None
     | ADDR_INET (addr, port) -> Some (addr, port)
 
-  let print_converted_list (converted_list : Unix.addr_info list) : unit =
-    List.iter print_addr_info converted_list
-
-  let print_body (body_promise : H2.Body.Writer.t Lwt.t) : unit Lwt.t =
-    body_promise >>= fun _ ->
-    print_endline "The promise has resolved!";
-    Lwt.return_unit
-
-  let request_buffer = Buffer.create 4096
-  let response_buffer = Buffer.create 4096
-
-  let write_to_request_body body data =
-    Buffer.add_string request_buffer data;
-    H2.Body.Writer.write_string body data;
-    H2.Body.Writer.flush body (function `Written | `Closed -> ())
-
   let get_addr_info (host : string) (port : int) : Unix.addr_info list Lwt.t =
     Lwt_unix.getaddrinfo host (string_of_int port) [ Unix.(AI_FAMILY PF_INET) ]
 
-  let response_handler : Client_connection.response_handler =
-   fun _response response_body ->
-    let open H2.Body.Reader in
-    let rec read_response () =
-      schedule_read response_body
-        ~on_read:(fun buffer ~off ~len ->
-          let chunk = Bytes.create len in
-          Bigstringaf.blit_to_bytes buffer ~src_off:off chunk ~dst_off:0 ~len;
-          let chunk_string = Bytes.to_string chunk in
-          Buffer.add_string response_buffer chunk_string;
-          print_string chunk_string;
-          read_response ())
-        ~on_eof:(fun () -> ())
+  let headers_to_list (h : H2.Headers.t) : (string * string) list =
+    H2.Headers.to_list h
+    |> List.filter (fun (k, _) ->
+           match k with
+           | ":status" | ":method" | ":path" | ":scheme" | ":authority" -> false
+           | _ -> true)
+
+  let request_headers ~host ~port (headers : (string * string) list) :
+      H2.Headers.t =
+    let authority =
+      if port = 443 then host else Printf.sprintf "%s:%d" host port
     in
-    read_response ()
-
-  (*let create_empty () = H2.Body.Writer.create ()*)
-  let create_empty () = Lwt.fail_with "No Initial Value"
-
-  let error_handler _error =
-    Format.eprintf "Unsuccessful request!\n%!";
-    failwith "Unsuccessful request!"
-
-  let create_socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0
-
-  let connect_socket socket (addr_info : Unix.addr_info) =
-    Lwt_unix.connect socket addr_info.Unix.ai_addr
-
-  let create_socket_for_addr_info addr_info =
-    let socket = create_socket in
-    let%bind () = connect_socket socket addr_info in
-    Lwt.return socket
-
-  let create_get_request (host : string) : Request.t =
-    Request.create `GET "/" ~scheme:"https"
-      ~headers:Headers.(add_list empty [ (":authority", host) ])
-
-  let handle_response (response_received : unit Lwt.t) : unit Lwt.t =
-    response_received >>= fun () -> Lwt.return_unit
-
-  let perform_request connection (request : Request.t) : Body.Writer.t Lwt.t =
-    let request_body =
-      Client.TLS.request connection request ~error_handler ~response_handler
+    let has_ua =
+      List.exists
+        (fun (k, _) -> String.lowercase_ascii k = "user-agent")
+        headers
     in
-    Lwt.return request_body
-
-  let get_host (host : string) (port : int) : H2.Body.Writer.t Lwt.t =
-    let open Lwt.Infix in
-    let timeout = 5.0 in
-    (* Timeout in seconds *)
-    get_addr_info host port >>= fun addrs ->
-    let rec find_successful_connection = function
-      | [] -> Lwt.fail_with "No successful request"
-      | addr_info :: rest -> (
-          let%bind socket = create_socket_for_addr_info addr_info in
-          let request = create_get_request host in
-          Lwt.pick
-            [
-              Lwt.catch
-                (fun () ->
-                  Client.TLS.create_connection_with_default ~error_handler
-                    socket
-                  >>= fun connection ->
-                  perform_request connection request >>= fun request_body ->
-                  Lwt.return_some request_body)
-                (fun _ -> Lwt.return_none);
-              (* If an error occurs, return None and continue with the next address *)
-              ( Lwt_unix.sleep timeout >>= fun () -> Lwt.return_none )
-              (* Return None if the operation times out *);
-            ]
-          >>= function
-          | Some request_body -> Lwt.return request_body
-          | None -> find_successful_connection rest)
+    let pairs =
+      (":authority", authority)
+      :: (if has_ua then [] else [ ("user-agent", user_agent) ])
+      @ List.filter
+          (fun (k, _) ->
+            let l = String.lowercase_ascii k in
+            l <> ":authority" && l <> "host" && l <> "connection"
+            && l <> "transfer-encoding")
+          headers
     in
-    find_successful_connection addrs
+    H2.Headers.of_list pairs
+
+  let error_message = function
+    | `Malformed_response s -> "malformed HTTP/2 response: " ^ s
+    | `Invalid_response_body_length _ -> "invalid HTTP/2 response body length"
+    | `Exn exn -> Printexc.to_string exn
+    | `Protocol_error (code, msg) ->
+        Printf.sprintf "HTTP/2 protocol error %s: %s"
+          (H2.Error_code.to_string code)
+          msg
+
+  let perform ~timeout (req : Request.request) : Response.response Lwt.t =
+    let parsed = parse_url req.url in
+    get_addr_info parsed.host parsed.port >>= fun addrs ->
+    if addrs = [] then Lwt.fail (Error ("DNS lookup failed for " ^ parsed.host))
+    else
+      let rec try_addrs = function
+        | [] -> Lwt.fail (Error ("HTTP/2 connect failed for " ^ parsed.host))
+        | addr_info :: rest ->
+            let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+            Lwt.catch
+              (fun () ->
+                Lwt.pick
+                  [
+                    ( Lwt_unix.sleep timeout >>= fun () ->
+                      Lwt.fail (Error "HTTP/2 connect timed out") );
+                    ( Lwt_unix.connect socket addr_info.Unix.ai_addr
+                    >>= fun () ->
+                      let error_p, error_w = Lwt.wait () in
+                      let error_handler err =
+                        if Lwt.is_sleeping error_p then
+                          Lwt.wakeup_exn error_w (Error (error_message err))
+                      in
+                      H2_lwt_unix.Client.TLS.create_connection_with_default
+                        ~error_handler socket
+                      >>= fun connection ->
+                      let response_p, response_w = Lwt.wait () in
+                      let response_handler (response : H2.Response.t) body =
+                        let buf = Buffer.create 4096 in
+                        let rec read_response () =
+                          H2.Body.Reader.schedule_read body
+                            ~on_read:(fun bigstr ~off ~len ->
+                              Buffer.add_string buf
+                                (Bigstringaf.substring bigstr ~off ~len);
+                              read_response ())
+                            ~on_eof:(fun () ->
+                              if Lwt.is_sleeping response_p then
+                                let status =
+                                  H2.Status.to_code response.H2.Response.status
+                                in
+                                Lwt.wakeup_later response_w
+                                  (Response.of_string ~status_code:status
+                                     ~headers:
+                                       (headers_to_list
+                                          response.H2.Response.headers)
+                                     (Buffer.contents buf)))
+                        in
+                        read_response ()
+                      in
+                      let h2_req =
+                        H2.Request.create (h2_meth req.method_) parsed.path
+                          ~scheme:"https"
+                          ~headers:
+                            (request_headers ~host:parsed.host ~port:parsed.port
+                               req.headers)
+                      in
+                      let writer =
+                        H2_lwt_unix.Client.TLS.request connection h2_req
+                          ~error_handler ~response_handler
+                      in
+                      (match req.body with
+                      | Some data when data <> "" ->
+                          H2.Body.Writer.write_string writer data
+                      | _ -> ());
+                      H2.Body.Writer.close writer;
+                      Lwt.pick [ response_p; error_p ] );
+                  ])
+              (fun exn ->
+                Lwt.catch
+                  (fun () -> Lwt_unix.close socket)
+                  (fun _ -> Lwt.return_unit)
+                >>= fun () ->
+                match rest with [] -> Lwt.fail exn | _ -> try_addrs rest)
+      in
+      try_addrs addrs
+
+  let request ?(timeout = default_timeout) (req : Request.request) :
+      Response.response Lwt.t =
+    perform ~timeout req
+
+  let get url ?(headers = []) ?timeout () : Response.response Lwt.t =
+    request ?timeout (Request.get url ~headers ())
+
+  let post url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
+    request ?timeout (Request.post url ~headers ?body ())
+
+  let get_host (host : string) (port : int) : Response.response Lwt.t =
+    let url =
+      if port = 443 then Printf.sprintf "https://%s/" host
+      else Printf.sprintf "https://%s:%d/" host port
+    in
+    get url ()
+
+  let xrpc_url ~host ?(port = 443) nsid ?(query = []) () : string =
+    let base =
+      if port = 443 then Printf.sprintf "https://%s/xrpc/%s" host nsid
+      else Printf.sprintf "https://%s:%d/xrpc/%s" host port nsid
+    in
+    match query with
+    | [] -> base
+    | qs ->
+        base ^ "?"
+        ^ String.concat "&"
+            (List.map
+               (fun (k, v) -> Uri.pct_encode k ^ "=" ^ Uri.pct_encode v)
+               qs)
+
+  let xrpc_get ~host ?port ~nsid ?(query = []) ?(headers = []) ?timeout () :
+      Response.response Lwt.t =
+    get (xrpc_url ~host ?port nsid ~query ()) ~headers ?timeout ()
+
+  let xrpc_post ~host ?port ~nsid ?(headers = []) ?body ?timeout () :
+      Response.response Lwt.t =
+    let hdrs =
+      if
+        List.exists
+          (fun (k, _) -> String.lowercase_ascii k = "content-type")
+          headers
+      then headers
+      else ("content-type", "application/json") :: headers
+    in
+    post (xrpc_url ~host ?port nsid ()) ~headers:hdrs ?body ?timeout ()
+
+  let run (t : 'a Lwt.t) : 'a = Lwt_main.run t
 end

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -387,6 +387,24 @@ module Lexicon = struct
   let official_revoke_creds =
     {|{"lexicon":1,"id":"com.atproto.temp.revokeAccountCredentials","defs":{"main":{"type":"procedure","description":"Revoke sessions, password, and app passwords associated with account.","input":{"encoding":"application/json","schema":{"type":"object","required":["account"],"properties":{"account":{"type":"string"}}}}}}}|}
 
+  let official_site_recommend =
+    {|{"lexicon":1,"id":"site.standard.graph.recommend","defs":{"main":{"type":"record","description":"Record declaring a recommendation of a document.","key":"tid","record":{"type":"object","required":["document","createdAt"],"properties":{"document":{"type":"string","format":"at-uri"},"createdAt":{"type":"string","format":"datetime"}}}}}}|}
+
+  let official_site_subscription =
+    {|{"lexicon":1,"id":"site.standard.graph.subscription","defs":{"main":{"type":"record","description":"Record declaring a subscription to a publication.","key":"tid","record":{"type":"object","required":["publication"],"properties":{"publication":{"type":"string","format":"at-uri"},"createdAt":{"type":"string","format":"datetime"}}}}}}|}
+
+  let official_germ_declaration =
+    {|{"lexicon":1,"id":"com.germnetwork.declaration","defs":{"main":{"type":"record","description":"A declaration of a Germ Network account","key":"literal:self","record":{"type":"object","required":["version","currentKey"],"properties":{"version":{"type":"string"},"currentKey":{"type":"bytes"},"messageMe":{"type":"ref","ref":"#messageMe"}}}},"messageMe":{"type":"object","required":["showButtonTo","messageMeUrl"],"properties":{"showButtonTo":{"type":"string","knownValues":["none","usersIFollow","everyone"]},"messageMeUrl":{"type":"string","format":"uri"}}}}}|}
+
+  let official_safelink_query_events =
+    {|{"lexicon":1,"id":"tools.ozone.safelink.queryEvents","defs":{"main":{"type":"procedure","description":"Query URL safety audit events","input":{"encoding":"application/json","schema":{"type":"object","properties":{"cursor":{"type":"string"},"limit":{"type":"integer"},"urls":{"type":"array","items":{"type":"string"}},"patternType":{"type":"string"},"sortDirection":{"type":"string"}}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["events"],"properties":{"cursor":{"type":"string"},"events":{"type":"array","items":{"type":"ref","ref":"tools.ozone.safelink.defs#event"}}}}}}}}|}
+
+  let official_admin_signing_key =
+    {|{"lexicon":1,"id":"com.atproto.admin.updateAccountSigningKey","defs":{"main":{"type":"procedure","description":"Administrative action to update an account's signing key in their Did document.","input":{"encoding":"application/json","schema":{"type":"object","required":["did","signingKey"],"properties":{"did":{"type":"string","format":"did"},"signingKey":{"type":"string","format":"did"}}}}}}}|}
+
+  let official_join_link =
+    {|{"lexicon":1,"id":"chat.bsky.embed.joinLink","defs":{"main":{"type":"object","required":["code"],"properties":{"code":{"type":"string"}}},"view":{"type":"object","required":["joinLinkPreview"],"properties":{"joinLinkPreview":{"type":"union","refs":["chat.bsky.group.defs#joinLinkPreviewView"]}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -409,6 +427,12 @@ module Lexicon = struct
       ("com.atproto.temp.checkSignupQueue", official_check_signup);
       ("com.atproto.temp.dereferenceScope", official_deref_scope);
       ("com.atproto.temp.revokeAccountCredentials", official_revoke_creds);
+      ("site.standard.graph.recommend", official_site_recommend);
+      ("site.standard.graph.subscription", official_site_subscription);
+      ("com.germnetwork.declaration", official_germ_declaration);
+      ("tools.ozone.safelink.queryEvents", official_safelink_query_events);
+      ("com.atproto.admin.updateAccountSigningKey", official_admin_signing_key);
+      ("chat.bsky.embed.joinLink", official_join_link);
     ]
 
   let official_documents () : document list =

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -1109,6 +1109,72 @@ module Ozone = struct
            | None -> []))))
     |> parse_url_rule
 
+  type safelink_event = {
+    id : int;
+    event_type : string;
+    url : string;
+    pattern : string option;
+    action : string option;
+    reason : string option;
+    created_by : string;
+    created_at : string;
+    comment : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type safelink_events = {
+    cursor : string option;
+    events : safelink_event list;
+  }
+
+  let parse_safelink_event json : safelink_event =
+    {
+      id = Client.int_member json "id";
+      event_type = Client.string_member json "eventType";
+      url = Client.string_member json "url";
+      pattern =
+        (match Client.string_opt json "pattern" with
+        | Some s -> Some s
+        | None -> Client.string_opt json "patternType");
+      action = Client.string_opt json "action";
+      reason = Client.string_opt json "reason";
+      created_by = Client.string_member json "createdBy";
+      created_at = Client.string_member json "createdAt";
+      comment = Client.string_opt json "comment";
+      original = json;
+    }
+
+  let parse_safelink_events json : safelink_events =
+    {
+      cursor = Client.string_opt json "cursor";
+      events = List.map parse_safelink_event (Client.list_member json "events");
+    }
+
+  let query_safelink_events_body ?cursor ?limit ?(urls = []) ?pattern_type
+      ?sort_direction () : Yojson.Safe.t =
+    `Assoc
+      ((match cursor with Some c -> [ ("cursor", `String c) ] | None -> [])
+      @ (match limit with Some n -> [ ("limit", `Int n) ] | None -> [])
+      @ (match urls with
+        | [] -> []
+        | xs -> [ ("urls", `List (List.map (fun u -> `String u) xs)) ])
+      @ (match pattern_type with
+        | Some p -> [ ("patternType", `String p) ]
+        | None -> [])
+      @
+      match sort_direction with
+      | Some d -> [ ("sortDirection", `String d) ]
+      | None -> [])
+
+  let query_safelink_events (s : Session.session) ~proxy ?cursor ?limit
+      ?(urls = []) ?pattern_type ?sort_direction () : safelink_events =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.safelink.queryEvents"
+      (Yojson.Safe.to_string
+         (query_safelink_events_body ?cursor ?limit ~urls ?pattern_type
+            ?sort_direction ()))
+    |> parse_safelink_events
+
   type related_account = { did : string; original : Yojson.Safe.t }
 
   type related_accounts = {

--- a/src/request.ml
+++ b/src/request.ml
@@ -8,11 +8,28 @@ module Request = struct
     body : string option;
   }
 
+  let user_agent = "david-engelmann/atproto (OCaml SDK)"
+
+  let create ~method_ ~url ?(headers = []) ?body () : request =
+    { method_; url; headers; body }
+
+  let get url ?(headers = []) () : request =
+    create ~method_:Http_method.Get ~url ~headers ()
+
+  let post url ?(headers = []) ?body () : request =
+    create ~method_:Http_method.Post ~url ~headers ?body ()
+
+  let put url ?(headers = []) ?body () : request =
+    create ~method_:Http_method.Put ~url ~headers ?body ()
+
+  let delete url ?(headers = []) ?body () : request =
+    create ~method_:Http_method.Delete ~url ~headers ?body ()
+
   let sample_request_with_body : request =
     {
       method_ = Http_method.Get;
       url = "https://github.com/david-engelmann";
-      headers = [ ("User-Agent", "david-engelmann/atproto (OCaml SDK)") ];
+      headers = [ ("User-Agent", user_agent) ];
       body = Some "{\"July\": \"Jackson\"}";
     }
 
@@ -20,7 +37,7 @@ module Request = struct
     {
       method_ = Http_method.Get;
       url = "https://github.com/david-engelmann";
-      headers = [ ("User-Agent", "david-engelmann/atproto (OCaml SDK)") ];
+      headers = [ ("User-Agent", user_agent) ];
       body = None;
     }
 

--- a/src/response.ml
+++ b/src/response.ml
@@ -5,4 +5,25 @@ module Response = struct
     content : bytes;
     headers : (string * string) list;
   }
+
+  let make ~status_code ~content ?(headers = []) () : response =
+    {
+      success = status_code >= 200 && status_code < 300;
+      status_code;
+      content;
+      headers;
+    }
+
+  let of_string ~status_code ?(headers = []) body : response =
+    make ~status_code ~content:(Bytes.of_string body) ~headers ()
+
+  let body_string (r : response) : string = Bytes.to_string r.content
+
+  let header (r : response) name : string option =
+    let lower = String.lowercase_ascii name in
+    List.find_map
+      (fun (k, v) -> if String.lowercase_ascii k = lower then Some v else None)
+      r.headers
+
+  let content_type (r : response) : string option = header r "content-type"
 end

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,7 @@
   test_facet
   test_feed
   test_firehose
+  test_germnetwork
   test_graph
   test_hash
   test_http_client
@@ -45,6 +46,7 @@
   test_response
   test_server
   test_session
+  test_site
   test_sync
   test_syntax
   test_temp
@@ -104,6 +106,7 @@
   test_facet
   test_feed
   test_firehose
+  test_germnetwork
   test_graph
   test_hash
   test_http_client
@@ -126,6 +129,7 @@
   test_response
   test_server
   test_session
+  test_site
   test_sync
   test_syntax
   test_temp

--- a/test/test_admin.ml
+++ b/test/test_admin.ml
@@ -51,6 +51,68 @@ let test_parse_account_info _ =
   OUnit2.assert_equal ~printer:(fun x -> x) "alice.test" info.handle;
   OUnit2.assert_equal (Some true) info.invites_disabled
 
+let test_invite_codes_and_admin_bodies _ =
+  let codes =
+    Admin.parse_invite_codes
+      (`Assoc
+        [
+          ("cursor", `String "c1");
+          ( "codes",
+            `List
+              [
+                `Assoc
+                  [
+                    ("code", `String "bsky-invite-1");
+                    ("available", `Int 5);
+                    ("disabled", `Bool false);
+                    ("forAccount", `String "did:plc:abc123xyz0001112223333");
+                    ("createdBy", `String "admin");
+                    ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                    ( "uses",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ( "usedBy",
+                                `String "did:plc:user000111222333444555666" );
+                              ("usedAt", `String "2024-01-02T00:00:00.000Z");
+                            ];
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bsky-invite-1" (List.hd codes.codes).code;
+  OUnit2.assert_equal 1 (List.length (List.hd codes.codes).uses);
+  let disable =
+    Admin.disable_invite_codes_body ~codes:[ "x" ]
+      ~accounts:[ "did:plc:abc123xyz0001112223333" ]
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "x"
+    (disable |> member "codes" |> to_list |> List.hd |> to_string);
+  let signing =
+    Admin.update_account_signing_key_body ~did:"did:plc:abc123xyz0001112223333"
+      ~signing_key:"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH" ()
+  in
+  OUnit2.assert_bool "signingKey present"
+    (match signing |> member "signingKey" with
+    | `String s -> String.length s > 8
+    | _ -> false);
+  let email =
+    Admin.update_account_email_body ~account:"alice.test" ~email:"a@example.com"
+      ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "a@example.com"
+    (email |> member "email" |> to_string)
+
 let test_send_email_body _ =
   let body =
     Admin.send_email_body ~recipient_did:"did:plc:abc123xyz0001112223333"
@@ -82,6 +144,8 @@ let suite =
          "test_parse_subject_status" >:: test_parse_subject_status;
          "test_update_body" >:: test_update_body;
          "test_parse_account_info" >:: test_parse_account_info;
+         "test_invite_codes_and_admin_bodies"
+         >:: test_invite_codes_and_admin_bodies;
          "test_send_email_body" >:: test_send_email_body;
          "test_admin_auth_skipped" >:: test_admin_auth_skipped;
        ]

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -364,6 +364,15 @@ let test_parse_embed_external_view _ =
       OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri
   | None -> OUnit2.assert_failure "expected view"
 
+let test_join_link_embed _ =
+  let built = Embed.join_link ~code:"abc123xyz" () in
+  (match built with
+  | `JoinLink e -> OUnit2.assert_equal ~printer:(fun x -> x) "abc123xyz" e.code
+  | _ -> OUnit2.assert_failure "expected join link builder");
+  match Embed.parse_embed (Embed.embed_to_json built) with
+  | `JoinLink e -> OUnit2.assert_equal ~printer:(fun x -> x) "abc123xyz" e.code
+  | _ -> OUnit2.assert_failure "expected join link parse"
+
 let suite =
   "embed"
   >::: [
@@ -379,6 +388,7 @@ let suite =
          "test_parse_record_view_not_found" >:: test_parse_record_view_not_found;
          "test_embed_to_json_roundtrip" >:: test_embed_to_json_roundtrip;
          "test_parse_embed_external_view" >:: test_parse_embed_external_view;
+         "test_join_link_embed" >:: test_join_link_embed;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_germnetwork.ml
+++ b/test/test_germnetwork.ml
@@ -1,0 +1,39 @@
+open OUnit2
+open Atproto.Germnetwork
+
+let test_declaration_roundtrip _ =
+  let key = "\x00ed25519-public-key-bytes!!"
+  and pkg = "mls-key-package"
+  and proof = "continuity" in
+  let json =
+    Germnetwork.declaration ~version:"1.0.0" ~current_key:key
+      ~message_me:
+        (Germnetwork.message_me ~show_button_to:Germnetwork.show_everyone
+           ~message_me_url:"https://germ.example/message")
+      ~key_package:pkg ~continuity_proofs:[ proof ] ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.germnetwork.declaration"
+    (json |> member "$type" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "1.0.0"
+    (json |> member "version" |> to_string);
+  let parsed = Germnetwork.parse_declaration json in
+  OUnit2.assert_equal ~printer:(fun x -> x) key parsed.current_key;
+  OUnit2.assert_equal (Some pkg) parsed.key_package;
+  OUnit2.assert_equal [ proof ] parsed.continuity_proofs;
+  match parsed.message_me with
+  | Some m ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        Germnetwork.show_everyone m.show_button_to
+  | None -> OUnit2.assert_failure "expected messageMe"
+
+let suite =
+  "germnetwork"
+  >::: [ "test_declaration_roundtrip" >:: test_declaration_roundtrip ]
+
+let () = run_test_tt_main suite

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -1,42 +1,113 @@
 open OUnit2
 open Atproto.Http_client
-open Lwt.Infix
+open Atproto.Request
+open Atproto.Response
+open Atproto.Http_method
 
-let test_http_client_with_quotes_to_scrape _ =
+let test_parse_https_url _ =
+  let p =
+    Http_client.parse_url
+      "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=bsky.app"
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "https" p.scheme;
+  OUnit2.assert_equal ~printer:(fun x -> x) "public.api.bsky.app" p.host;
+  OUnit2.assert_equal 443 p.port;
+  OUnit2.assert_bool "path includes nsid"
+    (let needle = "/xrpc/com.atproto.identity.resolveHandle" in
+     let rec contains i =
+       i + String.length needle <= String.length p.path
+       && (String.sub p.path i (String.length needle) = needle
+          || contains (i + 1))
+     in
+     contains 0)
+
+let test_parse_url_requires_https _ =
+  (try
+     ignore (Http_client.parse_url "http://example.com/xrpc/ping");
+     OUnit2.assert_failure "expected https requirement"
+   with Http_client.Error _ -> ());
+  try
+    ignore (Http_client.parse_url "/relative");
+    OUnit2.assert_failure "expected host requirement"
+  with Http_client.Error _ -> ()
+
+let test_xrpc_url _ =
+  let url =
+    Http_client.xrpc_url ~host:"public.api.bsky.app"
+      "com.atproto.identity.resolveHandle"
+      ~query:[ ("handle", "bsky.app") ]
+      ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=bsky.app"
+    url
+
+let test_request_builders _ =
+  let req =
+    Request.post
+      "https://public.api.bsky.app/xrpc/com.atproto.server.createSession"
+      ~headers:[ ("content-type", "application/json") ]
+      ~body:"{}" ()
+  in
+  OUnit2.assert_equal Http_method.Post req.method_;
+  OUnit2.assert_equal (Some "{}") req.body;
+  let get = Request.get "https://example.com/" () in
+  OUnit2.assert_equal Http_method.Get get.method_
+
+let test_response_helpers _ =
+  let r =
+    Response.of_string ~status_code:200
+      ~headers:
+        [ ("RateLimit-Remaining", "99"); ("Content-Type", "application/json") ]
+      "{\"ok\":true}"
+  in
+  OUnit2.assert_bool "success" r.success;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "{\"ok\":true}" (Response.body_string r);
+  OUnit2.assert_equal (Some "99") (Response.header r "ratelimit-remaining");
+  OUnit2.assert_equal (Some "application/json") (Response.content_type r);
+  let fail = Response.of_string ~status_code:429 "{}" in
+  OUnit2.assert_bool "not success" (not fail.success)
+
+let test_getaddrinfo _ =
+  let open Lwt.Infix in
   try
     Lwt_main.run
-      ( Http_client.get_host "quotes.toscrape.com" 443 >>= fun _ ->
+      ( Http_client.get_addr_info "public.api.bsky.app" 443 >>= fun addrs ->
+        OUnit2.assert_bool "resolved at least one A record" (addrs <> []);
         Lwt.return_unit )
-  with Failure msg -> failwith msg
-
-let test_http_client_with_getaddrinfo _ =
-  let open Lwt.Infix in
-  let addr_test =
-    Http_client.get_addr_info "quotes.toscrape.com" 443 >>= fun addrs ->
-    let lwt_list = List.map Lwt.return addrs in
-    Lwt_list.iter_p
-      (fun addr ->
-        addr >>= fun addr_info ->
-        match addr_info.Unix.ai_addr with
-        | Unix.ADDR_INET (addr, port) ->
-            Lwt_io.printf "Address: %s, Port: %d\n"
-              (Unix.string_of_inet_addr addr)
-              port
-        | _ -> Lwt_io.printf "Unknown address format\n")
-      lwt_list
-    >>= fun () -> Lwt.return_unit
-  in
-  try
-    Lwt_main.run addr_test;
-    OUnit2.assert_equal 1 1
   with exn -> skip_if true ("getaddrinfo skipped: " ^ Printexc.to_string exn)
 
+let test_live_h2_xrpc _ =
+  try
+    let resp =
+      Lwt_main.run
+        (Http_client.xrpc_get ~host:"public.api.bsky.app"
+           ~nsid:"com.atproto.identity.resolveHandle"
+           ~query:[ ("handle", "bsky.app") ]
+           ~timeout:12.0 ())
+    in
+    OUnit2.assert_bool "HTTP/2 XRPC returned a status"
+      (resp.status_code >= 200 && resp.status_code < 600);
+    if resp.status_code = 200 then
+      let json = Yojson.Safe.from_string (Response.body_string resp) in
+      match Yojson.Safe.Util.member "did" json with
+      | `String did -> OUnit2.assert_bool "resolved did" (String.length did > 8)
+      | _ -> ()
+  with exn -> skip_if true ("HTTP/2 XRPC skipped: " ^ Printexc.to_string exn)
+
 let suite =
-  "suite"
+  "http_client"
   >::: [
-         (*"test_http_client_with_quotes_to_scrape" >:: test_http_client_with_quotes_to_scrape;*)
-         "test_http_client_with_getaddrinfo"
-         >:: test_http_client_with_getaddrinfo;
+         "test_parse_https_url" >:: test_parse_https_url;
+         "test_parse_url_requires_https" >:: test_parse_url_requires_https;
+         "test_xrpc_url" >:: test_xrpc_url;
+         "test_request_builders" >:: test_request_builders;
+         "test_response_helpers" >:: test_response_helpers;
+         "test_getaddrinfo" >:: test_getaddrinfo;
+         "test_live_h2_xrpc" >:: test_live_h2_xrpc;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_http_client.ml
+++ b/test/test_http_client.ml
@@ -87,7 +87,7 @@ let test_live_h2_xrpc _ =
         (Http_client.xrpc_get ~host:"public.api.bsky.app"
            ~nsid:"com.atproto.identity.resolveHandle"
            ~query:[ ("handle", "bsky.app") ]
-           ~timeout:12.0 ())
+           ~timeout:5.0 ())
     in
     OUnit2.assert_bool "HTTP/2 XRPC returned a status"
       (resp.status_code >= 200 && resp.status_code < 600);
@@ -101,13 +101,17 @@ let test_live_h2_xrpc _ =
 let suite =
   "http_client"
   >::: [
+         "test_live_h2_xrpc" >:: test_live_h2_xrpc;
          "test_parse_https_url" >:: test_parse_https_url;
          "test_parse_url_requires_https" >:: test_parse_url_requires_https;
          "test_xrpc_url" >:: test_xrpc_url;
          "test_request_builders" >:: test_request_builders;
          "test_response_helpers" >:: test_response_helpers;
          "test_getaddrinfo" >:: test_getaddrinfo;
-         "test_live_h2_xrpc" >:: test_live_h2_xrpc;
        ]
 
-let () = run_test_tt_main suite
+(* oUnit2's default process runner forks; Lwt + OpenSSL after fork cannot
+   complete an HTTP/2 handshake. Sequential keeps the live XRPC check in-process. *)
+let () =
+  Unix.putenv "OUNIT_RUNNER" "sequential";
+  run_test_tt_main suite

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -213,11 +213,21 @@ let test_union_codegen_and_official_bundle _ =
       in
       match Lexicon.main list_doc with
       | None -> OUnit2.assert_failure "missing list main"
-      | Some main -> (
-          match List.assoc_opt "labels" main.properties with
+      | Some main ->
+          (match List.assoc_opt "labels" main.properties with
           | Some (Lexicon.Union refs) ->
               OUnit2.assert_equal [ "com.atproto.label.defs#selfLabels" ] refs
-          | _ -> OUnit2.assert_failure "list labels should be a union"))
+          | _ -> OUnit2.assert_failure "list labels should be a union");
+          let ids = List.map (fun (d : Lexicon.document) -> d.id) docs in
+          List.iter
+            (fun id -> OUnit2.assert_bool ("bundled " ^ id) (List.mem id ids))
+            [
+              "site.standard.graph.recommend";
+              "com.germnetwork.declaration";
+              "tools.ozone.safelink.queryEvents";
+              "chat.bsky.embed.joinLink";
+              "com.atproto.admin.updateAccountSigningKey";
+            ])
 
 let test_parse_resolved_lexicon _ =
   let json =

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -267,6 +267,43 @@ let test_operator_namespace_parsers _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "https://evil.example" (List.hd rules.rules).url;
+  let events =
+    Ozone.parse_safelink_events
+      (`Assoc
+        [
+          ( "events",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `Int 9);
+                    ("eventType", `String "addRule");
+                    ("url", `String "https://phish.example");
+                    ("pattern", `String "domain");
+                    ("action", `String "block");
+                    ("reason", `String "phishing");
+                    ("createdBy", `String "did:plc:mod000111222333444555666");
+                    ("createdAt", `String "2026-01-01T00:00:00.000Z");
+                    ("comment", `String "caught");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 9 (List.hd events.events).id;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "addRule" (List.hd events.events).event_type;
+  let qbody =
+    Ozone.query_safelink_events_body
+      ~urls:[ "https://phish.example" ]
+      ~pattern_type:"domain" ~sort_direction:"desc" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "domain"
+    (qbody
+    |> Yojson.Safe.Util.member "patternType"
+    |> Yojson.Safe.Util.to_string);
   let body =
     Ozone.create_template_body ~name:"Hello" ~content_markdown:"hi"
       ~subject:"welcome" ()

--- a/test/test_request.ml
+++ b/test/test_request.ml
@@ -1,5 +1,6 @@
 open OUnit2
 open Atproto.Request
+open Atproto.Http_method
 
 let test_sample_request_with_body_method_ _ =
   match Request.sample_request_with_body with
@@ -45,6 +46,18 @@ let test_sample_request_without_body_body _ =
       | None -> OUnit2.assert_equal 1 1
       | Some _ -> OUnit2.assert_equal 0 1)
 
+let test_create_helpers _ =
+  let get = Request.get "https://public.api.bsky.app/xrpc/ping" () in
+  OUnit2.assert_equal Request.test_get get.method_;
+  OUnit2.assert_equal None get.body;
+  let post =
+    Request.post "https://public.api.bsky.app/xrpc/ping" ~body:"{}" ()
+  in
+  OUnit2.assert_equal Request.test_post post.method_;
+  OUnit2.assert_equal (Some "{}") post.body;
+  let put = Request.put "https://example.com/x" ~body:"x" () in
+  OUnit2.assert_equal Http_method.Put put.method_
+
 let suite =
   "suite"
   >::: [
@@ -64,6 +77,7 @@ let suite =
          >:: test_sample_request_without_body_headers;
          "test_sample_request_without_body_body"
          >:: test_sample_request_without_body_body;
+         "test_create_helpers" >:: test_create_helpers;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_response.ml
+++ b/test/test_response.ml
@@ -44,6 +44,18 @@ let test_sample_response_headers _ =
       | (param_name, _) :: _ -> OUnit2.assert_equal "User-Agent" param_name
       | _ -> OUnit2.assert_equal 0 1)
 
+let test_of_string_and_header _ =
+  let r =
+    Response.of_string ~status_code:429
+      ~headers:[ ("RateLimit-Remaining", "0") ]
+      "{\"error\":\"RateLimitExceeded\"}"
+  in
+  OUnit2.assert_equal false r.success;
+  OUnit2.assert_equal (Some "0") (Response.header r "ratelimit-remaining");
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "{\"error\":\"RateLimitExceeded\"}" (Response.body_string r)
+
 let suite =
   "suite"
   >::: [
@@ -51,6 +63,7 @@ let suite =
          "test_sample_response_status_code" >:: test_sample_response_status_code;
          "test_sample_response_content" >:: test_sample_response_content;
          "test_sample_response_headers" >:: test_sample_response_headers;
+         "test_of_string_and_header" >:: test_of_string_and_header;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_site.ml
+++ b/test/test_site.ml
@@ -1,0 +1,107 @@
+open OUnit2
+open Atproto.Site
+open Atproto.Embed
+
+let test_document_roundtrip _ =
+  let json =
+    Site.document ~site:"https://standard.site" ~title:"Hello"
+      ~published_at:"2026-01-01T00:00:00.000Z" ~path:"/hello"
+      ~description:"intro" ~text_content:"plain hello" ~tags:[ "atproto" ]
+      ~contributors:
+        [
+          Site.contributor ~did:"did:plc:abc123xyz0001112223333"
+            ~display_name:"Ada" ~role:"editor" ();
+        ]
+      ~bsky_post_ref:
+        {
+          uri = "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k";
+          cid = "bafyreihdummy000000000000000000000000000000000";
+        }
+      ~self_labels:[ "graphic-media" ] ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "site.standard.document"
+    (json |> member "$type" |> to_string);
+  let parsed = Site.parse_document json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "Hello" parsed.title;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "/hello"
+    (Option.value parsed.path ~default:"");
+  OUnit2.assert_equal [ "atproto" ] parsed.tags;
+  OUnit2.assert_equal 1 (List.length parsed.contributors);
+  OUnit2.assert_equal (Some [ "graphic-media" ]) parsed.self_labels;
+  match parsed.bsky_post_ref with
+  | Some r -> OUnit2.assert_bool "post ref uri" (String.length r.Embed.uri > 8)
+  | None -> OUnit2.assert_failure "expected bskyPostRef"
+
+let test_publication_and_theme _ =
+  let theme =
+    Site.theme
+      ~background:(`Rgb (Site.rgb ~r:255 ~g:255 ~b:255))
+      ~foreground:(`Rgb (Site.rgb ~r:0 ~g:0 ~b:0))
+      ~accent:(`Rgb (Site.rgb ~r:0 ~g:80 ~b:200))
+      ~accent_foreground:(`Rgba (Site.rgba ~r:255 ~g:255 ~b:255 ~a:100))
+  in
+  let json =
+    Site.publication ~url:"https://standard.site" ~name:"Notes"
+      ~description:"essays" ~basic_theme:theme ~show_in_discover:false ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "site.standard.publication"
+    (json |> member "$type" |> to_string);
+  let parsed = Site.parse_publication json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "Notes" parsed.name;
+  (match parsed.preferences with
+  | Some { show_in_discover = Some false } -> ()
+  | _ -> OUnit2.assert_failure "expected showInDiscover=false");
+  match parsed.basic_theme with
+  | Some t -> (
+      match t.accent with
+      | `Rgb c -> OUnit2.assert_equal 200 c.b
+      | _ -> OUnit2.assert_failure "expected rgb accent")
+  | None -> OUnit2.assert_failure "expected basicTheme"
+
+let test_graph_records _ =
+  let rec_json =
+    Site.recommend
+      ~document:"at://did:plc:abc123xyz0001112223333/site.standard.document/3k"
+      ~created_at:"2026-01-01T00:00:00.000Z" ()
+  in
+  let sub_json =
+    Site.subscription
+      ~publication:
+        "at://did:plc:abc123xyz0001112223333/site.standard.publication/3k"
+      ~created_at:"2026-01-01T00:00:00.000Z" ()
+  in
+  let rec_ = Site.parse_recommend rec_json in
+  let sub = Site.parse_subscription sub_json in
+  OUnit2.assert_bool "recommend uri" (String.length rec_.document > 10);
+  OUnit2.assert_bool "subscription uri" (String.length sub.publication > 10);
+  let theme_json =
+    Site.theme_basic
+      ~background:(`Rgb { r = 1; g = 2; b = 3 })
+      ~foreground:(`Rgb { r = 4; g = 5; b = 6 })
+      ~accent:(`Rgb { r = 7; g = 8; b = 9 })
+      ~accent_foreground:(`Rgb { r = 10; g = 11; b = 12 })
+      ()
+  in
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "site.standard.theme.basic"
+    (theme_json |> member "$type" |> to_string)
+
+let suite =
+  "site"
+  >::: [
+         "test_document_roundtrip" >:: test_document_roundtrip;
+         "test_publication_and_theme" >:: test_publication_and_theme;
+         "test_graph_records" >:: test_graph_records;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Surveyed current official lexicons in [bluesky-social/atproto](https://github.com/bluesky-social/atproto/tree/main/lexicons) against `main` after #70–#83. New branch — does not redo that work. Remaining **library** gaps only: no hosted OAuth/PDS/Tap/transcoder/archive tokens/LtHash, and no invented credentials.

## New / completed library surfaces

- **`site.standard.*` records** (`Site`): document, publication, theme.basic / color (`rgb`/`rgba`), graph recommend + subscription. Builders + parsers, including self-labels and contributor lists.
- **`com.germnetwork.declaration`** (`Germnetwork`): `$bytes` currentKey / keyPackage / continuityProofs and `messageMe` policy.
- **Admin leftovers** (`com.atproto.admin`): `getInviteCodes` (+ typed invite-code parse), `disableInviteCodes`, `deleteAccount`, `updateAccountEmail` / `Handle` / `Password` / `SigningKey`. Bodies only for privileged writes; no live operator session invented.
- **`tools.ozone.safelink.queryEvents`**: typed event parse + request body + client.
- **`chat.bsky.embed.joinLink`** (+ `#view`) on `Embed` parse/serialize.
- **`Http_client`**: real HTTP/2 TLS GET/POST (OpenSSL + SNI + ALPN `h2`) that returns `Response` (status, headers, body). `xrpc_get` / `xrpc_post` helpers. Verified live against `public.api.bsky.app` `resolveHandle`. `Request`/`Response` now have constructors used by that path.

Bundled official lexicon documents for the new NSIDs. README / `examples/offline.ml` / opam description updated.

## Tests

Local `dune build` and `dune runtest` pass. Auth/admin/ozone live suites skip without real `ATP_AUTH`.

- Fixture parsers/builders for site, germnetwork, admin invite codes, safelink events, join-link embeds
- `Http_client.parse_url` / `xrpc_url` / Request+Response helpers
- Live HTTP/2 XRPC GET against `public.api.bsky.app` (no credentials); the http_client oUnit suite runs sequentially so Lwt+OpenSSL is not used after fork

## Still leftover (explicit)

- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`)
- Deprecated `com.atproto.sync.getCheckout` / `getHead` (use `getRepo` / `getLatestCommit`)
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (OAuth scope tokens, not XRPC)
- `internal.bsky.actor.getProfiles` (service-to-service AppView query)
- Hosted OAuth metadata URL, browser login, PDS, Tap, video transcoder, Jetstream archive operator token
- Permissioned data / spaces / LtHash (no stable public spec)
- Official `com.atproto.sync.getRepo` still has no `collection` query parameter

Action majors unchanged (`actions/checkout@v4`, `ocaml/setup-ocaml@v3`, `actions/cache@v4`, `actions/upload-artifact@v4`).

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-874e824d-f824-4da2-adc9-191f325f2d30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-874e824d-f824-4da2-adc9-191f325f2d30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

