### PR TITLE
Parse knownLikers, video presentation, and lexicon.schema records

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | --- | --- | --- |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
 | AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds) |
-| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts), generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
+| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts, `viewer.knownLikers`), generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
 | AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
@@ -45,7 +45,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `getConvoMembers`; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; `tools.ozone.queue.*` (list/create/update/delete, moderator assign, `routeReports`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
-| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration |
+| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration / `com.atproto.lexicon.schema` |
 | Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / `checkAccountStatus` clients), `getServiceAuth` (aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`) |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` DID document + updateHandle / PLC operation helpers + `refreshIdentity` |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
@@ -66,7 +66,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Drafts | `Draft` | `app.bsky.draft` create/get/update/delete + typed draft / embed / threadgate / postgate builders |
 | Contacts | `Contact` | `app.bsky.contact` phone verify, import, matches, dismiss, sync status, remove data |
 | Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union |
-| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video, **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
+| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video (`presentation` `default`/`gif`), **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
 | Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
@@ -84,9 +84,11 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-#70–#84 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, `com.germnetwork.declaration`, leftover admin, safelink `queryEvents`, `joinLink` embeds, and HTTP/2.
+#70–#85 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate clients, and extra DAG-CBOR / HTTP/2 tests.
 
-This stack fills leftover `com.atproto.server` email / activate-deactivate / `checkAccountStatus` clients, extra DAG-CBOR / HTTP/2 tests (query encoding, custom port, PUT/DELETE, 204, live POST), and the bundled `confirmEmail` lexicon. Privileged admin/ozone writes still need a real operator session and are not invented here.
+This stack fills leftover *library* gaps vs current public lexicons: `app.bsky.feed.defs#knownLikers` (Aug 2026 viewer hydration), video embed `presentation` (`default`/`gif`), and a `com.atproto.lexicon.schema` record builder for publishing lexicon documents.
+
+Privileged admin/ozone writes still need a real operator session and are not invented here.
 
 Still leftover vs current lexicons (not invented here):
 
@@ -140,7 +142,11 @@ let upload =
 let embed =
   Video.video_embed_json
     ~video:(`Assoc [ ("$type", `String "blob"); ("mimeType", `String "video/mp4") ])
-    ~alt:"demo" ()
+    ~alt:"demo" ~presentation:"gif" ()
+let schema =
+  Records.lexicon_schema ~id:"com.example.ping"
+    ~defs:(`Assoc [ ("main", `Assoc [ ("type", `String "query") ]) ])
+    ()
 let start =
   Video.start_upload_body ~size_bytes:1_048_576 ~mime_type:"video/mp4"
     ~name:"clip.mp4" ()

--- a/atproto.opam
+++ b/atproto.opam
@@ -55,7 +55,8 @@ Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
 Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact,
 Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and
-Response.
+Response. Feed views parse viewer.knownLikers; video embeds carry
+presentation; Records can publish com.atproto.lexicon.schema documents.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -70,7 +70,8 @@ let () =
       ]
   in
   let embed =
-    Video.video_embed_json ~video:blob ~alt:"demo" ~presentation:"gif" () in
+    Video.video_embed_json ~video:blob ~alt:"demo" ~presentation:"gif" ()
+  in
   assert (
     match Yojson.Safe.Util.member "$type" embed with
     | `String "app.bsky.embed.video" -> true
@@ -174,8 +175,8 @@ let () =
       (`Assoc
         [
           ( "uri",
-            `String
-              "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
+            `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+          );
           ("cid", `String "bafyreiabc");
           ( "author",
             `Assoc
@@ -197,8 +198,7 @@ let () =
                           [
                             `Assoc
                               [
-                                ( "did",
-                                  `String "did:plc:abc123xyz0001112223333" );
+                                ("did", `String "did:plc:abc123xyz0001112223333");
                                 ("handle", `String "alice.test");
                               ];
                           ] );

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -69,10 +69,15 @@ let () =
         ("size", `Int 8);
       ]
   in
-  let embed = Video.video_embed_json ~video:blob ~alt:"demo" () in
+  let embed =
+    Video.video_embed_json ~video:blob ~alt:"demo" ~presentation:"gif" () in
   assert (
     match Yojson.Safe.Util.member "$type" embed with
     | `String "app.bsky.embed.video" -> true
+    | _ -> false);
+  assert (
+    match Yojson.Safe.Util.member "presentation" embed with
+    | `String "gif" -> true
     | _ -> false);
   let start =
     Video.start_upload_body ~size_bytes:1_048_576 ~mime_type:"video/mp4"
@@ -163,6 +168,55 @@ let () =
   assert (
     match Yojson.Safe.Util.member "$type" status with
     | `String "app.bsky.actor.status" -> true
+    | _ -> false);
+  let liked =
+    Feed.parse_post
+      (`Assoc
+        [
+          ( "uri",
+            `String
+              "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
+          ("cid", `String "bafyreiabc");
+          ( "author",
+            `Assoc
+              [
+                ("did", `String "did:plc:abc123xyz0001112223333");
+                ("handle", `String "alice.test");
+              ] );
+          ("record", `Assoc [ ("text", `String "hi") ]);
+          ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+          ( "viewer",
+            `Assoc
+              [
+                ( "knownLikers",
+                  `Assoc
+                    [
+                      ("count", `Int 1);
+                      ( "actors",
+                        `List
+                          [
+                            `Assoc
+                              [
+                                ( "did",
+                                  `String "did:plc:abc123xyz0001112223333" );
+                                ("handle", `String "alice.test");
+                              ];
+                          ] );
+                    ] );
+              ] );
+        ])
+  in
+  (match liked.known_likers with
+  | Some kl -> assert (kl.count = 1)
+  | None -> assert false);
+  let schema =
+    Records.lexicon_schema ~id:"com.example.ping"
+      ~defs:(`Assoc [ ("main", `Assoc [ ("type", `String "query") ]) ])
+      ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "$type" schema with
+    | `String "com.atproto.lexicon.schema" -> true
     | _ -> false);
   let v2 =
     Feed.parse_search_posts_v2

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -58,6 +58,7 @@ module Embed = struct
     video : video_blob;
     alt : string option;
     aspect_ratio : aspect_ratio option;
+    presentation : string option;
   }
 
   type video_view_embed = {
@@ -67,7 +68,11 @@ module Embed = struct
     thumbnail : string option;
     alt : string option;
     aspect_ratio : aspect_ratio option;
+    presentation : string option;
   }
+
+  let video_presentation_default = "default"
+  let video_presentation_gif = "gif"
 
   type gallery_image = {
     image : image;
@@ -329,6 +334,7 @@ module Embed = struct
       video = json |> member "video" |> parse_video_blob;
       alt = string_opt json "alt";
       aspect_ratio = parse_aspect_ratio (json |> member "aspectRatio");
+      presentation = string_opt json "presentation";
     }
 
   let parse_video_view_embed json : video_view_embed =
@@ -340,6 +346,7 @@ module Embed = struct
       alt = string_opt json "alt";
       aspect_ratio =
         parse_aspect_ratio (Yojson.Safe.Util.member "aspectRatio" json);
+      presentation = string_opt json "presentation";
     }
 
   let parse_to_correct_external_type json =
@@ -721,9 +728,12 @@ module Embed = struct
                 ~size:e.video.size () );
           ]
           @ (match e.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+          @ (match e.aspect_ratio with
+            | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+            | None -> [])
           @
-          match e.aspect_ratio with
-          | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+          match e.presentation with
+          | Some p -> [ ("presentation", `String p) ]
           | None -> []
         in
         `Assoc fields
@@ -738,9 +748,12 @@ module Embed = struct
             | Some t -> [ ("thumbnail", `String t) ]
             | None -> [])
           @ (match e.alt with Some a -> [ ("alt", `String a) ] | None -> [])
+          @ (match e.aspect_ratio with
+            | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+            | None -> [])
           @
-          match e.aspect_ratio with
-          | Some a -> [ ("aspectRatio", aspect_ratio_to_json a) ]
+          match e.presentation with
+          | Some p -> [ ("presentation", `String p) ]
           | None -> []
         in
         `Assoc fields

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -49,6 +49,15 @@ module Feed = struct
     likes : like list;
   }
 
+  (* app.bsky.feed.defs#knownLikers — likers the viewer also follows. *)
+  type known_liker = {
+    did : string;
+    handle : string;
+    display_name : string option;
+  }
+
+  type known_likers = { count : int; actors : known_liker list }
+
   type post = {
     uri : string;
     cid : string;
@@ -61,6 +70,7 @@ module Feed = struct
     bookmark_count : int option;
     indexed_at : string;
     viewer : feed_viewer;
+    known_likers : known_likers option;
     labels : string list option;
     embed : Embed.embed option;
   }
@@ -202,6 +212,33 @@ module Feed = struct
             | true -> `ViewerStatus (Actor.parse_viewer_status json)
             | false -> `EmptyViewer))
 
+  let parse_known_liker json : known_liker =
+    {
+      did = string_or_empty json "did";
+      handle = string_or_empty json "handle";
+      display_name =
+        (match Yojson.Safe.Util.member "displayName" json with
+        | `String s -> Some s
+        | _ -> None);
+    }
+
+  let parse_known_likers json : known_likers =
+    {
+      count = int_or_zero json "count";
+      actors =
+        (match Yojson.Safe.Util.member "actors" json with
+        | `List xs -> List.map parse_known_liker xs
+        | _ -> []);
+    }
+
+  let parse_known_likers_opt json : known_likers option =
+    match json with
+    | `Assoc _ -> (
+        match Yojson.Safe.Util.member "knownLikers" json with
+        | `Assoc _ as obj -> Some (parse_known_likers obj)
+        | _ -> None)
+    | _ -> None
+
   let parse_post json : post =
     let open Yojson.Safe.Util in
     let uri = string_or_empty json "uri" in
@@ -214,7 +251,9 @@ module Feed = struct
     let quote_count = int_opt json "quoteCount" in
     let bookmark_count = int_opt json "bookmarkCount" in
     let indexed_at = string_or_empty json "indexedAt" in
-    let viewer = json |> member "viewer" |> parse_feed_viewer in
+    let viewer_json = json |> member "viewer" in
+    let viewer = parse_feed_viewer viewer_json in
+    let known_likers = parse_known_likers_opt viewer_json in
     let labels = Label.Label.parse_label_values (json |> member "labels") in
     let embed = Embed.parse_embed_option json in
     {
@@ -229,6 +268,7 @@ module Feed = struct
       bookmark_count;
       indexed_at;
       viewer;
+      known_likers;
       labels;
       embed;
     }
@@ -666,6 +706,7 @@ module Feed = struct
     like_count : int option;
     quote_count : int option;
     bookmark_count : int option;
+    known_likers : known_likers option;
     original : Yojson.Safe.t;
   }
 
@@ -855,6 +896,7 @@ module Feed = struct
         (match json |> member "bookmarkCount" with
         | `Int n -> Some n
         | _ -> None);
+      known_likers = parse_known_likers_opt (json |> member "viewer");
       original = json;
     }
 

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -396,8 +396,7 @@ module Records = struct
     let open Yojson.Safe.Util in
     {
       lexicon = (match json |> member "lexicon" with `Int n -> n | _ -> 1);
-      id =
-        (match json |> member "id" with `String s -> Some s | _ -> None);
+      id = (match json |> member "id" with `String s -> Some s | _ -> None);
       description =
         (match json |> member "description" with
         | `String s -> Some s

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -23,6 +23,7 @@ module Records = struct
   let nsid_generator = "app.bsky.feed.generator"
   let nsid_labeler_service = "app.bsky.labeler.service"
   let nsid_notification_declaration = "app.bsky.notification.declaration"
+  let nsid_lexicon_schema = "com.atproto.lexicon.schema"
   let status_live = "app.bsky.actor.status#live"
   let purpose_modlist = "app.bsky.graph.defs#modlist"
   let purpose_curatelist = "app.bsky.graph.defs#curatelist"
@@ -368,6 +369,41 @@ module Records = struct
         ("$type", `String nsid_notification_declaration);
         ("allowSubscriptions", `String allow_subscriptions);
       ]
+
+  let lexicon_schema ~id ~defs ?description () : Yojson.Safe.t =
+    let fields =
+      [
+        ("$type", `String nsid_lexicon_schema);
+        ("lexicon", `Int 1);
+        ("id", `String id);
+        ("defs", defs);
+      ]
+      @
+      match description with
+      | Some d -> [ ("description", `String d) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  type lexicon_schema_record = {
+    lexicon : int;
+    id : string option;
+    description : string option;
+    defs : Yojson.Safe.t;
+  }
+
+  let parse_lexicon_schema json : lexicon_schema_record =
+    let open Yojson.Safe.Util in
+    {
+      lexicon = (match json |> member "lexicon" with `Int n -> n | _ -> 1);
+      id =
+        (match json |> member "id" with `String s -> Some s | _ -> None);
+      description =
+        (match json |> member "description" with
+        | `String s -> Some s
+        | _ -> None);
+      defs = json |> member "defs";
+    }
 
   let chat_declaration ~allow_incoming ?allow_group_invites () : Yojson.Safe.t =
     let fields =

--- a/src/bsky/video.ml
+++ b/src/bsky/video.ml
@@ -207,13 +207,17 @@ module Video = struct
   let aspect_ratio_json (ar : aspect_ratio) : Yojson.Safe.t =
     `Assoc [ ("width", `Int ar.width); ("height", `Int ar.height) ]
 
-  let video_embed_json ~video ?alt ?aspect_ratio () : Yojson.Safe.t =
+  let video_embed_json ~video ?alt ?aspect_ratio ?presentation () :
+      Yojson.Safe.t =
     let fields =
       [ ("$type", `String "app.bsky.embed.video"); ("video", video) ]
       @ (match alt with Some a -> [ ("alt", `String a) ] | None -> [])
+      @ (match aspect_ratio with
+        | Some ar -> [ ("aspectRatio", aspect_ratio_json ar) ]
+        | None -> [])
       @
-      match aspect_ratio with
-      | Some ar -> [ ("aspectRatio", aspect_ratio_json ar) ]
+      match presentation with
+      | Some p -> [ ("presentation", `String p) ]
       | None -> []
     in
     `Assoc fields

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -408,6 +408,15 @@ module Lexicon = struct
   let official_confirm_email =
     {|{"lexicon":1,"id":"com.atproto.server.confirmEmail","defs":{"main":{"type":"procedure","description":"Confirm an email using a token from com.atproto.server.requestEmailConfirmation.","input":{"encoding":"application/json","schema":{"type":"object","required":["email","token"],"properties":{"email":{"type":"string"},"token":{"type":"string"}}}}}}}|}
 
+  let official_feed_known_likers =
+    {|{"lexicon":1,"id":"app.bsky.feed.defs","defs":{"knownLikers":{"type":"object","description":"The post's likers whom you also follow","required":["count","actors"],"properties":{"count":{"type":"integer"},"actors":{"type":"array","items":{"type":"ref","ref":"app.bsky.actor.defs#profileViewBasic"}}}},"viewerState":{"type":"object","properties":{"repost":{"type":"string"},"like":{"type":"string"},"bookmarked":{"type":"boolean"},"threadMuted":{"type":"boolean"},"replyDisabled":{"type":"boolean"},"embeddingDisabled":{"type":"boolean"},"pinned":{"type":"boolean"},"knownLikers":{"type":"ref","ref":"#knownLikers"}}}}}|}
+
+  let official_embed_video =
+    {|{"lexicon":1,"id":"app.bsky.embed.video","defs":{"main":{"type":"object","required":["video"],"properties":{"video":{"type":"blob"},"alt":{"type":"string"},"aspectRatio":{"type":"ref","ref":"app.bsky.embed.defs#aspectRatio"},"presentation":{"type":"string","knownValues":["default","gif"]}}},"view":{"type":"object","required":["cid","playlist"],"properties":{"cid":{"type":"string"},"playlist":{"type":"string"},"alt":{"type":"string"},"presentation":{"type":"string","knownValues":["default","gif"]}}}}}|}
+
+  let official_lexicon_schema =
+    {|{"lexicon":1,"id":"com.atproto.lexicon.schema","defs":{"main":{"type":"record","description":"Representation of Lexicon schemas themselves, when published as atproto records.","key":"nsid","record":{"type":"object","required":["lexicon"],"properties":{"lexicon":{"type":"integer"}}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -437,6 +446,9 @@ module Lexicon = struct
       ("com.atproto.admin.updateAccountSigningKey", official_admin_signing_key);
       ("chat.bsky.embed.joinLink", official_join_link);
       ("com.atproto.server.confirmEmail", official_confirm_email);
+      ("app.bsky.feed.defs", official_feed_known_likers);
+      ("app.bsky.embed.video", official_embed_video);
+      ("com.atproto.lexicon.schema", official_lexicon_schema);
     ]
 
   let official_documents () : document list =

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -59,13 +59,20 @@ let test_parse_video _ =
             ] );
         ("alt", `String "clip");
         ("aspectRatio", `Assoc [ ("width", `Int 16); ("height", `Int 9) ]);
+        ("presentation", `String "gif");
       ]
   in
   match Embed.parse_embed json with
   | `Video e ->
       OUnit2.assert_equal ~printer:(fun x -> x) "video/mp4" e.video.mime_type;
       OUnit2.assert_equal (Some "clip") e.alt;
-      OUnit2.assert_equal (Some { Embed.width = 16; height = 9 }) e.aspect_ratio
+      OUnit2.assert_equal (Some { Embed.width = 16; height = 9 }) e.aspect_ratio;
+      OUnit2.assert_equal (Some Embed.video_presentation_gif) e.presentation;
+      (match Embed.embed_to_json (`Video e) with
+      | `Assoc fields ->
+          OUnit2.assert_equal (Some (`String "gif"))
+            (List.assoc_opt "presentation" fields)
+      | _ -> OUnit2.assert_failure "expected video json")
   | _ -> OUnit2.assert_failure "expected video embed"
 
 let test_parse_video_view _ =
@@ -76,10 +83,13 @@ let test_parse_video_view _ =
         ("cid", `String "bafyreihdummy000000000000000000000000000000000");
         ("playlist", `String "https://video.bsky.app/watch/playlist.m3u8");
         ("thumbnail", `String "https://video.bsky.app/watch/thumb.jpg");
+        ("presentation", `String "default");
       ]
   in
   match Embed.parse_embed json with
-  | `VideoView e -> OUnit2.assert_bool "playlist" (String.length e.playlist > 0)
+  | `VideoView e ->
+      OUnit2.assert_bool "playlist" (String.length e.playlist > 0);
+      OUnit2.assert_equal (Some Embed.video_presentation_default) e.presentation
   | _ -> OUnit2.assert_failure "expected video view"
 
 let test_parse_record _ =

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -63,14 +63,15 @@ let test_parse_video _ =
       ]
   in
   match Embed.parse_embed json with
-  | `Video e ->
+  | `Video e -> (
       OUnit2.assert_equal ~printer:(fun x -> x) "video/mp4" e.video.mime_type;
       OUnit2.assert_equal (Some "clip") e.alt;
       OUnit2.assert_equal (Some { Embed.width = 16; height = 9 }) e.aspect_ratio;
       OUnit2.assert_equal (Some Embed.video_presentation_gif) e.presentation;
-      (match Embed.embed_to_json (`Video e) with
+      match Embed.embed_to_json (`Video e) with
       | `Assoc fields ->
-          OUnit2.assert_equal (Some (`String "gif"))
+          OUnit2.assert_equal
+            (Some (`String "gif"))
             (List.assoc_opt "presentation" fields)
       | _ -> OUnit2.assert_failure "expected video json")
   | _ -> OUnit2.assert_failure "expected video embed"

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -384,8 +384,7 @@ let test_parse_known_likers _ =
   let json =
     post_view_json
       ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
-      ~text:"liked"
-      ()
+      ~text:"liked" ()
     |> function
     | `Assoc fields ->
         `Assoc
@@ -408,8 +407,8 @@ let test_parse_known_likers _ =
                                 `Assoc
                                   [
                                     ( "did",
-                                      `String
-                                        "did:plc:abc123xyz0001112223333" );
+                                      `String "did:plc:abc123xyz0001112223333"
+                                    );
                                     ("handle", `String "alice.test");
                                     ("displayName", `String "Alice");
                                   ];

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -380,6 +380,60 @@ let test_parse_reply_ref_not_found _ =
   | `Post p -> OUnit2.assert_equal ~printer:(fun x -> x) "parent" p.record.text
   | _ -> OUnit2.assert_failure "expected parent post"
 
+let test_parse_known_likers _ =
+  let json =
+    post_view_json
+      ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+      ~text:"liked"
+      ()
+    |> function
+    | `Assoc fields ->
+        `Assoc
+          (fields
+          @ [
+              ( "viewer",
+                `Assoc
+                  [
+                    ( "like",
+                      `String
+                        "at://did:plc:abc123xyz0001112223333/app.bsky.feed.like/1"
+                    );
+                    ( "knownLikers",
+                      `Assoc
+                        [
+                          ("count", `Int 12);
+                          ( "actors",
+                            `List
+                              [
+                                `Assoc
+                                  [
+                                    ( "did",
+                                      `String
+                                        "did:plc:abc123xyz0001112223333" );
+                                    ("handle", `String "alice.test");
+                                    ("displayName", `String "Alice");
+                                  ];
+                              ] );
+                        ] );
+                  ] );
+            ])
+    | other -> other
+  in
+  let post = Feed.parse_post json in
+  (match post.known_likers with
+  | Some kl ->
+      OUnit2.assert_equal 12 kl.count;
+      OUnit2.assert_equal 1 (List.length kl.actors);
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "alice.test" (List.hd kl.actors).handle;
+      OUnit2.assert_equal (Some "Alice") (List.hd kl.actors).display_name
+  | None -> OUnit2.assert_failure "expected knownLikers on post viewer");
+  let view = Feed.parse_post_view json in
+  match view.known_likers with
+  | Some kl -> OUnit2.assert_equal 12 kl.count
+  | None -> OUnit2.assert_failure "expected knownLikers on post_view"
+
 let test_parse_post_view_embed _ =
   let json =
     `Assoc
@@ -482,6 +536,7 @@ let suite =
          >:: test_parse_thread_view_with_embed;
          "test_parse_blocked_thread" >:: test_parse_blocked_thread;
          "test_parse_reply_ref_not_found" >:: test_parse_reply_ref_not_found;
+         "test_parse_known_likers" >:: test_parse_known_likers;
          "test_parse_post_view_embed" >:: test_parse_post_view_embed;
          "test_send_interactions_body" >:: test_send_interactions_body;
          "test_get_feed_generator_live" >:: test_get_feed_generator_live;

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -228,7 +228,21 @@ let test_union_codegen_and_official_bundle _ =
               "chat.bsky.embed.joinLink";
               "com.atproto.admin.updateAccountSigningKey";
               "com.atproto.server.confirmEmail";
-            ])
+              "app.bsky.feed.defs";
+              "app.bsky.embed.video";
+              "com.atproto.lexicon.schema";
+            ];
+          let defs =
+            List.find
+              (fun (d : Lexicon.document) -> d.id = "app.bsky.feed.defs")
+              docs
+          in
+          let known =
+            List.find
+              (fun (d : Lexicon.def) -> d.name = "knownLikers")
+              defs.defs
+          in
+          OUnit2.assert_equal [ "count"; "actors" ] known.required)
 
 let test_parse_resolved_lexicon _ =
   let json =

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -242,7 +242,30 @@ let test_remaining_record_builders _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "app.bsky.labeler.service"
-    (labeler |> member "$type" |> to_string)
+    (labeler |> member "$type" |> to_string);
+  let schema =
+    Records.lexicon_schema ~id:"com.example.ping"
+      ~description:"tiny ping lexicon"
+      ~defs:
+        (`Assoc
+          [
+            ( "main",
+              `Assoc
+                [
+                  ("type", `String "query");
+                  ("parameters", `Assoc [ ("type", `String "params") ]);
+                ] );
+          ])
+      ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "com.atproto.lexicon.schema"
+    (schema |> member "$type" |> to_string);
+  OUnit2.assert_equal 1 (schema |> member "lexicon" |> to_int);
+  let parsed = Records.parse_lexicon_schema schema in
+  OUnit2.assert_equal 1 parsed.lexicon;
+  OUnit2.assert_equal (Some "com.example.ping") parsed.id
 
 let suite =
   "records"

--- a/test/test_video.ml
+++ b/test/test_video.ml
@@ -226,7 +226,7 @@ let test_ensure_blob_short_circuit _ =
 let test_video_embed_json _ =
   let embed =
     Video.video_embed_json ~video:sample_blob ~alt:"demo"
-      ~aspect_ratio:{ width = 16; height = 9 } ()
+      ~aspect_ratio:{ width = 16; height = 9 } ~presentation:"gif" ()
   in
   let open Yojson.Safe.Util in
   OUnit2.assert_equal
@@ -238,7 +238,11 @@ let test_video_embed_json _ =
     "demo"
     (embed |> member "alt" |> to_string);
   OUnit2.assert_equal 16
-    (embed |> member "aspectRatio" |> member "width" |> to_int)
+    (embed |> member "aspectRatio" |> member "width" |> to_int);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "gif"
+    (embed |> member "presentation" |> to_string)
 
 let test_upload_headers _ =
   let pairs =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Retargets this PR onto current `main` after #85 merged (`4b4e0e8`). Keeps only unique leftover library work. Does **not** redo #70–#85.

Official public XRPC NSIDs were already covered. This fills leftover *library* gaps vs current official lexicons:

- **`app.bsky.feed.defs#knownLikers`** (added 2026-08-20): parse `viewer.knownLikers` `{count, actors}` on `Feed.post` and `Feed.post_view`
- **`app.bsky.embed.video` `presentation`**: `default` / `gif` on record + view parse/serialize, plus `Video.video_embed_json ?presentation`
- **`com.atproto.lexicon.schema`**: record builder/parser for publishing lexicon documents (`lexicon` + `id` / `defs`)
- Bundled official lexicon snippets for those three documents (alongside #85's `confirmEmail` bundle)
- README / `atproto.opam` / `examples/offline.ml` notes

Fixes # (issue)

## Tests

Local `dune build` and `dune runtest` passed on this rebased revision. Auth/admin/ozone live suites skip without real `ATP_AUTH`. New unit tests cover knownLikers parse, video presentation roundtrip, lexicon.schema builder, and the bundled documents.

## Still leftover (explicit)

- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`)
- Deprecated `com.atproto.sync.getCheckout` / `getHead` (use `getRepo` / `getLatestCommit`)
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (OAuth scope tokens, not XRPC)
- `internal.bsky.actor.getProfiles` (service-to-service AppView query)
- Hosted OAuth metadata URL, browser login, PDS, Tap, video transcoder, Jetstream archive operator token
- Permissioned data / spaces / LtHash (no stable public spec)
- Official `com.atproto.sync.getRepo` still has no `collection` query parameter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2e6b5b5-9ae7-4b38-9471-7f4dd1fc80ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2e6b5b5-9ae7-4b38-9471-7f4dd1fc80ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

