### PR TITLE
Parse scoped mutes, profile associated/verification, and session extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 
 | Area | Module | Notes |
 | --- | --- | --- |
-| Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT` |
-| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds) |
+| Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT`; optional `authFactorToken` / `allowTakendown`; typed `getSession` (`emailConfirmed`, `active`, `status`) |
+| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds). Profile views parse pronouns/website, `associated` (chat / germ / activitySubscription), verification, status, and viewer scoped mutes / knownFollowers |
 | AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts, `viewer.knownLikers`), generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
-| AppView graph | `Graph` | Follows/blocks/mutes, lists, starter packs, `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships, known followers |
+| AppView graph | `Graph` | Follows/blocks/mutes (including `muteActor` `onlyReposts` / `onlyQuoteposts` scoped mutes), lists, starter packs, `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships, known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
@@ -46,7 +46,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; `tools.ozone.queue.*` (list/create/update/delete, moderator assign, `routeReports`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration / `com.atproto.lexicon.schema` |
-| Server | `Server` | describe server (typed), app passwords, invites, `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / `checkAccountStatus` clients), `getServiceAuth` (aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`) |
+| Server | `Server` | describe server (typed), app passwords (`privileged`), invites, `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / `checkAccountStatus` clients), `createAccount` extras (`did`, `verificationCode` / `verificationPhone`, `plcOp`), `getServiceAuth` (aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`) |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` DID document + updateHandle / PLC operation helpers + `refreshIdentity` |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
@@ -84,9 +84,9 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-#70–#85 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate clients, and extra DAG-CBOR / HTTP/2 tests.
+#70–#86 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate clients, `knownLikers`, video `presentation`, and `lexicon.schema`.
 
-This stack fills leftover *library* gaps vs current public lexicons: `app.bsky.feed.defs#knownLikers` (Aug 2026 viewer hydration), video embed `presentation` (`default`/`gif`), and a `com.atproto.lexicon.schema` record builder for publishing lexicon documents.
+This stack fills remaining current-lexicon *library* gaps: scoped mutes (`muteActor` `onlyReposts` / `onlyQuoteposts` and viewer `mutedOnlyReposts` / `mutedOnlyQuoteposts`), profile view `associated` (including germ), verification/status/pronouns/website, feed viewer flags (`bookmarked` / `threadMuted` / `replyDisabled` / `embeddingDisabled` / `pinned`), `createSession` `authFactorToken` / `allowTakendown`, typed `getSession`, `createAccount` import/verification/`plcOp` fields, and privileged app passwords.
 
 Privileged admin/ozone writes still need a real operator session and are not invented here.
 
@@ -178,7 +178,13 @@ let scopes = Oauth_scope.parse "atproto repo:app.bsky.feed.post"
 let username, password = Auth.username_and_password_from_env
 let session = Session.create_session username password
 let profile = Actor.get_profile session "jay.bsky.team"
+let _ = profile.pronouns
+let _ = profile.viewer.muted_only_reposts
 let prefs = Actor.get_preferences session
+let _ = Graph.mute_actor_body ~actor:"alice.test" ~only_reposts:true ()
+let _ =
+  Auth.create_session_body ~identifier:"alice.test" ~password:"x"
+    ~allow_takendown:true ()
 let bookmarks = Bookmark.get_bookmarks session ~limit:10 ()
 (* chat + ozone always need atproto-proxy (defaults shown) *)
 let convos = Chat.list_convos session ~limit:10 ()

--- a/atproto.opam
+++ b/atproto.opam
@@ -55,8 +55,10 @@ Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
 Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact,
 Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and
-Response. Feed views parse viewer.knownLikers; video embeds carry
-presentation; Records can publish com.atproto.lexicon.schema documents.
+Response. Feed views parse viewer.knownLikers and bookmarked/threadMuted
+flags; graph mutes accept onlyReposts/onlyQuoteposts scopes; profile views
+parse associated.germ and verification; createSession accepts
+authFactorToken/allowTakendown.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -38,6 +38,8 @@ open Atproto.Admin
 open Atproto.Request
 open Atproto.Response
 open Atproto.Http_client
+open Atproto.Auth
+open Atproto.Session
 
 let () =
   (* TID used as record keys and commit revs *)
@@ -209,6 +211,77 @@ let () =
   (match liked.known_likers with
   | Some kl -> assert (kl.count = 1)
   | None -> assert false);
+  assert (liked.bookmarked = None);
+  let mute =
+    Graph.mute_actor_body ~actor:"alice.test" ~only_reposts:true ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "onlyReposts" mute with
+    | `Bool true -> true
+    | _ -> false);
+  let session_body =
+    Auth.create_session_body ~identifier:"alice.test" ~password:"x"
+      ~allow_takendown:true ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "allowTakendown" session_body with
+    | `Bool true -> true
+    | _ -> false);
+  let acct =
+    Server.create_account_body ~handle:"alice.test"
+      ~verification_code:"123456" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "verificationCode" acct with
+    | `String "123456" -> true
+    | _ -> false);
+  let app_pw = Server.create_app_password_body ~name:"cli" ~privileged:true () in
+  assert (
+    match Yojson.Safe.Util.member "privileged" app_pw with
+    | `Bool true -> true
+    | _ -> false);
+  let profile_view =
+    Actor.parse_profile
+      (`Assoc
+        [
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("handle", `String "alice.test");
+          ("pronouns", `String "she/her");
+          ( "associated",
+            `Assoc
+              [
+                ( "germ",
+                  `Assoc
+                    [
+                      ("showButtonTo", `String "everyone");
+                      ("messageMeUrl", `String "https://germ.example/a");
+                    ] );
+              ] );
+          ( "viewer",
+            `Assoc
+              [ ("muted", `Bool false); ("mutedOnlyReposts", `Bool true) ] );
+        ])
+  in
+  assert (profile_view.pronouns = Some "she/her");
+  assert (profile_view.viewer.muted_only_reposts = Some true);
+  (match profile_view.associated with
+  | Some a -> (
+      match a.germ with
+      | Some g -> assert (g.show_button_to = "everyone")
+      | None -> assert false)
+  | None -> assert false);
+  let sess =
+    Session.parse_session_request
+      (`Assoc
+        [
+          ("handle", `String "alice.test");
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("active", `Bool false);
+          ("status", `String "takendown");
+        ])
+  in
+  assert (sess.email = None);
+  assert (sess.status = Some "takendown");
   let schema =
     Records.lexicon_schema ~id:"com.example.ping"
       ~defs:(`Assoc [ ("main", `Assoc [ ("type", `String "query") ]) ])

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -212,9 +212,7 @@ let () =
   | Some kl -> assert (kl.count = 1)
   | None -> assert false);
   assert (liked.bookmarked = None);
-  let mute =
-    Graph.mute_actor_body ~actor:"alice.test" ~only_reposts:true ()
-  in
+  let mute = Graph.mute_actor_body ~actor:"alice.test" ~only_reposts:true () in
   assert (
     match Yojson.Safe.Util.member "onlyReposts" mute with
     | `Bool true -> true
@@ -228,14 +226,16 @@ let () =
     | `Bool true -> true
     | _ -> false);
   let acct =
-    Server.create_account_body ~handle:"alice.test"
-      ~verification_code:"123456" ()
+    Server.create_account_body ~handle:"alice.test" ~verification_code:"123456"
+      ()
   in
   assert (
     match Yojson.Safe.Util.member "verificationCode" acct with
     | `String "123456" -> true
     | _ -> false);
-  let app_pw = Server.create_app_password_body ~name:"cli" ~privileged:true () in
+  let app_pw =
+    Server.create_app_password_body ~name:"cli" ~privileged:true ()
+  in
   assert (
     match Yojson.Safe.Util.member "privileged" app_pw with
     | `Bool true -> true
@@ -258,8 +258,8 @@ let () =
                     ] );
               ] );
           ( "viewer",
-            `Assoc
-              [ ("muted", `Bool false); ("mutedOnlyReposts", `Bool true) ] );
+            `Assoc [ ("muted", `Bool false); ("mutedOnlyReposts", `Bool true) ]
+          );
         ])
   in
   assert (profile_view.pronouns = Some "she/her");

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -118,9 +118,7 @@ module Auth = struct
   let create_session_body ~identifier ~password ?auth_factor_token
       ?allow_takendown () : Yojson.Safe.t =
     let fields =
-      [
-        ("identifier", `String identifier); ("password", `String password);
-      ]
+      [ ("identifier", `String identifier); ("password", `String password) ]
       @ (match auth_factor_token with
         | Some t -> [ ("authFactorToken", `String t) ]
         | None -> [])

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -115,12 +115,30 @@ module Auth = struct
     Printf.sprintf "https://%s/%s%s" personal_data_server base_endpoint
       create_session_endpoint
 
-  let make_auth_token_request (username : string) (password : string)
-      (personal_data_server : string) : string =
+  let create_session_body ~identifier ~password ?auth_factor_token
+      ?allow_takendown () : Yojson.Safe.t =
+    let fields =
+      [
+        ("identifier", `String identifier); ("password", `String password);
+      ]
+      @ (match auth_factor_token with
+        | Some t -> [ ("authFactorToken", `String t) ]
+        | None -> [])
+      @
+      match allow_takendown with
+      | Some b -> [ ("allowTakendown", `Bool b) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let make_auth_token_request ?auth_factor_token ?allow_takendown
+      (username : string) (password : string) (personal_data_server : string) :
+      string =
     let url = create_session_url personal_data_server in
     let data =
-      Printf.sprintf "{\"identifier\": \"%s\", \"password\": \"%s\"}" username
-        password
+      Yojson.Safe.to_string
+        (create_session_body ~identifier:username ~password ?auth_factor_token
+           ?allow_takendown ())
     in
     Lwt_main.run (Cohttp_client.post_data url data)
 

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -3,11 +3,84 @@ open Cohttp_client
 open App
 
 module Actor = struct
+  (* app.bsky.actor.defs#knownFollowers — subject's followers the viewer also follows. *)
+  type known_follower = {
+    did : string;
+    handle : string;
+    display_name : string option;
+  }
+
+  type known_followers = { count : int; followers : known_follower list }
+
+  (* app.bsky.notification.defs#activitySubscription on viewerState. *)
+  type viewer_activity_subscription = { post : bool; reply : bool }
+
+  type list_ref = {
+    uri : string;
+    cid : string option;
+    name : string option;
+  }
+
+  (* app.bsky.actor.defs#viewerState — includes scoped mutes (onlyReposts / onlyQuoteposts). *)
   type viewer_status = {
     muted : bool;
+    muted_only_reposts : bool option;
+    muted_only_quoteposts : bool option;
+    muted_by_list : list_ref option;
     blocked_by : bool;
+    blocking : string option;
+    blocking_by_list : list_ref option;
     following : string option;
     followed_by : string option;
+    known_followers : known_followers option;
+    activity_subscription : viewer_activity_subscription option;
+  }
+
+  type profile_associated_chat = {
+    allow_incoming : string;
+    allow_group_invites : string option;
+  }
+
+  (* app.bsky.actor.defs#profileAssociatedGerm — Germ Network button on a profile. *)
+  type profile_associated_germ = {
+    show_button_to : string;
+    message_me_url : string;
+  }
+
+  type profile_associated_activity = { allow_subscriptions : string }
+
+  type profile_associated = {
+    lists : int option;
+    feedgens : int option;
+    starter_packs : int option;
+    labeler : bool option;
+    chat : profile_associated_chat option;
+    activity_subscription : profile_associated_activity option;
+    germ : profile_associated_germ option;
+  }
+
+  type verification_view = {
+    issuer : string;
+    issuer_display_name : string option;
+    issuer_handle : string option;
+    uri : string;
+    is_valid : bool;
+    created_at : string;
+  }
+
+  type verification_state = {
+    verifications : verification_view list;
+    verified_status : string;
+    trusted_verifier_status : string;
+  }
+
+  type status_view = {
+    uri : string option;
+    cid : string option;
+    status : string;
+    expires_at : string option;
+    is_active : bool option;
+    is_disabled : bool option;
   }
 
   type profile = {
@@ -15,12 +88,19 @@ module Actor = struct
     handle : string;
     display_name : string option;
     description : string option;
+    pronouns : string option;
+    website : string option;
     avatar : string option;
     banner : string option;
     follows_count : int;
     followers_count : int;
     posts_count : int;
     indexed_at : string;
+    created_at : string option;
+    pinned_post_uri : string option;
+    associated : profile_associated option;
+    verification : verification_state option;
+    status : status_view option;
     viewer : viewer_status;
     labels : string list option;
   }
@@ -66,16 +146,89 @@ module Actor = struct
     let open Yojson.Safe.Util in
     try Some (to_string (member field json)) with Type_error _ -> None
 
+  let extract_bool_option json field : bool option =
+    match Yojson.Safe.Util.member field json with
+    | `Bool b -> Some b
+    | _ -> None
+
+  let extract_int_option json field : int option =
+    match Yojson.Safe.Util.member field json with
+    | `Int n -> Some n
+    | `Intlit s -> ( try Some (int_of_string s) with _ -> None)
+    | _ -> None
+
+  let empty_viewer_status : viewer_status =
+    {
+      muted = false;
+      muted_only_reposts = None;
+      muted_only_quoteposts = None;
+      muted_by_list = None;
+      blocked_by = false;
+      blocking = None;
+      blocking_by_list = None;
+      following = None;
+      followed_by = None;
+      known_followers = None;
+      activity_subscription = None;
+    }
+
+  let parse_list_ref json : list_ref option =
+    match json with
+    | `Assoc _ ->
+        (match extract_string_option json "uri" with
+        | None -> None
+        | Some uri ->
+            Some
+              {
+                uri;
+                cid = extract_string_option json "cid";
+                name = extract_string_option json "name";
+              })
+    | _ -> None
+
+  let parse_known_follower json : known_follower =
+    {
+      did = (match extract_string_option json "did" with Some s -> s | None -> "");
+      handle =
+        (match extract_string_option json "handle" with Some s -> s | None -> "");
+      display_name = extract_string_option json "displayName";
+    }
+
+  let parse_known_followers_opt json : known_followers option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            count =
+              (match extract_int_option json "count" with Some n -> n | None -> 0);
+            followers =
+              (match Yojson.Safe.Util.member "followers" json with
+              | `List xs -> List.map parse_known_follower xs
+              | _ -> []);
+          }
+    | _ -> None
+
+  let parse_viewer_activity_subscription json : viewer_activity_subscription option
+      =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            post =
+              (match extract_bool_option json "post" with
+              | Some b -> b
+              | None -> false);
+            reply =
+              (match extract_bool_option json "reply" with
+              | Some b -> b
+              | None -> false);
+          }
+    | _ -> None
+
   let parse_viewer_status json : viewer_status =
     let open Yojson.Safe.Util in
     match json with
-    | `Null ->
-        {
-          muted = false;
-          blocked_by = false;
-          following = None;
-          followed_by = None;
-        }
+    | `Null -> empty_viewer_status
     | _ ->
         let muted =
           match json |> member "muted" with `Bool b -> b | _ -> false
@@ -83,9 +236,114 @@ module Actor = struct
         let blocked_by =
           match json |> member "blockedBy" with `Bool b -> b | _ -> false
         in
-        let following = extract_string_option json "following" in
-        let followed_by = extract_string_option json "followedBy" in
-        { muted; blocked_by; following; followed_by }
+        {
+          muted;
+          muted_only_reposts = extract_bool_option json "mutedOnlyReposts";
+          muted_only_quoteposts = extract_bool_option json "mutedOnlyQuoteposts";
+          muted_by_list = parse_list_ref (json |> member "mutedByList");
+          blocked_by;
+          blocking = extract_string_option json "blocking";
+          blocking_by_list = parse_list_ref (json |> member "blockingByList");
+          following = extract_string_option json "following";
+          followed_by = extract_string_option json "followedBy";
+          known_followers = parse_known_followers_opt (json |> member "knownFollowers");
+          activity_subscription =
+            parse_viewer_activity_subscription
+              (json |> member "activitySubscription");
+        }
+
+  let parse_associated_chat json : profile_associated_chat option =
+    match extract_string_option json "allowIncoming" with
+    | None -> None
+    | Some allow_incoming ->
+        Some
+          {
+            allow_incoming;
+            allow_group_invites = extract_string_option json "allowGroupInvites";
+          }
+
+  let parse_associated_germ json : profile_associated_germ option =
+    match
+      ( extract_string_option json "showButtonTo",
+        extract_string_option json "messageMeUrl" )
+    with
+    | Some show_button_to, Some message_me_url ->
+        Some { show_button_to; message_me_url }
+    | _ -> None
+
+  let parse_associated json : profile_associated option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            lists = extract_int_option json "lists";
+            feedgens = extract_int_option json "feedgens";
+            starter_packs = extract_int_option json "starterPacks";
+            labeler = extract_bool_option json "labeler";
+            chat =
+              (match Yojson.Safe.Util.member "chat" json with
+              | `Assoc _ as c -> parse_associated_chat c
+              | _ -> None);
+            activity_subscription =
+              (match Yojson.Safe.Util.member "activitySubscription" json with
+              | `Assoc _ as a ->
+                  (match extract_string_option a "allowSubscriptions" with
+                  | Some s -> Some { allow_subscriptions = s }
+                  | None -> None)
+              | _ -> None);
+            germ =
+              (match Yojson.Safe.Util.member "germ" json with
+              | `Assoc _ as g -> parse_associated_germ g
+              | _ -> None);
+          }
+    | _ -> None
+
+  let parse_verification_view json : verification_view =
+    {
+      issuer =
+        (match extract_string_option json "issuer" with Some s -> s | None -> "");
+      issuer_display_name = extract_string_option json "issuerDisplayName";
+      issuer_handle = extract_string_option json "issuerHandle";
+      uri = (match extract_string_option json "uri" with Some s -> s | None -> "");
+      is_valid =
+        (match extract_bool_option json "isValid" with Some b -> b | None -> false);
+      created_at =
+        (match extract_string_option json "createdAt" with Some s -> s | None -> "");
+    }
+
+  let parse_verification_state json : verification_state option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            verifications =
+              (match Yojson.Safe.Util.member "verifications" json with
+              | `List xs -> List.map parse_verification_view xs
+              | _ -> []);
+            verified_status =
+              (match extract_string_option json "verifiedStatus" with
+              | Some s -> s
+              | None -> "");
+            trusted_verifier_status =
+              (match extract_string_option json "trustedVerifierStatus" with
+              | Some s -> s
+              | None -> "");
+          }
+    | _ -> None
+
+  let parse_status_view json : status_view option =
+    match extract_string_option json "status" with
+    | None -> None
+    | Some status ->
+        Some
+          {
+            uri = extract_string_option json "uri";
+            cid = extract_string_option json "cid";
+            status;
+            expires_at = extract_string_option json "expiresAt";
+            is_active = extract_bool_option json "isActive";
+            is_disabled = extract_bool_option json "isDisabled";
+          }
 
   let parse_profile json : profile =
     let open Yojson.Safe.Util in
@@ -109,27 +367,33 @@ module Actor = struct
     in
     let viewer =
       match json |> member "viewer" with
-      | `Null ->
-          {
-            muted = false;
-            blocked_by = false;
-            following = None;
-            followed_by = None;
-          }
+      | `Null -> empty_viewer_status
       | v -> parse_viewer_status v
     in
     let labels = Label.Label.parse_label_values (json |> member "labels") in
+    let pinned_post_uri =
+      match json |> member "pinnedPost" with
+      | `Assoc _ as p -> extract_string_option p "uri"
+      | _ -> None
+    in
     {
       did;
       handle;
       display_name;
       description;
+      pronouns = extract_string_option json "pronouns";
+      website = extract_string_option json "website";
       avatar;
       banner;
       follows_count;
       followers_count;
       posts_count;
       indexed_at;
+      created_at = extract_string_option json "createdAt";
+      pinned_post_uri;
+      associated = parse_associated (json |> member "associated");
+      verification = parse_verification_state (json |> member "verification");
+      status = parse_status_view (json |> member "status");
       viewer;
       labels;
     }

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -14,12 +14,7 @@ module Actor = struct
 
   (* app.bsky.notification.defs#activitySubscription on viewerState. *)
   type viewer_activity_subscription = { post : bool; reply : bool }
-
-  type list_ref = {
-    uri : string;
-    cid : string option;
-    name : string option;
-  }
+  type list_ref = { uri : string; cid : string option; name : string option }
 
   (* app.bsky.actor.defs#viewerState — includes scoped mutes (onlyReposts / onlyQuoteposts). *)
   type viewer_status = {
@@ -174,8 +169,8 @@ module Actor = struct
 
   let parse_list_ref json : list_ref option =
     match json with
-    | `Assoc _ ->
-        (match extract_string_option json "uri" with
+    | `Assoc _ -> (
+        match extract_string_option json "uri" with
         | None -> None
         | Some uri ->
             Some
@@ -188,9 +183,12 @@ module Actor = struct
 
   let parse_known_follower json : known_follower =
     {
-      did = (match extract_string_option json "did" with Some s -> s | None -> "");
+      did =
+        (match extract_string_option json "did" with Some s -> s | None -> "");
       handle =
-        (match extract_string_option json "handle" with Some s -> s | None -> "");
+        (match extract_string_option json "handle" with
+        | Some s -> s
+        | None -> "");
       display_name = extract_string_option json "displayName";
     }
 
@@ -200,7 +198,9 @@ module Actor = struct
         Some
           {
             count =
-              (match extract_int_option json "count" with Some n -> n | None -> 0);
+              (match extract_int_option json "count" with
+              | Some n -> n
+              | None -> 0);
             followers =
               (match Yojson.Safe.Util.member "followers" json with
               | `List xs -> List.map parse_known_follower xs
@@ -208,8 +208,8 @@ module Actor = struct
           }
     | _ -> None
 
-  let parse_viewer_activity_subscription json : viewer_activity_subscription option
-      =
+  let parse_viewer_activity_subscription json :
+      viewer_activity_subscription option =
     match json with
     | `Assoc _ ->
         Some
@@ -246,7 +246,8 @@ module Actor = struct
           blocking_by_list = parse_list_ref (json |> member "blockingByList");
           following = extract_string_option json "following";
           followed_by = extract_string_option json "followedBy";
-          known_followers = parse_known_followers_opt (json |> member "knownFollowers");
+          known_followers =
+            parse_known_followers_opt (json |> member "knownFollowers");
           activity_subscription =
             parse_viewer_activity_subscription
               (json |> member "activitySubscription");
@@ -286,8 +287,8 @@ module Actor = struct
               | _ -> None);
             activity_subscription =
               (match Yojson.Safe.Util.member "activitySubscription" json with
-              | `Assoc _ as a ->
-                  (match extract_string_option a "allowSubscriptions" with
+              | `Assoc _ as a -> (
+                  match extract_string_option a "allowSubscriptions" with
                   | Some s -> Some { allow_subscriptions = s }
                   | None -> None)
               | _ -> None);
@@ -301,14 +302,21 @@ module Actor = struct
   let parse_verification_view json : verification_view =
     {
       issuer =
-        (match extract_string_option json "issuer" with Some s -> s | None -> "");
+        (match extract_string_option json "issuer" with
+        | Some s -> s
+        | None -> "");
       issuer_display_name = extract_string_option json "issuerDisplayName";
       issuer_handle = extract_string_option json "issuerHandle";
-      uri = (match extract_string_option json "uri" with Some s -> s | None -> "");
+      uri =
+        (match extract_string_option json "uri" with Some s -> s | None -> "");
       is_valid =
-        (match extract_bool_option json "isValid" with Some b -> b | None -> false);
+        (match extract_bool_option json "isValid" with
+        | Some b -> b
+        | None -> false);
       created_at =
-        (match extract_string_option json "createdAt" with Some s -> s | None -> "");
+        (match extract_string_option json "createdAt" with
+        | Some s -> s
+        | None -> "");
     }
 
   let parse_verification_state json : verification_state option =

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -71,6 +71,11 @@ module Feed = struct
     indexed_at : string;
     viewer : feed_viewer;
     known_likers : known_likers option;
+    bookmarked : bool option;
+    thread_muted : bool option;
+    reply_disabled : bool option;
+    embedding_disabled : bool option;
+    pinned : bool option;
     labels : string list option;
     embed : Embed.embed option;
   }
@@ -239,6 +244,14 @@ module Feed = struct
         | _ -> None)
     | _ -> None
 
+  let viewer_bool_opt json field =
+    match json with
+    | `Assoc _ -> (
+        match Yojson.Safe.Util.member field json with
+        | `Bool b -> Some b
+        | _ -> None)
+    | _ -> None
+
   let parse_post json : post =
     let open Yojson.Safe.Util in
     let uri = string_or_empty json "uri" in
@@ -269,6 +282,11 @@ module Feed = struct
       indexed_at;
       viewer;
       known_likers;
+      bookmarked = viewer_bool_opt viewer_json "bookmarked";
+      thread_muted = viewer_bool_opt viewer_json "threadMuted";
+      reply_disabled = viewer_bool_opt viewer_json "replyDisabled";
+      embedding_disabled = viewer_bool_opt viewer_json "embeddingDisabled";
+      pinned = viewer_bool_opt viewer_json "pinned";
       labels;
       embed;
     }
@@ -707,6 +725,11 @@ module Feed = struct
     quote_count : int option;
     bookmark_count : int option;
     known_likers : known_likers option;
+    bookmarked : bool option;
+    thread_muted : bool option;
+    reply_disabled : bool option;
+    embedding_disabled : bool option;
+    pinned : bool option;
     original : Yojson.Safe.t;
   }
 
@@ -897,6 +920,12 @@ module Feed = struct
         | `Int n -> Some n
         | _ -> None);
       known_likers = parse_known_likers_opt (json |> member "viewer");
+      bookmarked = viewer_bool_opt (json |> member "viewer") "bookmarked";
+      thread_muted = viewer_bool_opt (json |> member "viewer") "threadMuted";
+      reply_disabled = viewer_bool_opt (json |> member "viewer") "replyDisabled";
+      embedding_disabled =
+        viewer_bool_opt (json |> member "viewer") "embeddingDisabled";
+      pinned = viewer_bool_opt (json |> member "viewer") "pinned";
       original = json;
     }
 

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -150,9 +150,10 @@ module Graph = struct
   let mute_actor_body ~actor ?only_reposts ?only_quoteposts () : Yojson.Safe.t =
     let fields =
       ("actor", `String actor)
-      :: (match only_reposts with
-         | Some b -> [ ("onlyReposts", `Bool b) ]
-         | None -> [])
+      ::
+      (match only_reposts with
+      | Some b -> [ ("onlyReposts", `Bool b) ]
+      | None -> [])
       @
       match only_quoteposts with
       | Some b -> [ ("onlyQuoteposts", `Bool b) ]

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -145,7 +145,23 @@ module Graph = struct
     in
     mutes |> convert_body_to_json |> parse_mutes
 
-  let mute_actor (s : Session.session) (actor : string) : string =
+  (* app.bsky.graph.muteActor — optional onlyReposts / onlyQuoteposts replace
+     a full mute with a scoped mute. Repeat calls replace the stored scope. *)
+  let mute_actor_body ~actor ?only_reposts ?only_quoteposts () : Yojson.Safe.t =
+    let fields =
+      ("actor", `String actor)
+      :: (match only_reposts with
+         | Some b -> [ ("onlyReposts", `Bool b) ]
+         | None -> [])
+      @
+      match only_quoteposts with
+      | Some b -> [ ("onlyQuoteposts", `Bool b) ]
+      | None -> []
+    in
+    `Assoc fields
+
+  let mute_actor (s : Session.session) ?only_reposts ?only_quoteposts
+      (actor : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
     let headers =
@@ -155,7 +171,10 @@ module Graph = struct
     let get_muted_actor_url =
       App.create_endpoint_url base_url (create_graph_endpoint "muteActor")
     in
-    let data = Printf.sprintf "{\"actor\": \"%s\"}" actor in
+    let data =
+      Yojson.Safe.to_string
+        (mute_actor_body ~actor ?only_reposts ?only_quoteposts ())
+    in
     let muted_actor =
       Lwt_main.run
         (Cohttp_client.post_data_with_headers get_muted_actor_url data headers)

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -176,7 +176,8 @@ module Records = struct
     `Assoc fields
 
   let profile ?display_name ?description ?pronouns ?website ?avatar ?banner
-      ?self_labels ?pinned_post ?created_at () : Yojson.Safe.t =
+      ?self_labels ?pinned_post ?joined_via_starter_pack ?created_at () :
+      Yojson.Safe.t =
     let fields =
       [ ("$type", `String nsid_profile) ]
       @ (match display_name with
@@ -195,6 +196,9 @@ module Records = struct
         | Some xs -> [ ("labels", Label.Label.self_labels_to_json xs) ]
         | None -> [])
       @ (match pinned_post with Some r -> [ ("pinnedPost", r) ] | None -> [])
+      @ (match joined_via_starter_pack with
+        | Some r -> [ ("joinedViaStarterPack", r) ]
+        | None -> [])
       @
       match created_at with
       | Some s -> [ ("createdAt", `String s) ]

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -417,6 +417,24 @@ module Lexicon = struct
   let official_lexicon_schema =
     {|{"lexicon":1,"id":"com.atproto.lexicon.schema","defs":{"main":{"type":"record","description":"Representation of Lexicon schemas themselves, when published as atproto records.","key":"nsid","record":{"type":"object","required":["lexicon"],"properties":{"lexicon":{"type":"integer"}}}}}}|}
 
+  let official_mute_actor =
+    {|{"lexicon":1,"id":"app.bsky.graph.muteActor","defs":{"main":{"type":"procedure","description":"Creates a mute relationship for the specified account.","input":{"encoding":"application/json","schema":{"type":"object","required":["actor"],"properties":{"actor":{"type":"string"},"onlyReposts":{"type":"boolean"},"onlyQuoteposts":{"type":"boolean"}}}}}}}|}
+
+  let official_actor_defs =
+    {|{"lexicon":1,"id":"app.bsky.actor.defs","defs":{"viewerState":{"type":"object","properties":{"muted":{"type":"boolean"},"mutedOnlyReposts":{"type":"boolean"},"mutedOnlyQuoteposts":{"type":"boolean"},"blocking":{"type":"string"},"knownFollowers":{"type":"ref","ref":"#knownFollowers"}}},"profileAssociatedGerm":{"type":"object","required":["showButtonTo","messageMeUrl"],"properties":{"showButtonTo":{"type":"string"},"messageMeUrl":{"type":"string"}}},"profileAssociated":{"type":"object","properties":{"germ":{"type":"ref","ref":"#profileAssociatedGerm"}}}}}|}
+
+  let official_create_session =
+    {|{"lexicon":1,"id":"com.atproto.server.createSession","defs":{"main":{"type":"procedure","description":"Create an authentication session.","input":{"encoding":"application/json","schema":{"type":"object","required":["identifier","password"],"properties":{"identifier":{"type":"string"},"password":{"type":"string"},"authFactorToken":{"type":"string"},"allowTakendown":{"type":"boolean"}}}}}}}|}
+
+  let official_create_account =
+    {|{"lexicon":1,"id":"com.atproto.server.createAccount","defs":{"main":{"type":"procedure","description":"Create an account.","input":{"encoding":"application/json","schema":{"type":"object","required":["handle"],"properties":{"handle":{"type":"string"},"email":{"type":"string"},"did":{"type":"string"},"inviteCode":{"type":"string"},"verificationCode":{"type":"string"},"verificationPhone":{"type":"string"},"password":{"type":"string"},"recoveryKey":{"type":"string"},"plcOp":{"type":"unknown"}}}}}}}|}
+
+  let official_get_session =
+    {|{"lexicon":1,"id":"com.atproto.server.getSession","defs":{"main":{"type":"query","description":"Get information about the current auth session.","output":{"encoding":"application/json","schema":{"type":"object","required":["handle","did"],"properties":{"handle":{"type":"string"},"did":{"type":"string"},"email":{"type":"string"},"emailConfirmed":{"type":"boolean"},"emailAuthFactor":{"type":"boolean"},"active":{"type":"boolean"},"status":{"type":"string"}}}}}}}|}
+
+  let official_create_app_password =
+    {|{"lexicon":1,"id":"com.atproto.server.createAppPassword","defs":{"main":{"type":"procedure","description":"Create an App Password.","input":{"encoding":"application/json","schema":{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"privileged":{"type":"boolean"}}}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -449,6 +467,12 @@ module Lexicon = struct
       ("app.bsky.feed.defs", official_feed_known_likers);
       ("app.bsky.embed.video", official_embed_video);
       ("com.atproto.lexicon.schema", official_lexicon_schema);
+      ("app.bsky.graph.muteActor", official_mute_actor);
+      ("app.bsky.actor.defs", official_actor_defs);
+      ("com.atproto.server.createSession", official_create_session);
+      ("com.atproto.server.createAccount", official_create_account);
+      ("com.atproto.server.getSession", official_get_session);
+      ("com.atproto.server.createAppPassword", official_create_app_password);
     ]
 
   let official_documents () : document list =

--- a/src/server.ml
+++ b/src/server.ml
@@ -43,8 +43,7 @@ module Server = struct
       @ (match recovery_key with
         | Some s -> [ ("recoveryKey", `String s) ]
         | None -> [])
-      @
-      match plc_op with Some v -> [ ("plcOp", v) ] | None -> []
+      @ match plc_op with Some v -> [ ("plcOp", v) ] | None -> []
     in
     `Assoc fields
 
@@ -62,9 +61,8 @@ module Server = struct
     in
     let data =
       Yojson.Safe.to_string
-        (create_account_body ~handle ~email ?did ?invite_code
-           ?verification_code ?verification_phone ~password ?recovery_key
-           ?plc_op ())
+        (create_account_body ~handle ~email ?did ?invite_code ?verification_code
+           ?verification_phone ~password ?recovery_key ?plc_op ())
     in
     let created_account =
       Lwt_main.run

--- a/src/server.ml
+++ b/src/server.ml
@@ -22,8 +22,35 @@ module Server = struct
     in
     server_description
 
+  let create_account_body ~handle ?email ?did ?invite_code ?verification_code
+      ?verification_phone ?password ?recovery_key ?plc_op () : Yojson.Safe.t =
+    let fields =
+      ("handle", `String handle)
+      :: (match email with Some s -> [ ("email", `String s) ] | None -> [])
+      @ (match did with Some s -> [ ("did", `String s) ] | None -> [])
+      @ (match invite_code with
+        | Some s -> [ ("inviteCode", `String s) ]
+        | None -> [])
+      @ (match verification_code with
+        | Some s -> [ ("verificationCode", `String s) ]
+        | None -> [])
+      @ (match verification_phone with
+        | Some s -> [ ("verificationPhone", `String s) ]
+        | None -> [])
+      @ (match password with
+        | Some s -> [ ("password", `String s) ]
+        | None -> [])
+      @ (match recovery_key with
+        | Some s -> [ ("recoveryKey", `String s) ]
+        | None -> [])
+      @
+      match plc_op with Some v -> [ ("plcOp", v) ] | None -> []
+    in
+    `Assoc fields
+
   let create_account (s : Session.session) (handle : string) (email : string)
-      ?invite_code ?recovery_key (password : string) : string =
+      ?invite_code ?recovery_key ?did ?verification_code ?verification_phone
+      ?plc_op (password : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
     let headers =
@@ -34,26 +61,10 @@ module Server = struct
       App.create_endpoint_url base_url (create_server_endpoint "createAccount")
     in
     let data =
-      match (invite_code, recovery_key) with
-      | Some actual_invite_code, Some actual_recovery_key ->
-          Printf.sprintf
-            "{\"email\": \"%s\", \"handle\": \"%s\", \"password\": \"%s\", \
-             \"inviteCode\": \"%s\", \"recoveryKey\": \"%s\"}"
-            email handle password actual_invite_code actual_recovery_key
-      | Some actual_invite_code, None ->
-          Printf.sprintf
-            "{\"email\": \"%s\", \"handle\": \"%s\", \"password\": \"%s\", \
-             \"inviteCode\": \"%s\"}"
-            email handle password actual_invite_code
-      | None, Some actual_recovery_key ->
-          Printf.sprintf
-            "{\"email\": \"%s\", \"handle\": \"%s\", \"password\": \"%s\", \
-             \"recoveryKey\": \"%s\"}"
-            email handle password actual_recovery_key
-      | None, None ->
-          Printf.sprintf
-            "{\"email\": \"%s\", \"handle\": \"%s\", \"password\": \"%s\"}"
-            email handle password
+      Yojson.Safe.to_string
+        (create_account_body ~handle ~email ?did ?invite_code
+           ?verification_code ?verification_phone ~password ?recovery_key
+           ?plc_op ())
     in
     let created_account =
       Lwt_main.run
@@ -61,7 +72,18 @@ module Server = struct
     in
     created_account
 
-  let create_app_password (s : Session.session) (name : string) : string =
+  let create_app_password_body ~name ?privileged () : Yojson.Safe.t =
+    let fields =
+      ("name", `String name)
+      ::
+      (match privileged with
+      | Some b -> [ ("privileged", `Bool b) ]
+      | None -> [])
+    in
+    `Assoc fields
+
+  let create_app_password (s : Session.session) ?privileged (name : string) :
+      string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
     let headers =
@@ -72,7 +94,9 @@ module Server = struct
       App.create_endpoint_url base_url
         (create_server_endpoint "createAppPassword")
     in
-    let data = Printf.sprintf "{\"name\": \"%s\"}" name in
+    let data =
+      Yojson.Safe.to_string (create_app_password_body ~name ?privileged ())
+    in
     let created_app_password =
       Lwt_main.run
         (Cohttp_client.post_data_with_headers create_app_password_url data

--- a/src/session.ml
+++ b/src/session.ml
@@ -9,14 +9,53 @@ module Session = struct
     auth : Auth.auth;
   }
 
-  type session_request = { handle : string; did : string; email : string }
+  (* com.atproto.server.getSession / createSession output extras. *)
+  type session_request = {
+    handle : string;
+    did : string;
+    email : string option;
+    email_confirmed : bool option;
+    email_auth_factor : bool option;
+    active : bool option;
+    status : string option;
+    did_doc : Yojson.Safe.t option;
+  }
 
   let parse_session_request json : session_request =
     let open Yojson.Safe.Util in
     let handle = json |> member "handle" |> to_string in
     let did = json |> member "did" |> to_string in
-    let email = json |> member "email" |> to_string in
-    { handle; did; email }
+    let email =
+      match json |> member "email" with `String s -> Some s | _ -> None
+    in
+    let email_confirmed =
+      match json |> member "emailConfirmed" with `Bool b -> Some b | _ -> None
+    in
+    let email_auth_factor =
+      match json |> member "emailAuthFactor" with `Bool b -> Some b | _ -> None
+    in
+    let active =
+      match json |> member "active" with `Bool b -> Some b | _ -> None
+    in
+    let status =
+      match json |> member "status" with `String s -> Some s | _ -> None
+    in
+    let did_doc =
+      match json |> member "didDoc" with
+      | `Null | `String _ -> None
+      | (`Assoc _ | `List _) as d -> Some d
+      | _ -> None
+    in
+    {
+      handle;
+      did;
+      email;
+      email_confirmed;
+      email_auth_factor;
+      active;
+      status;
+      did_doc;
+    }
 
   let atp_host_from_env : string =
     let atp_host =
@@ -24,9 +63,13 @@ module Session = struct
     in
     atp_host
 
-  let create_session (username : string) (password : string) : session =
+  let create_session ?auth_factor_token ?allow_takendown (username : string)
+      (password : string) : session =
     let atp_host = atp_host_from_env in
-    let body = Auth.make_auth_token_request username password atp_host in
+    let body =
+      Auth.make_auth_token_request ?auth_factor_token ?allow_takendown username
+        password atp_host
+    in
     let session_auth = body |> Auth.convert_body_to_json |> Auth.parse_auth in
     { username; password; atp_host; auth = session_auth }
 
@@ -55,6 +98,9 @@ module Session = struct
         (Cohttp_client.get_request_with_headers get_session_url headers)
     in
     session
+
+  let get_session (s : session) : session_request =
+    Yojson.Safe.from_string (get_session_request s) |> parse_session_request
 
   let refresh_session_auth (s : session) : session =
     if Auth.is_token_expired s.auth then

--- a/src/session.ml
+++ b/src/session.ml
@@ -32,7 +32,9 @@ module Session = struct
       match json |> member "emailConfirmed" with `Bool b -> Some b | _ -> None
     in
     let email_auth_factor =
-      match json |> member "emailAuthFactor" with `Bool b -> Some b | _ -> None
+      match json |> member "emailAuthFactor" with
+      | `Bool b -> Some b
+      | _ -> None
     in
     let active =
       match json |> member "active" with `Bool b -> Some b | _ -> None

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -240,6 +240,145 @@ let test_parse_preferences _ =
   | `Live_event e -> OUnit2.assert_equal [ "live-1" ] e.hidden_feed_ids
   | _ -> OUnit2.assert_failure "expected liveEventPreferences"
 
+let test_parse_profile_and_scoped_mute_viewer _ =
+  let json =
+    `Assoc
+      [
+        ("did", `String "did:plc:abc123xyz0001112223333");
+        ("handle", `String "alice.test");
+        ("displayName", `String "Alice");
+        ("pronouns", `String "she/her");
+        ("website", `String "https://alice.test");
+        ("createdAt", `String "2024-01-01T00:00:00.000Z");
+        ( "pinnedPost",
+          `Assoc
+            [
+              ( "uri",
+                `String
+                  "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
+              ("cid", `String "bafyreiabc");
+            ] );
+        ( "associated",
+          `Assoc
+            [
+              ("lists", `Int 2);
+              ("labeler", `Bool true);
+              ( "chat",
+                `Assoc
+                  [
+                    ("allowIncoming", `String "following");
+                    ("allowGroupInvites", `String "none");
+                  ] );
+              ( "germ",
+                `Assoc
+                  [
+                    ("showButtonTo", `String "everyone");
+                    ("messageMeUrl", `String "https://germ.example/alice");
+                  ] );
+              ( "activitySubscription",
+                `Assoc [ ("allowSubscriptions", `String "followers") ] );
+            ] );
+        ( "verification",
+          `Assoc
+            [
+              ("verifiedStatus", `String "valid");
+              ("trustedVerifierStatus", `String "none");
+              ( "verifications",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ("issuer", `String "did:plc:verifier000111222333444");
+                        ("uri", `String "at://did:plc:verifier/app.bsky.graph.verification/1");
+                        ("isValid", `Bool true);
+                        ("createdAt", `String "2024-02-01T00:00:00.000Z");
+                      ];
+                  ] );
+            ] );
+        ( "status",
+          `Assoc
+            [
+              ("status", `String "app.bsky.actor.status#live");
+              ("isActive", `Bool true);
+            ] );
+        ( "viewer",
+          `Assoc
+            [
+              ("muted", `Bool false);
+              ("mutedOnlyReposts", `Bool true);
+              ("mutedOnlyQuoteposts", `Bool false);
+              ("blockedBy", `Bool false);
+              ( "blocking",
+                `String
+                  "at://did:plc:me/app.bsky.graph.block/1" );
+              ( "knownFollowers",
+                `Assoc
+                  [
+                    ("count", `Int 3);
+                    ( "followers",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("did", `String "did:plc:abc123xyz0001112223333");
+                              ("handle", `String "bob.test");
+                            ];
+                        ] );
+                  ] );
+              ( "activitySubscription",
+                `Assoc [ ("post", `Bool true); ("reply", `Bool false) ] );
+            ] );
+      ]
+  in
+  let profile = Actor.parse_profile json in
+  OUnit2.assert_equal (Some "she/her") profile.pronouns;
+  OUnit2.assert_equal (Some "https://alice.test") profile.website;
+  OUnit2.assert_equal
+    (Some "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k")
+    profile.pinned_post_uri;
+  (match profile.associated with
+  | Some assoc -> (
+      OUnit2.assert_equal (Some 2) assoc.lists;
+      OUnit2.assert_equal (Some true) assoc.labeler;
+      (match assoc.germ with
+      | Some g ->
+          OUnit2.assert_equal
+            ~printer:(fun x -> x)
+            "everyone" g.show_button_to
+      | None -> OUnit2.assert_failure "expected associated.germ");
+      match assoc.chat with
+      | Some c ->
+          OUnit2.assert_equal
+            ~printer:(fun x -> x)
+            "following" c.allow_incoming
+      | None -> OUnit2.assert_failure "expected associated.chat")
+  | None -> OUnit2.assert_failure "expected associated");
+  (match profile.verification with
+  | Some v ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "valid" v.verified_status;
+      OUnit2.assert_equal 1 (List.length v.verifications)
+  | None -> OUnit2.assert_failure "expected verification");
+  (match profile.status with
+  | Some s -> OUnit2.assert_equal (Some true) s.is_active
+  | None -> OUnit2.assert_failure "expected status");
+  OUnit2.assert_equal false profile.viewer.muted;
+  OUnit2.assert_equal (Some true) profile.viewer.muted_only_reposts;
+  OUnit2.assert_equal (Some false) profile.viewer.muted_only_quoteposts;
+  (match profile.viewer.known_followers with
+  | Some kf ->
+      OUnit2.assert_equal 3 kf.count;
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "bob.test" (List.hd kf.followers).handle
+  | None -> OUnit2.assert_failure "expected knownFollowers");
+  match profile.viewer.activity_subscription with
+  | Some a ->
+      OUnit2.assert_equal true a.post;
+      OUnit2.assert_equal false a.reply
+  | None -> OUnit2.assert_failure "expected viewer activitySubscription"
+
 let test_get_preferences_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -257,6 +396,8 @@ let suite =
          "test_search_actors" >:: test_search_actors;
          "test_search_actors_typeahead" >:: test_search_actors_typeahead;
          "test_parse_preferences" >:: test_parse_preferences;
+         "test_parse_profile_and_scoped_mute_viewer"
+         >:: test_parse_profile_and_scoped_mute_viewer;
          "test_get_preferences_auth_skipped"
          >:: test_get_preferences_auth_skipped;
        ]

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -289,7 +289,10 @@ let test_parse_profile_and_scoped_mute_viewer _ =
                     `Assoc
                       [
                         ("issuer", `String "did:plc:verifier000111222333444");
-                        ("uri", `String "at://did:plc:verifier/app.bsky.graph.verification/1");
+                        ( "uri",
+                          `String
+                            "at://did:plc:verifier/app.bsky.graph.verification/1"
+                        );
                         ("isValid", `Bool true);
                         ("createdAt", `String "2024-02-01T00:00:00.000Z");
                       ];
@@ -308,9 +311,7 @@ let test_parse_profile_and_scoped_mute_viewer _ =
               ("mutedOnlyReposts", `Bool true);
               ("mutedOnlyQuoteposts", `Bool false);
               ("blockedBy", `Bool false);
-              ( "blocking",
-                `String
-                  "at://did:plc:me/app.bsky.graph.block/1" );
+              ("blocking", `String "at://did:plc:me/app.bsky.graph.block/1");
               ( "knownFollowers",
                 `Assoc
                   [
@@ -342,22 +343,16 @@ let test_parse_profile_and_scoped_mute_viewer _ =
       OUnit2.assert_equal (Some true) assoc.labeler;
       (match assoc.germ with
       | Some g ->
-          OUnit2.assert_equal
-            ~printer:(fun x -> x)
-            "everyone" g.show_button_to
+          OUnit2.assert_equal ~printer:(fun x -> x) "everyone" g.show_button_to
       | None -> OUnit2.assert_failure "expected associated.germ");
       match assoc.chat with
       | Some c ->
-          OUnit2.assert_equal
-            ~printer:(fun x -> x)
-            "following" c.allow_incoming
+          OUnit2.assert_equal ~printer:(fun x -> x) "following" c.allow_incoming
       | None -> OUnit2.assert_failure "expected associated.chat")
   | None -> OUnit2.assert_failure "expected associated");
   (match profile.verification with
   | Some v ->
-      OUnit2.assert_equal
-        ~printer:(fun x -> x)
-        "valid" v.verified_status;
+      OUnit2.assert_equal ~printer:(fun x -> x) "valid" v.verified_status;
       OUnit2.assert_equal 1 (List.length v.verifications)
   | None -> OUnit2.assert_failure "expected verification");
   (match profile.status with

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -108,6 +108,26 @@ let test_get_base_endpoint _ =
   OUnit2.assert_bool "BASE_ENDPOINT should be non-empty and end with /"
     (String.length endpoint > 0 && endpoint.[String.length endpoint - 1] = '/')
 
+let test_create_session_body _ =
+  let open Yojson.Safe.Util in
+  let basic =
+    Auth.create_session_body ~identifier:"alice.test" ~password:"secret" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "alice.test"
+    (basic |> member "identifier" |> to_string);
+  OUnit2.assert_equal `Null (basic |> member "authFactorToken");
+  let extra =
+    Auth.create_session_body ~identifier:"alice.test" ~password:"secret"
+      ~auth_factor_token:"otp-9" ~allow_takendown:true ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "otp-9"
+    (extra |> member "authFactorToken" |> to_string);
+  OUnit2.assert_equal true (extra |> member "allowTakendown" |> to_bool)
+
 let test_create_session_url _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
@@ -161,6 +181,7 @@ let suite =
          "test_sample_auth_without_jti_refresh_token"
          >:: test_sample_auth_without_jti_refresh_token;
          "test_get_base_endpoint" >:: test_get_base_endpoint;
+         "test_create_session_body" >:: test_create_session_body;
          "test_create_session_url" >:: test_create_session_url;
          "test_make_auth_token_request_valid_info"
          >:: test_make_auth_token_request_valid_info;

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -429,9 +429,39 @@ let test_parse_known_likers _ =
       OUnit2.assert_equal (Some "Alice") (List.hd kl.actors).display_name
   | None -> OUnit2.assert_failure "expected knownLikers on post viewer");
   let view = Feed.parse_post_view json in
-  match view.known_likers with
+  (match view.known_likers with
   | Some kl -> OUnit2.assert_equal 12 kl.count
-  | None -> OUnit2.assert_failure "expected knownLikers on post_view"
+  | None -> OUnit2.assert_failure "expected knownLikers on post_view");
+  let flags =
+    post_view_json
+      ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k"
+      ~text:"flags" ()
+    |> function
+    | `Assoc fields ->
+        `Assoc
+          (fields
+          @ [
+              ( "viewer",
+                `Assoc
+                  [
+                    ("bookmarked", `Bool true);
+                    ("threadMuted", `Bool true);
+                    ("replyDisabled", `Bool false);
+                    ("embeddingDisabled", `Bool true);
+                    ("pinned", `Bool false);
+                  ] );
+            ])
+    | other -> other
+  in
+  let flagged = Feed.parse_post flags in
+  OUnit2.assert_equal (Some true) flagged.bookmarked;
+  OUnit2.assert_equal (Some true) flagged.thread_muted;
+  OUnit2.assert_equal (Some false) flagged.reply_disabled;
+  OUnit2.assert_equal (Some true) flagged.embedding_disabled;
+  OUnit2.assert_equal (Some false) flagged.pinned;
+  let flagged_view = Feed.parse_post_view flags in
+  OUnit2.assert_equal (Some true) flagged_view.bookmarked;
+  OUnit2.assert_equal (Some true) flagged_view.thread_muted
 
 let test_parse_post_view_embed _ =
   let json =

--- a/test/test_graph.ml
+++ b/test/test_graph.ml
@@ -98,6 +98,21 @@ let with_public_timeout ?(seconds = 20) f =
       Sys.set_signal Sys.sigalrm old)
     f
 
+let test_mute_actor_body _ =
+  let open Yojson.Safe.Util in
+  let full = Graph.mute_actor_body ~actor:"alice.test" () in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "alice.test"
+    (full |> member "actor" |> to_string);
+  OUnit2.assert_equal `Null (full |> member "onlyReposts");
+  let scoped =
+    Graph.mute_actor_body ~actor:"did:plc:abc123xyz0001112223333"
+      ~only_reposts:true ~only_quoteposts:false ()
+  in
+  OUnit2.assert_equal true (scoped |> member "onlyReposts" |> to_bool);
+  OUnit2.assert_equal false (scoped |> member "onlyQuoteposts" |> to_bool)
+
 let test_parse_list _ =
   let json =
     `Assoc
@@ -307,6 +322,7 @@ let suite =
          "test_get_mutes" >:: test_get_mutes;
          "test_mute_actor" >:: test_mute_actor;
          "test_unmute_actor" >:: test_unmute_actor;
+         "test_mute_actor_body" >:: test_mute_actor_body;
          "test_parse_list" >:: test_parse_list;
          "test_parse_starter_pack" >:: test_parse_starter_pack;
          "test_parse_relationships" >:: test_parse_relationships;

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -213,7 +213,7 @@ let test_union_codegen_and_official_bundle _ =
       in
       match Lexicon.main list_doc with
       | None -> OUnit2.assert_failure "missing list main"
-      | Some main ->
+      | Some main -> (
           (match List.assoc_opt "labels" main.properties with
           | Some (Lexicon.Union refs) ->
               OUnit2.assert_equal [ "com.atproto.label.defs#selfLabels" ] refs
@@ -274,7 +274,7 @@ let test_union_codegen_and_official_bundle _ =
               OUnit2.assert_bool "onlyReposts"
                 (List.exists
                    (fun (name, _) -> name = "onlyReposts")
-                   main.input.properties))
+                   main.input.properties)))
 
 let test_parse_resolved_lexicon _ =
   let json =

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -231,6 +231,12 @@ let test_union_codegen_and_official_bundle _ =
               "app.bsky.feed.defs";
               "app.bsky.embed.video";
               "com.atproto.lexicon.schema";
+              "app.bsky.graph.muteActor";
+              "app.bsky.actor.defs";
+              "com.atproto.server.createSession";
+              "com.atproto.server.createAccount";
+              "com.atproto.server.getSession";
+              "com.atproto.server.createAppPassword";
             ];
           let defs =
             List.find
@@ -242,7 +248,33 @@ let test_union_codegen_and_official_bundle _ =
               (fun (d : Lexicon.def) -> d.name = "knownLikers")
               defs.defs
           in
-          OUnit2.assert_equal [ "count"; "actors" ] known.required)
+          OUnit2.assert_equal [ "count"; "actors" ] known.required;
+          let actor_defs =
+            List.find
+              (fun (d : Lexicon.document) -> d.id = "app.bsky.actor.defs")
+              docs
+          in
+          let viewer =
+            List.find
+              (fun (d : Lexicon.def) -> d.name = "viewerState")
+              actor_defs.defs
+          in
+          OUnit2.assert_bool "mutedOnlyReposts"
+            (List.exists
+               (fun (name, _) -> name = "mutedOnlyReposts")
+               viewer.properties);
+          let mute =
+            List.find
+              (fun (d : Lexicon.document) -> d.id = "app.bsky.graph.muteActor")
+              docs
+          in
+          match Lexicon.main mute with
+          | None -> OUnit2.assert_failure "missing muteActor main"
+          | Some main ->
+              OUnit2.assert_bool "onlyReposts"
+                (List.exists
+                   (fun (name, _) -> name = "onlyReposts")
+                   main.input.properties))
 
 let test_parse_resolved_lexicon _ =
   let json =

--- a/test/test_records.ml
+++ b/test/test_records.ml
@@ -56,7 +56,17 @@ let test_graph_and_like_builders _ =
   in
   let profile =
     Records.profile ~display_name:"Ada" ~pronouns:"she/her"
-      ~website:"https://atproto.com" ()
+      ~website:"https://atproto.com"
+      ~joined_via_starter_pack:
+        (`Assoc
+          [
+            ( "uri",
+              `String
+                "at://did:plc:alice000111222333444555666/app.bsky.graph.starterpack/3k"
+            );
+            ("cid", `String "bafyreipack");
+          ])
+      ()
   in
   let open Yojson.Safe.Util in
   OUnit2.assert_equal
@@ -74,7 +84,11 @@ let test_graph_and_like_builders _ =
   OUnit2.assert_equal
     ~printer:(fun x -> x)
     "Ada"
-    (profile |> member "displayName" |> to_string)
+    (profile |> member "displayName" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "at://did:plc:alice000111222333444555666/app.bsky.graph.starterpack/3k"
+    (profile |> member "joinedViaStarterPack" |> member "uri" |> to_string)
 
 let test_list_and_starterpack_builders _ =
   let list =

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -125,6 +125,32 @@ let test_reserve_signing_key_body _ =
     "did:plc:abc123xyz0001112223333"
     (body |> member "did" |> to_string)
 
+let test_create_account_and_app_password_bodies _ =
+  let open Yojson.Safe.Util in
+  let acct =
+    Server.create_account_body ~handle:"alice.test" ~email:"a@b.test"
+      ~did:"did:plc:abc123xyz0001112223333" ~verification_code:"123456"
+      ~verification_phone:"+15551212" ~password:"secret"
+      ~plc_op:(`Assoc [ ("sig", `String "abc") ])
+      ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "did:plc:abc123xyz0001112223333"
+    (acct |> member "did" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "123456"
+    (acct |> member "verificationCode" |> to_string);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "abc"
+    (acct |> member "plcOp" |> member "sig" |> to_string);
+  let app = Server.create_app_password_body ~name:"cli" ~privileged:true () in
+  OUnit2.assert_equal true (app |> member "privileged" |> to_bool);
+  let basic = Server.create_app_password_body ~name:"cli" () in
+  OUnit2.assert_equal `Null (basic |> member "privileged")
+
 let test_email_and_account_bodies _ =
   let open Yojson.Safe.Util in
   let confirm = Server.confirm_email_body ~email:"a@b.test" ~token:"tok-1" in
@@ -174,6 +200,8 @@ let suite =
          "test_parse_describe_server_missing_contact"
          >:: test_parse_describe_server_missing_contact;
          "test_reserve_signing_key_body" >:: test_reserve_signing_key_body;
+         "test_create_account_and_app_password_bodies"
+         >:: test_create_account_and_app_password_bodies;
          "test_email_and_account_bodies" >:: test_email_and_account_bodies;
          "test_describe_server_public" >:: test_describe_server_public;
        ]

--- a/test/test_session.ml
+++ b/test/test_session.ml
@@ -79,6 +79,42 @@ let test_bearer_token_from_session _ =
       OUnit2.assert_equal "Authorization" setting_name;
       OUnit2.assert_equal ~printer:string_of_bool true (String.length bearer > 0)
 
+let test_parse_session_request _ =
+  let full =
+    Session.parse_session_request
+      (`Assoc
+        [
+          ("handle", `String "alice.test");
+          ("did", `String "did:plc:abc123xyz0001112223333");
+          ("email", `String "alice@example.com");
+          ("emailConfirmed", `Bool true);
+          ("emailAuthFactor", `Bool false);
+          ("active", `Bool true);
+          ("didDoc", `Assoc [ ("id", `String "did:plc:abc123xyz0001112223333") ]);
+        ])
+  in
+  OUnit2.assert_equal (Some "alice@example.com") full.email;
+  OUnit2.assert_equal (Some true) full.email_confirmed;
+  OUnit2.assert_equal (Some false) full.email_auth_factor;
+  OUnit2.assert_equal (Some true) full.active;
+  OUnit2.assert_equal None full.status;
+  (match full.did_doc with
+  | Some _ -> ()
+  | None -> OUnit2.assert_failure "expected didDoc");
+  let minimal =
+    Session.parse_session_request
+      (`Assoc
+        [
+          ("handle", `String "bob.test");
+          ("did", `String "did:plc:xyz789aaa0001112223333");
+          ("active", `Bool false);
+          ("status", `String "takendown");
+        ])
+  in
+  OUnit2.assert_equal None minimal.email;
+  OUnit2.assert_equal (Some false) minimal.active;
+  OUnit2.assert_equal (Some "takendown") minimal.status
+
 let test_get_session_request _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -110,6 +146,7 @@ let suite =
          "test_sample_session_auth_did" >:: test_sample_session_auth_did;
          "test_create_session" >:: test_create_session;
          "test_bearer_token_from_session" >:: test_bearer_token_from_session;
+         "test_parse_session_request" >:: test_parse_session_request;
          "test_get_session_request" >:: test_get_session_request;
          "test_delete_session" >:: test_delete_session;
        ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Surveyed current official lexicons (`bluesky-social/atproto` `lexicons/`) against `main` after #70–#86. Public XRPC methods and records were already covered; remaining gaps were typed parsers and request bodies for newer official fields.

## What this adds

- **Scoped mutes:** `Graph.mute_actor` / `mute_actor_body` accept `onlyReposts` / `onlyQuoteposts`. `Actor.viewer_status` parses `mutedOnlyReposts` / `mutedOnlyQuoteposts`, plus blocking, knownFollowers, and activitySubscription.
- **Profile views:** pronouns, website, createdAt, pinnedPost, `associated` (chat / germ / activitySubscription / labeler counts), verification state, and status view.
- **Feed viewer flags** leftover after #86: `bookmarked`, `threadMuted`, `replyDisabled`, `embeddingDisabled`, `pinned`.
- **Session / account:** `createSession` `authFactorToken` / `allowTakendown`; typed `getSession` (optional email, `emailConfirmed`, `active`, `status`, `didDoc`); `createAccount` `did` / verification / `plcOp`; privileged app passwords.
- **Records:** `joinedViaStarterPack` on the profile builder.
- Bundled official lexicon snippets + fixture tests. No invented credentials.

## Verification

Local `dune build` and `dune runtest` passed (live ATP_AUTH tests skipped; no invented credentials).

## Still leftover (not invented here)

- Deprecated `com.atproto.temp.fetchLabels`, `com.atproto.sync.getCheckout` / `getHead`
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (not XRPC)
- `internal.bsky.actor.getProfiles`
- Hosted OAuth/PDS/Tap/transcoder/archive token/LtHash
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5d6e548-6390-409c-8cc0-d669e0f7d6d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5d6e548-6390-409c-8cc0-d669e0f7d6d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

