### PR TITLE
Parse leftover official lexicon fields after #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Area | Module | Notes |
 | --- | --- | --- |
 | Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT`; optional `authFactorToken` / `allowTakendown`; typed `getSession` (`emailConfirmed`, `active`, `status`) |
-| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds). Profile views parse pronouns/website, `associated` (chat / germ / activitySubscription), verification, status, and viewer scoped mutes / knownFollowers |
-| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts, `viewer.knownLikers`), generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
-| AppView graph | `Graph` | Follows/blocks/mutes (including `muteActor` `onlyReposts` / `onlyQuoteposts` scoped mutes), lists, starter packs, `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships, known followers |
+| AppView actor | `Actor` | Profiles, search, suggestions, get/put preferences (all current `app.bsky.actor.defs#preferences` kinds). Profile views parse pronouns/website, `associated` (chat / germ / activitySubscription), verification, status, `joinedViaStarterPack`, and viewer scoped mutes / knownFollowers |
+| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts, `viewer.knownLikers`), `getAuthorFeed` (`filter` / `includePins` + public `get_author_feed_page`), reply `grandparentAuthor`, generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
+| AppView graph | `Graph` | Follows/blocks/mutes (including `muteActor` `onlyReposts` / `onlyQuoteposts` scoped mutes), lists, starter packs (`listItemsSample`), `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships (`blockedByList` / `blockingByList`), known followers |
 | Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
 | Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; Network Replay planner + skippable unauthenticated HTTP (no invented archive token); `.jss` v1 header / block-index / columnar decode (zstd via injected callback) |
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, unspecced age-assurance state, suggestion / feed / starter-pack / onboarding / discover / explore / seeMore skeletons, `getPostThreadV2` / `getPostThreadOtherV2`, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `getConvoMembers`; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `getConvoMembers`, `getMessages.relatedProfiles`, group convo lock/join-request fields; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; `tools.ozone.queue.*` (list/create/update/delete, moderator assign, `routeReports`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); requires `atproto-proxy` |
-| Admin | `Admin` | `com.atproto.admin` subject status, account info, invites, email |
+| Admin | `Admin` | `com.atproto.admin` subject status, account info (`inviteNote` / `invitedBy` / `threatSignatures`), invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration / `com.atproto.lexicon.schema` |
-| Server | `Server` | describe server (typed), app passwords (`privileged`), invites, `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / `checkAccountStatus` clients), `createAccount` extras (`did`, `verificationCode` / `verificationPhone`, `plcOp`), `getServiceAuth` (aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`) |
+| Server | `Server` | describe server (typed), app passwords (`privileged`), invites (`createInviteCodes` `forAccounts` body), `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / typed `checkAccountStatus` including `repoCommit` / `repoRev` / `repoBlocks`), `createAccount` extras (`did`, `verificationCode` / `verificationPhone`, `plcOp`), `getServiceAuth` (aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`) |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` DID document + updateHandle / PLC operation helpers + `refreshIdentity` |
 | PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363) |
 | Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
@@ -59,14 +59,14 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Temp | `Temp` | `com.atproto.temp.checkHandleAvailability` (available / suggestions union), `checkSignupQueue`, `dereferenceScope`, plus privileged `addReservedHandle` / `requestPhoneVerification` / `revokeAccountCredentials` clients (no invented operator session). Deprecated `fetchLabels` remains `Label.query_labels` |
 | Firehose | `Firehose`, `Websocket` | RFC 6455 client + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
 | OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce, client metadata, PAR/token loop; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) |
-| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) + `#selfLabels` |
+| Labels | `Label` | `queryLabels` + label / query parse (`ver`, `exp`) + `#selfLabels` + typed `#labelValueDefinition` (`severity` / `blurs` / `locales`) |
 | XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit; service-auth JWT mint/verify (ES256/ES256K, `kid`/`jti`/`iat`/`lxm`, `did#service` aud, replay cache) |
 | Errors | `Error` | XRPC `{error, message}` including rate limits |
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
 | Drafts | `Draft` | `app.bsky.draft` create/get/update/delete + typed draft / embed / threadgate / postgate builders |
 | Contacts | `Contact` | `app.bsky.contact` phone verify, import, matches, dismiss, sync status, remove data |
 | Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union |
-| Embeds / facets | `Embed`, `Facet` | Images, external, record, recordWithMedia, video (`presentation` `default`/`gif`), **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
+| Embeds / facets | `Embed`, `Facet` | Images, external (`readingTime`, `associatedProfiles`, source theme RGB, `associatedRefs`), record, recordWithMedia, video (`presentation` `default`/`gif`), **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
 | Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint` | secp256k1, multibase, CID/CAR varints |
@@ -84,9 +84,9 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-#70–#86 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate clients, `knownLikers`, video `presentation`, and `lexicon.schema`.
+#70–#87 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, `knownLikers` / video `presentation` / `lexicon.schema`, and scoped mutes / profile associated / session extras.
 
-This stack fills remaining current-lexicon *library* gaps: scoped mutes (`muteActor` `onlyReposts` / `onlyQuoteposts` and viewer `mutedOnlyReposts` / `mutedOnlyQuoteposts`), profile view `associated` (including germ), verification/status/pronouns/website, feed viewer flags (`bookmarked` / `threadMuted` / `replyDisabled` / `embeddingDisabled` / `pinned`), `createSession` `authFactorToken` / `allowTakendown`, typed `getSession`, `createAccount` import/verification/`plcOp` fields, and privileged app passwords.
+This stack fills leftover *library* field gaps vs current official lexicons: external-embed hydration (`readingTime`, `associatedProfiles`, source theme), feed `grandparentAuthor` + `getAuthorFeed` `includePins`, graph list-block relationship URIs + starter-pack `listItemsSample`, typed `checkAccountStatus` / label-value definitions, chat `relatedProfiles`, and admin invite/threat fields.
 
 Privileged admin/ozone writes still need a real operator session and are not invented here.
 
@@ -108,6 +108,9 @@ let commit = Sync.get_latest_commit did
 let discover =
   Feed.get_feed_generator
     ~feed:"at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
+    ()
+let author =
+  Feed.get_author_feed_page ~actor:"jay.bsky.team" ~limit:5 ~include_pins:true
     ()
 let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 let posts_v2 = Feed.search_posts_v2 ~query:"atproto" ~hashtags:[ "atproto" ] ~limit:5 ()

--- a/atproto.opam
+++ b/atproto.opam
@@ -55,10 +55,10 @@ Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
 Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact,
 Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and
-Response. Feed views parse viewer.knownLikers and bookmarked/threadMuted
-flags; graph mutes accept onlyReposts/onlyQuoteposts scopes; profile views
-parse associated.germ and verification; createSession accepts
-authFactorToken/allowTakendown.
+Response. Feed views parse grandparentAuthor and getAuthorFeed includePins;
+external embeds parse readingTime / associatedProfiles / source theme;
+label policies parse labelValueDefinition; checkAccountStatus includes
+repoCommit/repoRev/repoBlocks.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -40,6 +40,7 @@ open Atproto.Response
 open Atproto.Http_client
 open Atproto.Auth
 open Atproto.Session
+open Atproto.Label
 
 let () =
   (* TID used as record keys and commit revs *)
@@ -217,6 +218,84 @@ let () =
     match Yojson.Safe.Util.member "onlyReposts" mute with
     | `Bool true -> true
     | _ -> false);
+  let reply =
+    Feed.parse_reply
+      (`Assoc
+        [
+          ( "root",
+            `Assoc
+              [
+                ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/r");
+                ("cid", `String "bafyreiroot");
+                ( "author",
+                  `Assoc
+                    [
+                      ("did", `String "did:plc:abc123xyz0001112223333");
+                      ("handle", `String "alice.test");
+                    ] );
+                ("record", `Assoc [ ("text", `String "root") ]);
+                ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+              ] );
+          ( "parent",
+            `Assoc
+              [
+                ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/p");
+                ("cid", `String "bafyreiparent");
+                ( "author",
+                  `Assoc
+                    [
+                      ("did", `String "did:plc:abc123xyz0001112223333");
+                      ("handle", `String "alice.test");
+                    ] );
+                ("record", `Assoc [ ("text", `String "parent") ]);
+                ("indexedAt", `String "2024-01-01T00:00:00.000Z");
+              ] );
+          ( "grandparentAuthor",
+            `Assoc
+              [
+                ("did", `String "did:plc:abc123xyz0001112223333");
+                ("handle", `String "alice.test");
+              ] );
+        ])
+  in
+  (match reply.grandparent_author with
+  | Some a -> assert (a.handle = "alice.test")
+  | None -> assert false);
+  let status =
+    Server.parse_account_status
+      (`Assoc
+        [
+          ("activated", `Bool true);
+          ("validDid", `Bool true);
+          ("repoCommit", `String "bafyreicommit");
+          ("repoRev", `String "3jzfcijpj2z2a");
+          ("repoBlocks", `Int 1);
+          ("indexedRecords", `Int 1);
+          ("privateStateValues", `Int 0);
+          ("expectedBlobs", `Int 0);
+          ("importedBlobs", `Int 0);
+        ])
+  in
+  assert (status.repo_rev = Some "3jzfcijpj2z2a");
+  let invites =
+    Server.create_invite_codes_body ~code_count:1 ~use_count:1
+      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ] ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "codeCount" invites with
+    | `Int 1 -> true
+    | _ -> false);
+  let lvd =
+    Label.parse_label_value_definition
+      (`Assoc
+        [
+          ("identifier", `String "spam");
+          ("severity", `String "inform");
+          ("blurs", `String "none");
+          ("locales", `List []);
+        ])
+  in
+  assert (lvd.identifier = "spam");
   let session_body =
     Auth.create_session_body ~identifier:"alice.test" ~password:"x"
       ~allow_takendown:true ()

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -225,7 +225,10 @@ let () =
           ( "root",
             `Assoc
               [
-                ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/r");
+                ( "uri",
+                  `String
+                    "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/r"
+                );
                 ("cid", `String "bafyreiroot");
                 ( "author",
                   `Assoc
@@ -239,7 +242,10 @@ let () =
           ( "parent",
             `Assoc
               [
-                ("uri", `String "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/p");
+                ( "uri",
+                  `String
+                    "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/p"
+                );
                 ("cid", `String "bafyreiparent");
                 ( "author",
                   `Assoc
@@ -279,7 +285,8 @@ let () =
   assert (status.repo_rev = Some "3jzfcijpj2z2a");
   let invites =
     Server.create_invite_codes_body ~code_count:1 ~use_count:1
-      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ] ()
+      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ]
+      ()
   in
   assert (
     match Yojson.Safe.Util.member "codeCount" invites with

--- a/src/admin.ml
+++ b/src/admin.ml
@@ -17,6 +17,8 @@ module Admin = struct
     original : Yojson.Safe.t;
   }
 
+  type threat_signature = { property : string; value : string }
+
   type account_info = {
     did : string;
     handle : string;
@@ -25,6 +27,9 @@ module Admin = struct
     invites_disabled : bool option;
     email_confirmed_at : string option;
     deactivated_at : string option;
+    invite_note : string option;
+    invited_by_code : string option;
+    threat_signatures : threat_signature list;
     original : Yojson.Safe.t;
   }
 
@@ -101,7 +106,19 @@ module Admin = struct
       original = json;
     }
 
+  let parse_threat_signature json : threat_signature =
+    {
+      property = Client.string_member json "property";
+      value = Client.string_member json "value";
+    }
+
   let parse_account_info json : account_info =
+    let invited_by_code =
+      match Yojson.Safe.Util.member "invitedBy" json with
+      | `Assoc _ as inv -> Client.string_opt inv "code"
+      | `String s -> Some s
+      | _ -> None
+    in
     {
       did = Client.string_member json "did";
       handle = Client.string_member json "handle";
@@ -110,6 +127,11 @@ module Admin = struct
       invites_disabled = Client.bool_opt json "invitesDisabled";
       email_confirmed_at = Client.string_opt json "emailConfirmedAt";
       deactivated_at = Client.string_opt json "deactivatedAt";
+      invite_note = Client.string_opt json "inviteNote";
+      invited_by_code;
+      threat_signatures =
+        List.map parse_threat_signature
+          (Client.list_member json "threatSignatures");
       original = json;
     }
 

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -93,6 +93,7 @@ module Actor = struct
     indexed_at : string;
     created_at : string option;
     pinned_post_uri : string option;
+    joined_via_starter_pack_uri : string option;
     associated : profile_associated option;
     verification : verification_state option;
     status : status_view option;
@@ -384,6 +385,12 @@ module Actor = struct
       | `Assoc _ as p -> extract_string_option p "uri"
       | _ -> None
     in
+    let joined_via_starter_pack_uri =
+      match json |> member "joinedViaStarterPack" with
+      | `Assoc _ as p -> extract_string_option p "uri"
+      | `String s -> Some s
+      | _ -> None
+    in
     {
       did;
       handle;
@@ -399,6 +406,7 @@ module Actor = struct
       indexed_at;
       created_at = extract_string_option json "createdAt";
       pinned_post_uri;
+      joined_via_starter_pack_uri;
       associated = parse_associated (json |> member "associated");
       verification = parse_verification_state (json |> member "verification");
       status = parse_status_view (json |> member "status");

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -22,11 +22,37 @@ module Embed = struct
     size : int;
   }
 
+  type strong_ref = { uri : string; cid : string }
+
+  type color_rgb = { r : int; g : int; b : int }
+
+  type ext_view_source_theme = {
+    background_rgb : color_rgb option;
+    foreground_rgb : color_rgb option;
+    accent_rgb : color_rgb option;
+    accent_foreground_rgb : color_rgb option;
+  }
+
+  type ext_view_source = {
+    uri : string;
+    title : string;
+    icon : string option;
+    description : string option;
+    theme : ext_view_source_theme option;
+  }
+
+  type associated_profile = {
+    did : string;
+    handle : string;
+    display_name : string option;
+  }
+
   type ext = {
     uri : string;
     thumb : thumb;
     title : string;
     description : string;
+    associated_refs : strong_ref list;
   }
 
   type ext_view = {
@@ -34,6 +60,13 @@ module Embed = struct
     title : string;
     description : string;
     thumb : string;
+    created_at : string option;
+    updated_at : string option;
+    reading_time : int option;
+    labels : string list option;
+    associated_refs : strong_ref list;
+    associated_profiles : associated_profile list;
+    source : ext_view_source option;
   }
 
   type image_data = { alt : string; image : image }
@@ -42,7 +75,6 @@ module Embed = struct
   type image_view_embed = { embed_type : string; images : image_view list }
   type ext_embed = { embed_type : string; ext : ext }
   type ext_view_embed = { embed_type : string; ext : ext_view }
-  type strong_ref = { uri : string; cid : string }
   type record_embed = { embed_type : string; record : strong_ref }
   type aspect_ratio = { width : int; height : int }
 
@@ -191,6 +223,12 @@ module Embed = struct
   let int_member json field =
     match Yojson.Safe.Util.member field json with `Int n -> n | _ -> 0
 
+  let int_opt json field =
+    match Yojson.Safe.Util.member field json with `Int n -> Some n | _ -> None
+
+  let parse_strong_ref json : strong_ref =
+    { uri = string_member json "uri"; cid = string_member json "cid" }
+
   let parse_ref json : ref =
     let open Yojson.Safe.Util in
     let ref_link =
@@ -215,13 +253,69 @@ module Embed = struct
     let size = int_member json "size" in
     { thumb_type = image_type; ref; mime_type; size }
 
+  let parse_strong_ref_list json : strong_ref list =
+    match Yojson.Safe.Util.member "associatedRefs" json with
+    | `List xs -> List.map parse_strong_ref xs
+    | _ -> []
+
+  let parse_color_rgb json : color_rgb option =
+    match json with
+    | `Assoc _ -> (
+        match
+          ( Yojson.Safe.Util.member "r" json,
+            Yojson.Safe.Util.member "g" json,
+            Yojson.Safe.Util.member "b" json )
+        with
+        | `Int r, `Int g, `Int b -> Some { r; g; b }
+        | _ -> None)
+    | _ -> None
+
+  let parse_ext_view_source_theme json : ext_view_source_theme option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            background_rgb =
+              parse_color_rgb (Yojson.Safe.Util.member "backgroundRGB" json);
+            foreground_rgb =
+              parse_color_rgb (Yojson.Safe.Util.member "foregroundRGB" json);
+            accent_rgb =
+              parse_color_rgb (Yojson.Safe.Util.member "accentRGB" json);
+            accent_foreground_rgb =
+              parse_color_rgb
+                (Yojson.Safe.Util.member "accentForegroundRGB" json);
+          }
+    | _ -> None
+
+  let parse_ext_view_source json : ext_view_source option =
+    match json with
+    | `Assoc _ ->
+        Some
+          {
+            uri = string_member json "uri";
+            title = string_member json "title";
+            icon = string_opt json "icon";
+            description = string_opt json "description";
+            theme =
+              parse_ext_view_source_theme
+                (Yojson.Safe.Util.member "theme" json);
+          }
+    | _ -> None
+
+  let parse_associated_profile json : associated_profile =
+    {
+      did = string_member json "did";
+      handle = string_member json "handle";
+      display_name = string_opt json "displayName";
+    }
+
   let parse_ext json : ext =
     let open Yojson.Safe.Util in
     let uri = string_member json "uri" in
     let thumb = json |> member "thumb" |> parse_thumb in
     let title = string_member json "title" in
     let description = string_member json "description" in
-    { uri; thumb; title; description }
+    { uri; thumb; title; description; associated_refs = parse_strong_ref_list json }
 
   let parse_ext_view json : ext_view =
     {
@@ -229,6 +323,16 @@ module Embed = struct
       title = string_member json "title";
       description = string_member json "description";
       thumb = string_member json "thumb";
+      created_at = string_opt json "createdAt";
+      updated_at = string_opt json "updatedAt";
+      reading_time = int_opt json "readingTime";
+      labels = Label.Label.parse_label_values (Yojson.Safe.Util.member "labels" json);
+      associated_refs = parse_strong_ref_list json;
+      associated_profiles =
+        (match Yojson.Safe.Util.member "associatedProfiles" json with
+        | `List xs -> List.map parse_associated_profile xs
+        | _ -> []);
+      source = parse_ext_view_source (Yojson.Safe.Util.member "source" json);
     }
 
   let parse_ext_embed json : ext_embed =
@@ -280,9 +384,6 @@ module Embed = struct
     match json with
     | `Assoc fields -> List.exists (fun (key, _) -> key = field) fields
     | _ -> false
-
-  let parse_strong_ref json : strong_ref =
-    { uri = string_member json "uri"; cid = string_member json "cid" }
 
   let parse_record_embed json : record_embed =
     let open Yojson.Safe.Util in
@@ -651,40 +752,126 @@ module Embed = struct
                    e.images) );
           ]
     | `External (e : ext_embed) ->
+        let ext_fields =
+          [
+            ("uri", `String e.ext.uri);
+            ("title", `String e.ext.title);
+            ("description", `String e.ext.description);
+            ( "thumb",
+              blob_to_json
+                ~type_:
+                  (if e.ext.thumb.thumb_type = "" then "blob"
+                   else e.ext.thumb.thumb_type)
+                ~cid:e.ext.thumb.ref.ref_link ~mime_type:e.ext.thumb.mime_type
+                ~size:e.ext.thumb.size () );
+          ]
+          @
+          match e.ext.associated_refs with
+          | [] -> []
+          | refs ->
+              [
+                ( "associatedRefs",
+                  `List (List.map strong_ref_to_json refs) );
+              ]
+        in
         `Assoc
           [
             ( "$type",
               `String
                 (if e.embed_type = "" then "app.bsky.embed.external"
                  else e.embed_type) );
-            ( "external",
-              `Assoc
-                [
-                  ("uri", `String e.ext.uri);
-                  ("title", `String e.ext.title);
-                  ("description", `String e.ext.description);
-                  ( "thumb",
-                    blob_to_json
-                      ~type_:
-                        (if e.ext.thumb.thumb_type = "" then "blob"
-                         else e.ext.thumb.thumb_type)
-                      ~cid:e.ext.thumb.ref.ref_link
-                      ~mime_type:e.ext.thumb.mime_type ~size:e.ext.thumb.size ()
-                  );
-                ] );
+            ("external", `Assoc ext_fields);
           ]
     | `ExternalView (e : ext_view_embed) ->
+        let color_rgb_json (c : color_rgb) =
+          `Assoc [ ("r", `Int c.r); ("g", `Int c.g); ("b", `Int c.b) ]
+        in
+        let theme_json (t : ext_view_source_theme) =
+          `Assoc
+            ((match t.background_rgb with
+             | Some c -> [ ("backgroundRGB", color_rgb_json c) ]
+             | None -> [])
+            @ (match t.foreground_rgb with
+              | Some c -> [ ("foregroundRGB", color_rgb_json c) ]
+              | None -> [])
+            @ (match t.accent_rgb with
+              | Some c -> [ ("accentRGB", color_rgb_json c) ]
+              | None -> [])
+            @
+            match t.accent_foreground_rgb with
+            | Some c -> [ ("accentForegroundRGB", color_rgb_json c) ]
+            | None -> [])
+        in
+        let source_json (s : ext_view_source) =
+          `Assoc
+            ([ ("uri", `String s.uri); ("title", `String s.title) ]
+            @ (match s.icon with
+              | Some i -> [ ("icon", `String i) ]
+              | None -> [])
+            @ (match s.description with
+              | Some d -> [ ("description", `String d) ]
+              | None -> [])
+            @
+            match s.theme with
+            | Some t -> [ ("theme", theme_json t) ]
+            | None -> [])
+        in
+        let ext_fields =
+          [
+            ("uri", `String e.ext.uri);
+            ("title", `String e.ext.title);
+            ("description", `String e.ext.description);
+            ("thumb", `String e.ext.thumb);
+          ]
+          @ (match e.ext.created_at with
+            | Some t -> [ ("createdAt", `String t) ]
+            | None -> [])
+          @ (match e.ext.updated_at with
+            | Some t -> [ ("updatedAt", `String t) ]
+            | None -> [])
+          @ (match e.ext.reading_time with
+            | Some n -> [ ("readingTime", `Int n) ]
+            | None -> [])
+          @ (match e.ext.labels with
+            | Some vs ->
+                [
+                  ( "labels",
+                    `List (List.map (fun v -> `Assoc [ ("val", `String v) ]) vs)
+                  );
+                ]
+            | None -> [])
+          @ (match e.ext.associated_refs with
+            | [] -> []
+            | refs ->
+                [ ("associatedRefs", `List (List.map strong_ref_to_json refs)) ])
+          @ (match e.ext.associated_profiles with
+            | [] -> []
+            | ps ->
+                [
+                  ( "associatedProfiles",
+                    `List
+                      (List.map
+                         (fun (p : associated_profile) ->
+                           `Assoc
+                             ([
+                                ("did", `String p.did);
+                                ("handle", `String p.handle);
+                              ]
+                             @
+                             match p.display_name with
+                             | Some n -> [ ("displayName", `String n) ]
+                             | None -> []))
+                         ps) );
+                ])
+          @
+          match e.ext.source with
+          | Some s -> [ ("source", source_json s) ]
+          | None -> []
+        in
         `Assoc
           [
             ("$type", `String "app.bsky.embed.external#view");
-            ( "external",
-              `Assoc
-                [
-                  ("uri", `String e.ext.uri);
-                  ("title", `String e.ext.title);
-                  ("description", `String e.ext.description);
-                  ("thumb", `String e.ext.thumb);
-                ] );
+            ("external", `Assoc ext_fields);
           ]
     | `Record (e : record_embed) ->
         `Assoc

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -23,7 +23,6 @@ module Embed = struct
   }
 
   type strong_ref = { uri : string; cid : string }
-
   type color_rgb = { r : int; g : int; b : int }
 
   type ext_view_source_theme = {
@@ -297,8 +296,7 @@ module Embed = struct
             icon = string_opt json "icon";
             description = string_opt json "description";
             theme =
-              parse_ext_view_source_theme
-                (Yojson.Safe.Util.member "theme" json);
+              parse_ext_view_source_theme (Yojson.Safe.Util.member "theme" json);
           }
     | _ -> None
 
@@ -315,7 +313,13 @@ module Embed = struct
     let thumb = json |> member "thumb" |> parse_thumb in
     let title = string_member json "title" in
     let description = string_member json "description" in
-    { uri; thumb; title; description; associated_refs = parse_strong_ref_list json }
+    {
+      uri;
+      thumb;
+      title;
+      description;
+      associated_refs = parse_strong_ref_list json;
+    }
 
   let parse_ext_view json : ext_view =
     {
@@ -326,7 +330,8 @@ module Embed = struct
       created_at = string_opt json "createdAt";
       updated_at = string_opt json "updatedAt";
       reading_time = int_opt json "readingTime";
-      labels = Label.Label.parse_label_values (Yojson.Safe.Util.member "labels" json);
+      labels =
+        Label.Label.parse_label_values (Yojson.Safe.Util.member "labels" json);
       associated_refs = parse_strong_ref_list json;
       associated_profiles =
         (match Yojson.Safe.Util.member "associatedProfiles" json with
@@ -769,10 +774,7 @@ module Embed = struct
           match e.ext.associated_refs with
           | [] -> []
           | refs ->
-              [
-                ( "associatedRefs",
-                  `List (List.map strong_ref_to_json refs) );
-              ]
+              [ ("associatedRefs", `List (List.map strong_ref_to_json refs)) ]
         in
         `Assoc
           [

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -99,6 +99,7 @@ module Feed = struct
     parent : reply_ref_item;
     grandparent_author : Actor.typeahead_profile option;
   }
+
   type reply_feed = { post : reply_post; reply : reply }
 
   type reason = {

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -94,7 +94,11 @@ module Feed = struct
   type reply_ref_item =
     [ `Post of post | `NotFound of not_found_post | `Blocked of blocked_post ]
 
-  type reply = { root : reply_ref_item; parent : reply_ref_item }
+  type reply = {
+    root : reply_ref_item;
+    parent : reply_ref_item;
+    grandparent_author : Actor.typeahead_profile option;
+  }
   type reply_feed = { post : reply_post; reply : reply }
 
   type reason = {
@@ -366,7 +370,13 @@ module Feed = struct
     let open Yojson.Safe.Util in
     let root = json |> member "root" |> parse_reply_ref_item in
     let parent = json |> member "parent" |> parse_reply_ref_item in
-    { root; parent }
+    let grandparent_author =
+      match json |> member "grandparentAuthor" with
+      | `Assoc _ as a -> (
+          try Some (Actor.parse_typeahead_profile a) with _ -> None)
+      | _ -> None
+    in
+    { root; parent; grandparent_author }
 
   let parse_repost_feed json : repost_feed =
     let open Yojson.Safe.Util in
@@ -516,8 +526,8 @@ module Feed = struct
   let create_feed_endpoint (query_name : string) : string =
     "app.bsky.feed" ^ "." ^ query_name
 
-  let get_author_feed (s : Session.session) (actor : string) (limit : int) :
-      feed list =
+  let get_author_feed ?filter ?include_pins (s : Session.session)
+      (actor : string) (limit : int) : feed list =
     let open Yojson.Safe.Util in
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -530,7 +540,12 @@ module Feed = struct
     in
     let body =
       Cohttp_client.create_body_from_pairs
-        [ ("actor", actor); ("limit", string_of_int limit) ]
+        ([ ("actor", actor); ("limit", string_of_int limit) ]
+        @ (match filter with Some f -> [ ("filter", f) ] | None -> [])
+        @
+        match include_pins with
+        | Some b -> [ ("includePins", string_of_bool b) ]
+        | None -> [])
     in
     let author_feed =
       Lwt_main.run
@@ -1027,6 +1042,15 @@ module Feed = struct
       (Client.Client.opt_int "limit" limit
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_generators
+
+  let get_author_feed_page ?session ?host ~actor ?limit ?cursor ?filter
+      ?include_pins () : timeline =
+    Client.Client.get_json ?session ?host "app.bsky.feed.getAuthorFeed"
+      ((("actor", actor) :: Client.Client.opt_int "limit" limit)
+      @ Client.Client.opt_pair "cursor" cursor
+      @ Client.Client.opt_pair "filter" filter
+      @ Client.Client.opt_bool "includePins" include_pins)
+    |> parse_timeline
 
   let get_list_feed ?session ?host ~list ?limit ?cursor () : timeline =
     Client.Client.get_json ?session ?host "app.bsky.feed.getListFeed"

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -241,6 +241,7 @@ module Graph = struct
     list_item_count : int option;
     joined_week_count : int option;
     joined_all_time_count : int option;
+    list_items_sample : list_item list;
     indexed_at : string;
     original : Yojson.Safe.t;
   }
@@ -274,6 +275,8 @@ module Graph = struct
     followed_by : string option;
     blocking : string option;
     blocked_by : string option;
+    blocking_by_list : string option;
+    blocked_by_list : string option;
     not_found : bool;
     original : Yojson.Safe.t;
   }
@@ -446,6 +449,11 @@ module Graph = struct
         (match Yojson.Safe.Util.member "joinedAllTimeCount" json with
         | `Int n -> Some n
         | _ -> None);
+      list_items_sample =
+        List.map parse_list_item
+          (match Yojson.Safe.Util.member "listItemsSample" json with
+          | `List xs -> xs
+          | _ -> []);
       indexed_at =
         (match Yojson.Safe.Util.member "indexedAt" json with
         | `String s -> s
@@ -548,6 +556,14 @@ module Graph = struct
         | _ -> None);
       blocked_by =
         (match Yojson.Safe.Util.member "blockedBy" json with
+        | `String s -> Some s
+        | _ -> None);
+      blocking_by_list =
+        (match Yojson.Safe.Util.member "blockingByList" json with
+        | `String s -> Some s
+        | _ -> None);
+      blocked_by_list =
+        (match Yojson.Safe.Util.member "blockedByList" json with
         | `String s -> Some s
         | _ -> None);
       not_found;

--- a/src/bsky/labeler.ml
+++ b/src/bsky/labeler.ml
@@ -4,7 +4,7 @@ open Client
 module Labeler = struct
   type policies = {
     label_values : string list;
-    label_value_definitions : Yojson.Safe.t list;
+    label_value_definitions : Label.Label.label_value_definition list;
   }
 
   type service = {
@@ -26,7 +26,9 @@ module Labeler = struct
         List.filter_map
           (function `String s -> Some s | _ -> None)
           (Client.list_member json "labelValues");
-      label_value_definitions = Client.list_member json "labelValueDefinitions";
+      label_value_definitions =
+        List.map Label.Label.parse_label_value_definition
+          (Client.list_member json "labelValueDefinitions");
     }
 
   let parse_service json : service =

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -37,6 +37,8 @@ module Chat = struct
     original : Yojson.Safe.t;
   }
 
+  type last_reaction = { message : message; reaction : reaction }
+
   type convo = {
     id : string;
     rev : string;
@@ -45,11 +47,22 @@ module Chat = struct
     status : string option;
     members : member list;
     last_message : message option;
+    last_reaction : last_reaction option;
+    unread_join_request_count : int option;
+    lock_status : string option;
+    lock_status_moderation_override : bool option;
+    member_count : int option;
+    group_name : string option;
     original : Yojson.Safe.t;
   }
 
   type convos = { cursor : string option; convos : convo list }
-  type messages = { cursor : string option; messages : message list }
+
+  type messages = {
+    cursor : string option;
+    messages : message list;
+    related_profiles : member list;
+  }
 
   let parse_member json : member =
     {
@@ -112,7 +125,25 @@ module Chat = struct
       original = json;
     }
 
+  let parse_last_reaction json : last_reaction option =
+    match json with
+    | `Assoc _ -> (
+        match
+          ( Yojson.Safe.Util.member "message" json,
+            Yojson.Safe.Util.member "reaction" json )
+        with
+        | `Assoc _ as m, `Assoc _ as r ->
+            Some { message = parse_message m; reaction = parse_reaction r }
+        | _ -> None)
+    | _ -> None
+
+  let parse_group_kind json =
+    match Yojson.Safe.Util.member "kind" json with
+    | `Assoc _ as k -> k
+    | _ -> `Null
+
   let parse_convo json : convo =
+    let kind = parse_group_kind json in
     {
       id = Client.string_member json "id";
       rev = Client.string_member json "rev";
@@ -123,6 +154,28 @@ module Chat = struct
       last_message =
         (match Yojson.Safe.Util.member "lastMessage" json with
         | `Assoc _ as m -> Some (parse_message m)
+        | _ -> None);
+      last_reaction =
+        parse_last_reaction (Yojson.Safe.Util.member "lastReaction" json);
+      unread_join_request_count =
+        (match kind with
+        | `Assoc _ -> Client.int_opt kind "unreadJoinRequestCount"
+        | _ -> Client.int_opt json "unreadJoinRequestCount");
+      lock_status =
+        (match kind with
+        | `Assoc _ -> Client.string_opt kind "lockStatus"
+        | _ -> Client.string_opt json "lockStatus");
+      lock_status_moderation_override =
+        (match kind with
+        | `Assoc _ -> Client.bool_opt kind "lockStatusModerationOverride"
+        | _ -> Client.bool_opt json "lockStatusModerationOverride");
+      member_count =
+        (match kind with
+        | `Assoc _ -> Client.int_opt kind "memberCount"
+        | _ -> Client.int_opt json "memberCount");
+      group_name =
+        (match kind with
+        | `Assoc _ -> Client.string_opt kind "name"
         | _ -> None);
       original = json;
     }
@@ -137,6 +190,8 @@ module Chat = struct
     {
       cursor = Client.string_opt json "cursor";
       messages = List.map parse_message (Client.list_member json "messages");
+      related_profiles =
+        List.map parse_member (Client.list_member json "relatedProfiles");
     }
 
   let message_input ?facets ?embed ?reply_to text : Yojson.Safe.t =

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -128,12 +128,15 @@ module Chat = struct
   let parse_last_reaction json : last_reaction option =
     match json with
     | `Assoc _ -> (
-        match
-          ( Yojson.Safe.Util.member "message" json,
-            Yojson.Safe.Util.member "reaction" json )
-        with
-        | `Assoc _ as m, `Assoc _ as r ->
-            Some { message = parse_message m; reaction = parse_reaction r }
+        let message = Yojson.Safe.Util.member "message" json in
+        let reaction = Yojson.Safe.Util.member "reaction" json in
+        match (message, reaction) with
+        | `Assoc _, `Assoc _ ->
+            Some
+              {
+                message = parse_message message;
+                reaction = parse_reaction reaction;
+              }
         | _ -> None)
     | _ -> None
 

--- a/src/label.ml
+++ b/src/label.ml
@@ -136,6 +136,51 @@ module Label = struct
         if vals = [] then None else Some vals
     | _ -> None
 
+  type label_value_definition_strings = {
+    lang : string;
+    name : string;
+    description : string;
+  }
+
+  type label_value_definition = {
+    identifier : string;
+    severity : string;
+    blurs : string;
+    default_setting : string option;
+    adult_only : bool option;
+    locales : label_value_definition_strings list;
+  }
+
+  let parse_label_value_definition_strings json : label_value_definition_strings
+      =
+    let open Yojson.Safe.Util in
+    {
+      lang = (match json |> member "lang" with `String s -> s | _ -> "");
+      name = (match json |> member "name" with `String s -> s | _ -> "");
+      description =
+        (match json |> member "description" with `String s -> s | _ -> "");
+    }
+
+  let parse_label_value_definition json : label_value_definition =
+    let open Yojson.Safe.Util in
+    {
+      identifier =
+        (match json |> member "identifier" with `String s -> s | _ -> "");
+      severity =
+        (match json |> member "severity" with `String s -> s | _ -> "");
+      blurs = (match json |> member "blurs" with `String s -> s | _ -> "");
+      default_setting =
+        (match json |> member "defaultSetting" with
+        | `String s -> Some s
+        | _ -> None);
+      adult_only =
+        (match json |> member "adultOnly" with `Bool b -> Some b | _ -> None);
+      locales =
+        (match json |> member "locales" with
+        | `List xs -> List.map parse_label_value_definition_strings xs
+        | _ -> []);
+    }
+
   let self_labels_to_json (vals : string list) : Yojson.Safe.t =
     `Assoc
       [

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -409,7 +409,7 @@ module Lexicon = struct
     {|{"lexicon":1,"id":"com.atproto.server.confirmEmail","defs":{"main":{"type":"procedure","description":"Confirm an email using a token from com.atproto.server.requestEmailConfirmation.","input":{"encoding":"application/json","schema":{"type":"object","required":["email","token"],"properties":{"email":{"type":"string"},"token":{"type":"string"}}}}}}}|}
 
   let official_feed_known_likers =
-    {|{"lexicon":1,"id":"app.bsky.feed.defs","defs":{"knownLikers":{"type":"object","description":"The post's likers whom you also follow","required":["count","actors"],"properties":{"count":{"type":"integer"},"actors":{"type":"array","items":{"type":"ref","ref":"app.bsky.actor.defs#profileViewBasic"}}}},"viewerState":{"type":"object","properties":{"repost":{"type":"string"},"like":{"type":"string"},"bookmarked":{"type":"boolean"},"threadMuted":{"type":"boolean"},"replyDisabled":{"type":"boolean"},"embeddingDisabled":{"type":"boolean"},"pinned":{"type":"boolean"},"knownLikers":{"type":"ref","ref":"#knownLikers"}}}}}|}
+    {|{"lexicon":1,"id":"app.bsky.feed.defs","defs":{"knownLikers":{"type":"object","description":"The post's likers whom you also follow","required":["count","actors"],"properties":{"count":{"type":"integer"},"actors":{"type":"array","items":{"type":"ref","ref":"app.bsky.actor.defs#profileViewBasic"}}}},"viewerState":{"type":"object","properties":{"repost":{"type":"string"},"like":{"type":"string"},"bookmarked":{"type":"boolean"},"threadMuted":{"type":"boolean"},"replyDisabled":{"type":"boolean"},"embeddingDisabled":{"type":"boolean"},"pinned":{"type":"boolean"},"knownLikers":{"type":"ref","ref":"#knownLikers"}}},"replyRef":{"type":"object","required":["root","parent"],"properties":{"root":{"type":"union"},"parent":{"type":"union"},"grandparentAuthor":{"type":"ref","ref":"app.bsky.actor.defs#profileViewBasic"}}}}}|}
 
   let official_embed_video =
     {|{"lexicon":1,"id":"app.bsky.embed.video","defs":{"main":{"type":"object","required":["video"],"properties":{"video":{"type":"blob"},"alt":{"type":"string"},"aspectRatio":{"type":"ref","ref":"app.bsky.embed.defs#aspectRatio"},"presentation":{"type":"string","knownValues":["default","gif"]}}},"view":{"type":"object","required":["cid","playlist"],"properties":{"cid":{"type":"string"},"playlist":{"type":"string"},"alt":{"type":"string"},"presentation":{"type":"string","knownValues":["default","gif"]}}}}}|}
@@ -421,7 +421,7 @@ module Lexicon = struct
     {|{"lexicon":1,"id":"app.bsky.graph.muteActor","defs":{"main":{"type":"procedure","description":"Creates a mute relationship for the specified account.","input":{"encoding":"application/json","schema":{"type":"object","required":["actor"],"properties":{"actor":{"type":"string"},"onlyReposts":{"type":"boolean"},"onlyQuoteposts":{"type":"boolean"}}}}}}}|}
 
   let official_actor_defs =
-    {|{"lexicon":1,"id":"app.bsky.actor.defs","defs":{"viewerState":{"type":"object","properties":{"muted":{"type":"boolean"},"mutedOnlyReposts":{"type":"boolean"},"mutedOnlyQuoteposts":{"type":"boolean"},"blocking":{"type":"string"},"knownFollowers":{"type":"ref","ref":"#knownFollowers"}}},"profileAssociatedGerm":{"type":"object","required":["showButtonTo","messageMeUrl"],"properties":{"showButtonTo":{"type":"string"},"messageMeUrl":{"type":"string"}}},"profileAssociated":{"type":"object","properties":{"germ":{"type":"ref","ref":"#profileAssociatedGerm"}}}}}|}
+    {|{"lexicon":1,"id":"app.bsky.actor.defs","defs":{"viewerState":{"type":"object","properties":{"muted":{"type":"boolean"},"mutedOnlyReposts":{"type":"boolean"},"mutedOnlyQuoteposts":{"type":"boolean"},"blocking":{"type":"string"},"knownFollowers":{"type":"ref","ref":"#knownFollowers"}}},"profileAssociatedGerm":{"type":"object","required":["showButtonTo","messageMeUrl"],"properties":{"showButtonTo":{"type":"string"},"messageMeUrl":{"type":"string"}}},"profileAssociated":{"type":"object","properties":{"germ":{"type":"ref","ref":"#profileAssociatedGerm"}}},"profileViewDetailed":{"type":"object","required":["did","handle"],"properties":{"joinedViaStarterPack":{"type":"ref","ref":"app.bsky.graph.defs#starterPackViewBasic"}}}}}|}
 
   let official_create_session =
     {|{"lexicon":1,"id":"com.atproto.server.createSession","defs":{"main":{"type":"procedure","description":"Create an authentication session.","input":{"encoding":"application/json","schema":{"type":"object","required":["identifier","password"],"properties":{"identifier":{"type":"string"},"password":{"type":"string"},"authFactorToken":{"type":"string"},"allowTakendown":{"type":"boolean"}}}}}}}|}
@@ -434,6 +434,24 @@ module Lexicon = struct
 
   let official_create_app_password =
     {|{"lexicon":1,"id":"com.atproto.server.createAppPassword","defs":{"main":{"type":"procedure","description":"Create an App Password.","input":{"encoding":"application/json","schema":{"type":"object","required":["name"],"properties":{"name":{"type":"string"},"privileged":{"type":"boolean"}}}}}}}|}
+
+  let official_embed_external =
+    {|{"lexicon":1,"id":"app.bsky.embed.external","defs":{"main":{"type":"object","required":["external"],"properties":{"external":{"type":"ref","ref":"#external"}}},"external":{"type":"object","required":["uri","title","description"],"properties":{"associatedRefs":{"type":"array"}}},"viewExternal":{"type":"object","required":["uri","title","description"],"properties":{"readingTime":{"type":"integer"},"associatedProfiles":{"type":"array"},"source":{"type":"ref","ref":"#viewExternalSource"}}},"viewExternalSourceTheme":{"type":"object","properties":{"backgroundRGB":{"type":"ref","ref":"#colorRGB"},"foregroundRGB":{"type":"ref","ref":"#colorRGB"},"accentRGB":{"type":"ref","ref":"#colorRGB"},"accentForegroundRGB":{"type":"ref","ref":"#colorRGB"}}}}}|}
+
+  let official_get_author_feed =
+    {|{"lexicon":1,"id":"app.bsky.feed.getAuthorFeed","defs":{"main":{"type":"query","description":"Get a view of an actor's author feed.","parameters":{"type":"params","required":["actor"],"properties":{"actor":{"type":"string"},"filter":{"type":"string"},"includePins":{"type":"boolean"}}}}}}|}
+
+  let official_graph_relationship =
+    {|{"lexicon":1,"id":"app.bsky.graph.defs","defs":{"relationship":{"type":"object","required":["did"],"properties":{"did":{"type":"string"},"blockingByList":{"type":"string"},"blockedByList":{"type":"string"}}},"starterPackView":{"type":"object","required":["uri","cid","record","creator","indexedAt"],"properties":{"listItemsSample":{"type":"array"}}}}}|}
+
+  let official_check_account_status =
+    {|{"lexicon":1,"id":"com.atproto.server.checkAccountStatus","defs":{"main":{"type":"query","description":"Returns the status of an account, especially as pertaining to import or recovery.","output":{"encoding":"application/json","schema":{"type":"object","required":["activated","validDid","repoCommit","repoRev","repoBlocks","indexedRecords","privateStateValues","expectedBlobs","importedBlobs"],"properties":{"activated":{"type":"boolean"},"validDid":{"type":"boolean"},"repoCommit":{"type":"string"},"repoRev":{"type":"string"},"repoBlocks":{"type":"integer"},"indexedRecords":{"type":"integer"},"privateStateValues":{"type":"integer"},"expectedBlobs":{"type":"integer"},"importedBlobs":{"type":"integer"}}}}}}}|}
+
+  let official_label_value_definition =
+    {|{"lexicon":1,"id":"com.atproto.label.defs","defs":{"labelValueDefinition":{"type":"object","required":["identifier","severity","blurs","locales"],"properties":{"identifier":{"type":"string"},"severity":{"type":"string"},"blurs":{"type":"string"},"defaultSetting":{"type":"string"},"adultOnly":{"type":"boolean"},"locales":{"type":"array"}}}}}|}
+
+  let official_get_messages =
+    {|{"lexicon":1,"id":"chat.bsky.convo.getMessages","defs":{"main":{"type":"query","description":"Returns a page of messages from a conversation.","parameters":{"type":"params","required":["convoId"],"properties":{"convoId":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["messages"],"properties":{"messages":{"type":"array"},"relatedProfiles":{"type":"array"}}}}}}}|}
 
   let official_lexicons : (string * string) list =
     [
@@ -473,6 +491,12 @@ module Lexicon = struct
       ("com.atproto.server.createAccount", official_create_account);
       ("com.atproto.server.getSession", official_get_session);
       ("com.atproto.server.createAppPassword", official_create_app_password);
+      ("app.bsky.embed.external", official_embed_external);
+      ("app.bsky.feed.getAuthorFeed", official_get_author_feed);
+      ("app.bsky.graph.defs", official_graph_relationship);
+      ("com.atproto.server.checkAccountStatus", official_check_account_status);
+      ("com.atproto.label.defs", official_label_value_definition);
+      ("chat.bsky.convo.getMessages", official_get_messages);
     ]
 
   let official_documents () : document list =

--- a/src/server.ml
+++ b/src/server.ml
@@ -327,26 +327,48 @@ module Server = struct
   type account_status = {
     activated : bool option;
     valid_did : bool option;
+    repo_commit : string option;
+    repo_rev : string option;
+    repo_blocks : int option;
+    indexed_records : int option;
+    private_state_values : int option;
     expected_blobs : int option;
     imported_blobs : int option;
   }
 
   let parse_account_status json : account_status =
     let open Yojson.Safe.Util in
+    let int_opt field =
+      match json |> member field with `Int n -> Some n | _ -> None
+    in
     {
       activated =
         (match json |> member "activated" with `Bool b -> Some b | _ -> None);
       valid_did =
         (match json |> member "validDid" with `Bool b -> Some b | _ -> None);
-      expected_blobs =
-        (match json |> member "expectedBlobs" with
-        | `Int n -> Some n
+      repo_commit =
+        (match json |> member "repoCommit" with
+        | `String s -> Some s
         | _ -> None);
-      imported_blobs =
-        (match json |> member "importedBlobs" with
-        | `Int n -> Some n
-        | _ -> None);
+      repo_rev =
+        (match json |> member "repoRev" with `String s -> Some s | _ -> None);
+      repo_blocks = int_opt "repoBlocks";
+      indexed_records = int_opt "indexedRecords";
+      private_state_values = int_opt "privateStateValues";
+      expected_blobs = int_opt "expectedBlobs";
+      imported_blobs = int_opt "importedBlobs";
     }
+
+  let create_invite_codes_body ~code_count ~use_count ?(for_accounts = []) () :
+      Yojson.Safe.t =
+    let fields =
+      [ ("codeCount", `Int code_count); ("useCount", `Int use_count) ]
+      @
+      match for_accounts with
+      | [] -> []
+      | xs -> [ ("forAccounts", `List (List.map (fun s -> `String s) xs)) ]
+    in
+    `Assoc fields
 
   let deactivate_account_url (s : Session.session) : string =
     App.create_endpoint_url (App.create_base_url s)

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -347,8 +347,7 @@ let test_parse_profile_and_scoped_mute_viewer _ =
     (Some "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k")
     profile.pinned_post_uri;
   OUnit2.assert_equal
-    (Some
-       "at://did:plc:abc123xyz0001112223333/app.bsky.graph.starterpack/3k")
+    (Some "at://did:plc:abc123xyz0001112223333/app.bsky.graph.starterpack/3k")
     profile.joined_via_starter_pack_uri;
   (match profile.associated with
   | Some assoc -> (

--- a/test/test_actor.ml
+++ b/test/test_actor.ml
@@ -258,6 +258,15 @@ let test_parse_profile_and_scoped_mute_viewer _ =
                   "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k" );
               ("cid", `String "bafyreiabc");
             ] );
+        ( "joinedViaStarterPack",
+          `Assoc
+            [
+              ( "uri",
+                `String
+                  "at://did:plc:abc123xyz0001112223333/app.bsky.graph.starterpack/3k"
+              );
+              ("cid", `String "bafyreipack");
+            ] );
         ( "associated",
           `Assoc
             [
@@ -337,6 +346,10 @@ let test_parse_profile_and_scoped_mute_viewer _ =
   OUnit2.assert_equal
     (Some "at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k")
     profile.pinned_post_uri;
+  OUnit2.assert_equal
+    (Some
+       "at://did:plc:abc123xyz0001112223333/app.bsky.graph.starterpack/3k")
+    profile.joined_via_starter_pack_uri;
   (match profile.associated with
   | Some assoc -> (
       OUnit2.assert_equal (Some 2) assoc.lists;

--- a/test/test_admin.ml
+++ b/test/test_admin.ml
@@ -71,8 +71,9 @@ let test_parse_account_info _ =
   OUnit2.assert_equal (Some "friend") info.invite_note;
   OUnit2.assert_equal (Some "bsky-invite-9") info.invited_by_code;
   OUnit2.assert_equal 1 (List.length info.threat_signatures);
-  OUnit2.assert_equal ~printer:(fun x -> x) "ip"
-    (List.hd info.threat_signatures).property
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "ip" (List.hd info.threat_signatures).property
 
 let test_invite_codes_and_admin_bodies _ =
   let codes =

--- a/test/test_admin.ml
+++ b/test/test_admin.ml
@@ -45,11 +45,34 @@ let test_parse_account_info _ =
         ("handle", `String "alice.test");
         ("indexedAt", `String "2024-01-01T00:00:00.000Z");
         ("invitesDisabled", `Bool true);
+        ("inviteNote", `String "friend");
+        ( "invitedBy",
+          `Assoc
+            [
+              ("code", `String "bsky-invite-9");
+              ("available", `Int 1);
+              ("disabled", `Bool false);
+              ("forAccount", `String "did:plc:abc123xyz0001112223333");
+              ("createdBy", `String "admin");
+              ("createdAt", `String "2024-01-01T00:00:00.000Z");
+              ("uses", `List []);
+            ] );
+        ( "threatSignatures",
+          `List
+            [
+              `Assoc
+                [ ("property", `String "ip"); ("value", `String "203.0.113.1") ];
+            ] );
       ]
   in
   let info = Admin.parse_account_info json in
   OUnit2.assert_equal ~printer:(fun x -> x) "alice.test" info.handle;
-  OUnit2.assert_equal (Some true) info.invites_disabled
+  OUnit2.assert_equal (Some true) info.invites_disabled;
+  OUnit2.assert_equal (Some "friend") info.invite_note;
+  OUnit2.assert_equal (Some "bsky-invite-9") info.invited_by_code;
+  OUnit2.assert_equal 1 (List.length info.threat_signatures);
+  OUnit2.assert_equal ~printer:(fun x -> x) "ip"
+    (List.hd info.threat_signatures).property
 
 let test_invite_codes_and_admin_bodies _ =
   let codes =

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -91,8 +91,12 @@ let test_parse_messages_related_profiles _ =
   let page = Chat.parse_messages json in
   OUnit2.assert_equal 1 (List.length page.messages);
   OUnit2.assert_equal 1 (List.length page.related_profiles);
-  OUnit2.assert_equal ~printer:(fun x -> x) "alice.test"
-    (List.hd page.related_profiles).handle
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "alice.test"
+    (match (List.hd page.related_profiles).handle with
+    | Some h -> h
+    | None -> "")
 
 let test_parse_group_convo_extras _ =
   let json =
@@ -141,8 +145,7 @@ let test_parse_group_convo_extras _ =
   OUnit2.assert_equal (Some 4) convo.member_count;
   OUnit2.assert_equal (Some 2) convo.unread_join_request_count;
   match convo.last_reaction with
-  | Some lr ->
-      OUnit2.assert_equal ~printer:(fun x -> x) "👍" lr.reaction.value
+  | Some lr -> OUnit2.assert_equal ~printer:(fun x -> x) "👍" lr.reaction.value
   | None -> OUnit2.assert_failure "expected lastReaction"
 
 let test_send_message_body _ =

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -59,6 +59,92 @@ let test_parse_convos _ =
   OUnit2.assert_equal ~printer:(fun x -> x) "convo1" (List.hd page.convos).id;
   OUnit2.assert_equal 2 (List.hd page.convos).unread_count
 
+let test_parse_messages_related_profiles _ =
+  let json =
+    `Assoc
+      [
+        ( "messages",
+          `List
+            [
+              `Assoc
+                [
+                  ("id", `String "m1");
+                  ("rev", `String "r1");
+                  ("text", `String "hello");
+                  ("sentAt", `String "2024-01-01T00:00:00.000Z");
+                  ( "sender",
+                    `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
+                  );
+                ];
+            ] );
+        ( "relatedProfiles",
+          `List
+            [
+              `Assoc
+                [
+                  ("did", `String "did:plc:abc123xyz0001112223333");
+                  ("handle", `String "alice.test");
+                ];
+            ] );
+      ]
+  in
+  let page = Chat.parse_messages json in
+  OUnit2.assert_equal 1 (List.length page.messages);
+  OUnit2.assert_equal 1 (List.length page.related_profiles);
+  OUnit2.assert_equal ~printer:(fun x -> x) "alice.test"
+    (List.hd page.related_profiles).handle
+
+let test_parse_group_convo_extras _ =
+  let json =
+    `Assoc
+      [
+        ("id", `String "g1");
+        ("rev", `String "r1");
+        ("muted", `Bool false);
+        ("unreadCount", `Int 0);
+        ( "lastReaction",
+          `Assoc
+            [
+              ( "message",
+                `Assoc
+                  [
+                    ("id", `String "m2");
+                    ("rev", `String "r2");
+                    ("text", `String "reacted");
+                    ("sentAt", `String "2024-01-01T00:00:00.000Z");
+                  ] );
+              ( "reaction",
+                `Assoc
+                  [
+                    ("value", `String "👍");
+                    ( "sender",
+                      `Assoc
+                        [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
+                    ("createdAt", `String "2024-01-01T00:00:01.000Z");
+                  ] );
+            ] );
+        ( "kind",
+          `Assoc
+            [
+              ("$type", `String "chat.bsky.convo.defs#groupConvo");
+              ("name", `String "mods");
+              ("lockStatus", `String "unlocked");
+              ("lockStatusModerationOverride", `Bool false);
+              ("memberCount", `Int 4);
+              ("unreadJoinRequestCount", `Int 2);
+            ] );
+      ]
+  in
+  let convo = Chat.parse_convo json in
+  OUnit2.assert_equal (Some "mods") convo.group_name;
+  OUnit2.assert_equal (Some "unlocked") convo.lock_status;
+  OUnit2.assert_equal (Some 4) convo.member_count;
+  OUnit2.assert_equal (Some 2) convo.unread_join_request_count;
+  match convo.last_reaction with
+  | Some lr ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "👍" lr.reaction.value
+  | None -> OUnit2.assert_failure "expected lastReaction"
+
 let test_send_message_body _ =
   let body = Chat.send_message_body ~convo_id:"c1" ~text:"hi" () in
   let open Yojson.Safe.Util in
@@ -516,6 +602,9 @@ let suite =
   >::: [
          "test_default_proxy" >:: test_default_proxy;
          "test_parse_convos" >:: test_parse_convos;
+         "test_parse_messages_related_profiles"
+         >:: test_parse_messages_related_profiles;
+         "test_parse_group_convo_extras" >:: test_parse_group_convo_extras;
          "test_send_message_body" >:: test_send_message_body;
          "test_parse_unread_and_logs" >:: test_parse_unread_and_logs;
          "test_parse_message_facets_reactions_embed"

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -399,14 +399,14 @@ let test_parse_embed_external_view _ =
   let v = Embed.parse_embed_external_view json in
   OUnit2.assert_equal 1 (List.length v.associated_refs);
   match v.view with
-  | Some e ->
+  | Some e -> (
       OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri;
       OUnit2.assert_equal (Some 8) e.ext.reading_time;
       OUnit2.assert_equal 1 (List.length e.ext.associated_profiles);
-      (match e.ext.source with
-      | Some s ->
+      match e.ext.source with
+      | Some s -> (
           OUnit2.assert_equal ~printer:(fun x -> x) "Standard" s.title;
-          (match s.theme with
+          match s.theme with
           | Some t -> (
               match t.background_rgb with
               | Some c -> OUnit2.assert_equal 10 c.r
@@ -446,8 +446,8 @@ let test_parse_external_associated_refs _ =
                     `Assoc
                       [
                         ( "uri",
-                          `String
-                            "at://did:plc:alice/site.standard.document/1" );
+                          `String "at://did:plc:alice/site.standard.document/1"
+                        );
                         ("cid", `String "bafyreihdummy000000000000000000000");
                       ];
                   ] );
@@ -457,7 +457,8 @@ let test_parse_external_associated_refs _ =
   match Embed.parse_embed json with
   | `External e ->
       OUnit2.assert_equal 1 (List.length e.ext.associated_refs);
-      OUnit2.assert_equal ~printer:(fun x -> x)
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
         "at://did:plc:alice/site.standard.document/1"
         (List.hd e.ext.associated_refs).uri
   | _ -> OUnit2.assert_failure "expected external embed"

--- a/test/test_embed.ml
+++ b/test/test_embed.ml
@@ -354,6 +354,34 @@ let test_parse_embed_external_view _ =
                     ("title", `String "AT Protocol");
                     ("description", `String "specs");
                     ("thumb", `String "https://cdn.example/t.jpg");
+                    ("readingTime", `Int 8);
+                    ("createdAt", `String "2024-01-01T00:00:00.000Z");
+                    ( "associatedProfiles",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("did", `String "did:plc:abc123xyz0001112223333");
+                              ("handle", `String "alice.test");
+                            ];
+                        ] );
+                    ( "source",
+                      `Assoc
+                        [
+                          ("uri", `String "https://standard.site");
+                          ("title", `String "Standard");
+                          ( "theme",
+                            `Assoc
+                              [
+                                ( "backgroundRGB",
+                                  `Assoc
+                                    [
+                                      ("r", `Int 10);
+                                      ("g", `Int 20);
+                                      ("b", `Int 30);
+                                    ] );
+                              ] );
+                        ] );
                   ] );
             ] );
         ( "associatedRefs",
@@ -372,8 +400,67 @@ let test_parse_embed_external_view _ =
   OUnit2.assert_equal 1 (List.length v.associated_refs);
   match v.view with
   | Some e ->
-      OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri
+      OUnit2.assert_equal ~printer:(fun x -> x) "https://atproto.com" e.ext.uri;
+      OUnit2.assert_equal (Some 8) e.ext.reading_time;
+      OUnit2.assert_equal 1 (List.length e.ext.associated_profiles);
+      (match e.ext.source with
+      | Some s ->
+          OUnit2.assert_equal ~printer:(fun x -> x) "Standard" s.title;
+          (match s.theme with
+          | Some t -> (
+              match t.background_rgb with
+              | Some c -> OUnit2.assert_equal 10 c.r
+              | None -> OUnit2.assert_failure "expected backgroundRGB")
+          | None -> OUnit2.assert_failure "expected theme")
+      | None -> OUnit2.assert_failure "expected source")
   | None -> OUnit2.assert_failure "expected view"
+
+let test_parse_external_associated_refs _ =
+  let json =
+    `Assoc
+      [
+        ("$type", `String "app.bsky.embed.external");
+        ( "external",
+          `Assoc
+            [
+              ("uri", `String "https://atproto.com");
+              ("title", `String "AT Protocol");
+              ("description", `String "specs");
+              ( "thumb",
+                `Assoc
+                  [
+                    ("$type", `String "blob");
+                    ( "ref",
+                      `Assoc
+                        [
+                          ( "$link",
+                            `String
+                              "bafyimage0000000000000000000000000000000000" );
+                        ] );
+                    ("mimeType", `String "image/jpeg");
+                    ("size", `Int 12);
+                  ] );
+              ( "associatedRefs",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ( "uri",
+                          `String
+                            "at://did:plc:alice/site.standard.document/1" );
+                        ("cid", `String "bafyreihdummy000000000000000000000");
+                      ];
+                  ] );
+            ] );
+      ]
+  in
+  match Embed.parse_embed json with
+  | `External e ->
+      OUnit2.assert_equal 1 (List.length e.ext.associated_refs);
+      OUnit2.assert_equal ~printer:(fun x -> x)
+        "at://did:plc:alice/site.standard.document/1"
+        (List.hd e.ext.associated_refs).uri
+  | _ -> OUnit2.assert_failure "expected external embed"
 
 let test_join_link_embed _ =
   let built = Embed.join_link ~code:"abc123xyz" () in
@@ -399,6 +486,8 @@ let suite =
          "test_parse_record_view_not_found" >:: test_parse_record_view_not_found;
          "test_embed_to_json_roundtrip" >:: test_embed_to_json_roundtrip;
          "test_parse_embed_external_view" >:: test_parse_embed_external_view;
+         "test_parse_external_associated_refs"
+         >:: test_parse_external_associated_refs;
          "test_join_link_embed" >:: test_join_link_embed;
        ]
 

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -380,6 +380,34 @@ let test_parse_reply_ref_not_found _ =
   | `Post p -> OUnit2.assert_equal ~printer:(fun x -> x) "parent" p.record.text
   | _ -> OUnit2.assert_failure "expected parent post"
 
+let test_parse_grandparent_author _ =
+  let json =
+    `Assoc
+      [
+        ( "root",
+          post_view_json
+            ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/root"
+            ~text:"root" () );
+        ( "parent",
+          post_view_json
+            ~uri:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/p"
+            ~text:"parent" () );
+        ( "grandparentAuthor",
+          `Assoc
+            [
+              ("did", `String "did:plc:abc123xyz0001112223333");
+              ("handle", `String "alice.test");
+              ("displayName", `String "Alice");
+            ] );
+      ]
+  in
+  let reply = Feed.parse_reply json in
+  match reply.grandparent_author with
+  | Some a ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "alice.test" a.handle;
+      OUnit2.assert_equal (Some "Alice") a.display_name
+  | None -> OUnit2.assert_failure "expected grandparentAuthor"
+
 let test_parse_known_likers _ =
   let json =
     post_view_json
@@ -548,6 +576,17 @@ let test_search_posts_v2_live _ =
         OUnit2.assert_bool "search posts v2" (List.length page.posts >= 0))
   with exn -> skip_if true ("searchPostsV2 skipped: " ^ Printexc.to_string exn)
 
+let test_get_author_feed_page_live _ =
+  try
+    with_public_timeout (fun () ->
+        let page =
+          Feed.get_author_feed_page ~actor:"jay.bsky.team" ~limit:3
+            ~filter:"posts_no_replies" ~include_pins:true ()
+        in
+        OUnit2.assert_bool "author feed page" (List.length page.feed >= 0))
+  with exn ->
+    skip_if true ("getAuthorFeed skipped: " ^ Printexc.to_string exn)
+
 let suite =
   "suite"
   >::: [
@@ -565,12 +604,14 @@ let suite =
          >:: test_parse_thread_view_with_embed;
          "test_parse_blocked_thread" >:: test_parse_blocked_thread;
          "test_parse_reply_ref_not_found" >:: test_parse_reply_ref_not_found;
+         "test_parse_grandparent_author" >:: test_parse_grandparent_author;
          "test_parse_known_likers" >:: test_parse_known_likers;
          "test_parse_post_view_embed" >:: test_parse_post_view_embed;
          "test_send_interactions_body" >:: test_send_interactions_body;
          "test_get_feed_generator_live" >:: test_get_feed_generator_live;
          "test_search_posts_live" >:: test_search_posts_live;
          "test_search_posts_v2_live" >:: test_search_posts_v2_live;
+         "test_get_author_feed_page_live" >:: test_get_author_feed_page_live;
        ]
 
 let () = run_test_tt_main suite

--- a/test/test_feed.ml
+++ b/test/test_feed.ml
@@ -584,8 +584,7 @@ let test_get_author_feed_page_live _ =
             ~filter:"posts_no_replies" ~include_pins:true ()
         in
         OUnit2.assert_bool "author feed page" (List.length page.feed >= 0))
-  with exn ->
-    skip_if true ("getAuthorFeed skipped: " ^ Printexc.to_string exn)
+  with exn -> skip_if true ("getAuthorFeed skipped: " ^ Printexc.to_string exn)
 
 let suite =
   "suite"

--- a/test/test_graph.ml
+++ b/test/test_graph.ml
@@ -185,11 +185,31 @@ let test_parse_starter_pack _ =
             ] );
         ("indexedAt", `String "2024-01-01T00:00:00.000Z");
         ("joinedAllTimeCount", `Int 12);
+        ( "listItemsSample",
+          `List
+            [
+              `Assoc
+                [
+                  ( "uri",
+                    `String
+                      "at://did:plc:abc123xyz0001112223333/app.bsky.graph.listitem/1"
+                  );
+                  ( "subject",
+                    `Assoc
+                      [
+                        ("did", `String "did:plc:xyz789aaa0001112223333");
+                        ("handle", `String "bob.test");
+                      ] );
+                ];
+            ] );
       ]
   in
   let pack = Graph.parse_starter_pack json in
   OUnit2.assert_equal (Some "New folks") pack.name;
-  OUnit2.assert_equal (Some 12) pack.joined_all_time_count
+  OUnit2.assert_equal (Some 12) pack.joined_all_time_count;
+  OUnit2.assert_equal 1 (List.length pack.list_items_sample);
+  OUnit2.assert_equal ~printer:(fun x -> x) "bob.test"
+    (List.hd pack.list_items_sample).subject.handle
 
 let test_parse_relationships _ =
   let json =
@@ -206,6 +226,14 @@ let test_parse_relationships _ =
                     `String
                       "at://did:plc:abc123xyz0001112223333/app.bsky.graph.follow/1"
                   );
+                  ( "blockedByList",
+                    `String
+                      "at://did:plc:xyz789aaa0001112223333/app.bsky.graph.listblock/1"
+                  );
+                  ( "blockingByList",
+                    `String
+                      "at://did:plc:abc123xyz0001112223333/app.bsky.graph.listblock/2"
+                  );
                 ];
             ] );
       ]
@@ -214,6 +242,14 @@ let test_parse_relationships _ =
   OUnit2.assert_equal 1 (List.length rels.relationships);
   OUnit2.assert_bool "following present"
     (match (List.hd rels.relationships).following with
+    | Some _ -> true
+    | None -> false);
+  OUnit2.assert_bool "blockedByList"
+    (match (List.hd rels.relationships).blocked_by_list with
+    | Some _ -> true
+    | None -> false);
+  OUnit2.assert_bool "blockingByList"
+    (match (List.hd rels.relationships).blocking_by_list with
     | Some _ -> true
     | None -> false)
 

--- a/test/test_graph.ml
+++ b/test/test_graph.ml
@@ -208,8 +208,9 @@ let test_parse_starter_pack _ =
   OUnit2.assert_equal (Some "New folks") pack.name;
   OUnit2.assert_equal (Some 12) pack.joined_all_time_count;
   OUnit2.assert_equal 1 (List.length pack.list_items_sample);
-  OUnit2.assert_equal ~printer:(fun x -> x) "bob.test"
-    (List.hd pack.list_items_sample).subject.handle
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "bob.test" (List.hd pack.list_items_sample).subject.handle
 
 let test_parse_relationships _ =
   let json =

--- a/test/test_label.ml
+++ b/test/test_label.ml
@@ -167,11 +167,43 @@ let test_self_labels _ =
   let encoded = Label.self_labels_to_json [ "nudity" ] in
   OUnit2.assert_equal (Some [ "nudity" ]) (Label.parse_self_labels encoded)
 
+let test_parse_label_value_definition _ =
+  let json =
+    `Assoc
+      [
+        ("identifier", `String "spam");
+        ("severity", `String "alert");
+        ("blurs", `String "content");
+        ("defaultSetting", `String "hide");
+        ("adultOnly", `Bool false);
+        ( "locales",
+          `List
+            [
+              `Assoc
+                [
+                  ("lang", `String "en");
+                  ("name", `String "Spam");
+                  ("description", `String "Unwanted commercial content");
+                ];
+            ] );
+      ]
+  in
+  let def = Label.parse_label_value_definition json in
+  OUnit2.assert_equal ~printer:(fun x -> x) "spam" def.identifier;
+  OUnit2.assert_equal ~printer:(fun x -> x) "alert" def.severity;
+  OUnit2.assert_equal ~printer:(fun x -> x) "content" def.blurs;
+  OUnit2.assert_equal (Some "hide") def.default_setting;
+  OUnit2.assert_equal (Some false) def.adult_only;
+  OUnit2.assert_equal 1 (List.length def.locales);
+  OUnit2.assert_equal ~printer:(fun x -> x) "en" (List.hd def.locales).lang
+
 let suite =
   "suite"
   >::: [
          "test_query_labels" >:: test_query_labels;
          "test_self_labels" >:: test_self_labels;
+         "test_parse_label_value_definition"
+         >:: test_parse_label_value_definition;
          "test_parse_query_labels" >:: test_parse_query_labels;
          "test_label_sign_verify_p256" >:: test_label_sign_verify_p256;
          "test_label_sign_verify_k256" >:: test_label_sign_verify_k256;

--- a/test/test_labeler.ml
+++ b/test/test_labeler.ml
@@ -71,12 +71,12 @@ let test_parse_services _ =
   OUnit2.assert_equal (Some official_labeler) (List.hd svcs.views).creator_did;
   OUnit2.assert_bool "policies"
     (match (List.hd svcs.views).policies with
-    | Some p ->
+    | Some p -> (
         List.mem "spam" p.label_values
         &&
         match p.label_value_definitions with
         | def :: _ -> def.identifier = "spam" && def.severity = "inform"
-        | [] -> false
+        | [] -> false)
     | None -> false)
 
 let test_get_services_live _ =

--- a/test/test_labeler.ml
+++ b/test/test_labeler.ml
@@ -40,6 +40,27 @@ let test_parse_services _ =
                       [
                         ( "labelValues",
                           `List [ `String "spam"; `String "!hide" ] );
+                        ( "labelValueDefinitions",
+                          `List
+                            [
+                              `Assoc
+                                [
+                                  ("identifier", `String "spam");
+                                  ("severity", `String "inform");
+                                  ("blurs", `String "none");
+                                  ("defaultSetting", `String "warn");
+                                  ( "locales",
+                                    `List
+                                      [
+                                        `Assoc
+                                          [
+                                            ("lang", `String "en");
+                                            ("name", `String "Spam");
+                                            ("description", `String "Spam");
+                                          ];
+                                      ] );
+                                ];
+                            ] );
                       ] );
                 ];
             ] );
@@ -50,7 +71,12 @@ let test_parse_services _ =
   OUnit2.assert_equal (Some official_labeler) (List.hd svcs.views).creator_did;
   OUnit2.assert_bool "policies"
     (match (List.hd svcs.views).policies with
-    | Some p -> List.mem "spam" p.label_values
+    | Some p ->
+        List.mem "spam" p.label_values
+        &&
+        match p.label_value_definitions with
+        | def :: _ -> def.identifier = "spam" && def.severity = "inform"
+        | [] -> false
     | None -> false)
 
 let test_get_services_live _ =

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -237,6 +237,12 @@ let test_union_codegen_and_official_bundle _ =
               "com.atproto.server.createAccount";
               "com.atproto.server.getSession";
               "com.atproto.server.createAppPassword";
+              "app.bsky.embed.external";
+              "app.bsky.feed.getAuthorFeed";
+              "app.bsky.graph.defs";
+              "com.atproto.server.checkAccountStatus";
+              "com.atproto.label.defs";
+              "chat.bsky.convo.getMessages";
             ];
           let defs =
             List.find
@@ -249,6 +255,13 @@ let test_union_codegen_and_official_bundle _ =
               defs.defs
           in
           OUnit2.assert_equal [ "count"; "actors" ] known.required;
+          let reply_ref =
+            List.find (fun (d : Lexicon.def) -> d.name = "replyRef") defs.defs
+          in
+          OUnit2.assert_bool "grandparentAuthor"
+            (List.exists
+               (fun (name, _) -> name = "grandparentAuthor")
+               reply_ref.properties);
           let actor_defs =
             List.find
               (fun (d : Lexicon.document) -> d.id = "app.bsky.actor.defs")

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -188,12 +188,14 @@ let test_email_and_account_bodies _ =
   OUnit2.assert_equal (`Assoc []) empty;
   let invites =
     Server.create_invite_codes_body ~code_count:2 ~use_count:5
-      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ] ()
+      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ]
+      ()
   in
   OUnit2.assert_equal 2 (invites |> member "codeCount" |> to_int);
   match invites |> member "forAccounts" with
   | `List [ `String did ] ->
-      OUnit2.assert_equal ~printer:(fun x -> x)
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
         "did:plc:abc123xyz0001112223333" did
   | _ -> OUnit2.assert_failure "expected forAccounts"
 

--- a/test/test_server.ml
+++ b/test/test_server.ml
@@ -50,11 +50,21 @@ let test_parse_account_status _ =
         ("validDid", `Bool true);
         ("expectedBlobs", `Int 3);
         ("importedBlobs", `Int 3);
+        ("repoCommit", `String "bafyreicommit");
+        ("repoRev", `String "3jzfcijpj2z2a");
+        ("repoBlocks", `Int 40);
+        ("indexedRecords", `Int 12);
+        ("privateStateValues", `Int 1);
       ]
   in
   let st = Server.parse_account_status json in
   OUnit2.assert_equal (Some true) st.activated;
-  OUnit2.assert_equal (Some 3) st.expected_blobs
+  OUnit2.assert_equal (Some 3) st.expected_blobs;
+  OUnit2.assert_equal (Some "bafyreicommit") st.repo_commit;
+  OUnit2.assert_equal (Some "3jzfcijpj2z2a") st.repo_rev;
+  OUnit2.assert_equal (Some 40) st.repo_blocks;
+  OUnit2.assert_equal (Some 12) st.indexed_records;
+  OUnit2.assert_equal (Some 1) st.private_state_values
 
 let test_account_urls _ =
   skip_if
@@ -175,7 +185,17 @@ let test_email_and_account_bodies _ =
     "2026-01-01T00:00:00.000Z"
     (deact |> member "deleteAfter" |> to_string);
   let empty = Server.deactivate_account_body () in
-  OUnit2.assert_equal (`Assoc []) empty
+  OUnit2.assert_equal (`Assoc []) empty;
+  let invites =
+    Server.create_invite_codes_body ~code_count:2 ~use_count:5
+      ~for_accounts:[ "did:plc:abc123xyz0001112223333" ] ()
+  in
+  OUnit2.assert_equal 2 (invites |> member "codeCount" |> to_int);
+  match invites |> member "forAccounts" with
+  | `List [ `String did ] ->
+      OUnit2.assert_equal ~printer:(fun x -> x)
+        "did:plc:abc123xyz0001112223333" did
+  | _ -> OUnit2.assert_failure "expected forAccounts"
 
 let test_describe_server_public _ =
   try


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Surveyed current official lexicons (`bluesky-social/atproto` `lexicons/`) against `main` after #70–#87. All public XRPC NSIDs and records were already covered; remaining gaps were typed parsers and request fields for newer official properties.

## What this adds

- **External embeds:** `readingTime`, `createdAt` / `updatedAt`, `associatedRefs`, `associatedProfiles`, and source theme RGB (`backgroundRGB` / `foregroundRGB` / `accentRGB` / `accentForegroundRGB`)
- **Feed:** `replyRef.grandparentAuthor`; `getAuthorFeed` `filter` / `includePins`; public `get_author_feed_page`
- **Graph:** relationship `blockedByList` / `blockingByList`; starter pack `listItemsSample`
- **Actor:** profile `joinedViaStarterPack`
- **Server:** typed `checkAccountStatus` (`repoCommit` / `repoRev` / `repoBlocks` / `indexedRecords` / `privateStateValues`); `createInviteCodes` `forAccounts` body
- **Labels:** typed `com.atproto.label.defs#labelValueDefinition` used by `Labeler` policies
- **Chat:** `getMessages.relatedProfiles`; group convo lock / join-request / lastReaction fields
- **Admin:** account `inviteNote` / `invitedBy` / `threatSignatures`
- Bundled official lexicon snippets + fixture tests. No invented credentials.

## Verification

Local `dune build` and `OUNIT_RUNNER=sequential dune runtest --force` passed. Auth/admin/ozone live suites skip without real `ATP_AUTH`. Public `getAuthorFeed` page test is skippable if the AppView request fails.

## Still leftover (not invented here)

- Deprecated `com.atproto.temp.fetchLabels`, `com.atproto.sync.getCheckout` / `getHead`
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (not XRPC)
- `internal.bsky.actor.getProfiles`
- Hosted OAuth/PDS/Tap/transcoder/archive token/LtHash
- Internal `debug` fields and deprecated `entities` / `isFallback`
- Privileged Ozone operator view fields (clients exist; live operator session not invented)

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ead562df-c660-4ef3-8115-9b7946941f83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ead562df-c660-4ef3-8115-9b7946941f83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

