### PR TITLE
Parse leftover chat system messages and age-assurance event fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Video | `Video` | `getJobStatus`, `getUploadLimits`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`did:web:<pds>` + `uploadBlob` lxm), injectable job poll, `video_embed_json`. Client only — no hosted transcoder |
 | Unspecced | `Unspecced` | Popular generators, search skeletons, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, unspecced age-assurance state, suggestion / feed / starter-pack / onboarding / discover / explore / seeMore skeletons, `getPostThreadV2` / `getPostThreadOtherV2`, config |
 | Labeler | `Labeler` | `app.bsky.labeler.getServices` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, lock/unlock, `getConvoMembers`, `getMessages.relatedProfiles`, group convo lock/join-request fields; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
+| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, **system message data** (`addedBy` / `removedBy` / `approvedBy` / `unlockedBy` / `lockedBy`), `getConvoMembers` (`role` / `addedBy` / `chatDisabled` / `kind`), `getMessages.relatedProfiles`, group convo leftover fields (`createdAt` / `joinLink` / `joinRequestCount` / `memberLimit`), `listConvoRequests` `convoView` / `joinRequestConvoView` union, `getLog` message / relatedProfiles / member; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / export / delete; moderation views + `subscribeModEvents`; `atproto-proxy: did:web:api.bsky.chat#bsky_chat` |
 | Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions, subjects/repos/records, timeline, reporter stats, scheduled actions; plus communication templates, sets, settings, team, safelink, signature, verification, hosting history + `getConfig`; `tools.ozone.queue.*` (list/create/update/delete, moderator assign, `routeReports`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); requires `atproto-proxy` |
 | Admin | `Admin` | `com.atproto.admin` subject status, account info (`inviteNote` / `invitedBy` / `threatSignatures`), invites, email |
 | Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies; typed `describeRepo` / `getRecord` / `listRecords` parsers; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration / `com.atproto.lexicon.schema` |
@@ -65,7 +65,7 @@ Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to
 | Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
 | Drafts | `Draft` | `app.bsky.draft` create/get/update/delete + typed draft / embed / threadgate / postgate builders |
 | Contacts | `Contact` | `app.bsky.contact` phone verify, import, matches, dismiss, sync status, remove data |
-| Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union |
+| Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union; stash `#event` parses `initIp` / `initUa` / `completeIp` / `completeUa` |
 | Embeds / facets | `Embed`, `Facet` | Images, external (`readingTime`, `associatedProfiles`, source theme RGB, `associatedRefs`), record, recordWithMedia, video (`presentation` `default`/`gif`), **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
 | Notifications | `Notification` | All `listNotifications` known reasons; prefs / prefs-v2 / activity subscriptions / register+unregister push |
 | User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants) |
@@ -84,9 +84,9 @@ These are product-level, not missing protocol cores:
 - Permissioned data / spaces / LtHash (no stable public spec to implement yet)
 - Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
 
-#70–#87 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, `knownLikers` / video `presentation` / `lexicon.schema`, and scoped mutes / profile associated / session extras.
+#70–#88 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, `knownLikers` / video `presentation` / `lexicon.schema`, scoped mutes / profile associated / session extras, and leftover official field parsers after #87.
 
-This stack fills leftover *library* field gaps vs current official lexicons: external-embed hydration (`readingTime`, `associatedProfiles`, source theme), feed `grandparentAuthor` + `getAuthorFeed` `includePins`, graph list-block relationship URIs + starter-pack `listItemsSample`, typed `checkAccountStatus` / label-value definitions, chat `relatedProfiles`, and admin invite/threat fields.
+This stack fills leftover *library* field gaps vs current official lexicons: chat system-message actor refs, group-member `addedBy`/`role`/`kind`, leftover group-convo fields, `listConvoRequests` union, `getLog` payloads, join-preview `viewer.requestedAt`, and age-assurance stash event IP/UA.
 
 Privileged admin/ozone writes still need a real operator session and are not invented here.
 
@@ -96,6 +96,8 @@ Still leftover vs current lexicons (not invented here):
 - Deprecated `com.atproto.sync.getCheckout` / `getHead` (use `getRepo` / `getLatestCommit`)
 - `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (OAuth scope tokens, not XRPC clients)
 - `internal.bsky.actor.getProfiles` (service-to-service AppView query, not a public client surface)
+- Internal `debug` fields and deprecated `entities` / `isFallback`
+- Privileged Ozone operator view fields (clients exist; live operator session not invented)
 
 Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
 

--- a/atproto.opam
+++ b/atproto.opam
@@ -55,10 +55,10 @@ Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri,
 Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc,
 Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact,
 Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and
-Response. Feed views parse grandparentAuthor and getAuthorFeed includePins;
-external embeds parse readingTime / associatedProfiles / source theme;
-label policies parse labelValueDefinition; checkAccountStatus includes
-repoCommit/repoRev/repoBlocks.
+Response. Chat parses system-message actor refs (addedBy / removedBy / approvedBy /
+unlockedBy), group-member role/kind, leftover group-convo fields, and
+listConvoRequests joinRequestConvoView. Age-assurance events parse
+initIp/initUa/completeIp/completeUa.
 
 Video support is a client for the hosted video service (byte upload +
 job-status poll). This package does not host a PDS, OAuth client-metadata

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -504,6 +504,53 @@ let () =
         ])
   in
   assert (actor_st.group_member_limit = 50);
+  let sys =
+    Chat.parse_message
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.convo.defs#systemMessageView");
+          ("id", `String "s1");
+          ("rev", `String "r1");
+          ("sentAt", `String "2026-01-01T00:00:00.000Z");
+          ( "data",
+            `Assoc
+              [
+                ( "$type",
+                  `String "chat.bsky.convo.defs#systemMessageDataUnlockConvo" );
+                ( "unlockedBy",
+                  `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
+              ] );
+        ])
+  in
+  assert sys.is_system;
+  (match sys.system with
+  | Some (`Unlock u) -> assert (String.length u.did > 0)
+  | _ -> assert false);
+  let reqs =
+    Chat.parse_convo_requests
+      (`Assoc
+        [
+          ( "requests",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "$type",
+                      `String "chat.bsky.group.defs#joinRequestConvoView" );
+                    ("convoId", `String "g1");
+                    ("name", `String "Friends");
+                    ( "owner",
+                      `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
+                    );
+                    ("memberCount", `Int 2);
+                    ("memberLimit", `Int 50);
+                  ];
+              ] );
+        ])
+  in
+  (match reqs.requests with
+  | [ `Join_request jr ] -> assert (jr.member_limit = 50)
+  | _ -> assert false);
   let decl = Records.chat_declaration ~allow_incoming:"following" () in
   assert (
     match Yojson.Safe.Util.member "$type" decl with

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -518,7 +518,8 @@ let () =
                 ( "$type",
                   `String "chat.bsky.convo.defs#systemMessageDataUnlockConvo" );
                 ( "unlockedBy",
-                  `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
+                  `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
+                );
               ] );
         ])
   in
@@ -540,8 +541,8 @@ let () =
                     ("convoId", `String "g1");
                     ("name", `String "Friends");
                     ( "owner",
-                      `Assoc [ ("did", `String "did:plc:abc123xyz0001112223333") ]
-                    );
+                      `Assoc
+                        [ ("did", `String "did:plc:abc123xyz0001112223333") ] );
                     ("memberCount", `Int 2);
                     ("memberLimit", `Int 50);
                   ];

--- a/src/bsky/ageassurance.ml
+++ b/src/bsky/ageassurance.ml
@@ -41,6 +41,10 @@ module Ageassurance = struct
     country_code : string;
     region_code : string option;
     email : string option;
+    init_ip : string option;
+    init_ua : string option;
+    complete_ip : string option;
+    complete_ua : string option;
     original : Yojson.Safe.t;
   }
 
@@ -119,6 +123,10 @@ module Ageassurance = struct
       country_code = Client.string_member json "countryCode";
       region_code = Client.string_opt json "regionCode";
       email = Client.string_opt json "email";
+      init_ip = Client.string_opt json "initIp";
+      init_ua = Client.string_opt json "initUa";
+      complete_ip = Client.string_opt json "completeIp";
+      complete_ua = Client.string_opt json "completeUa";
       original = json;
     }
 

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -199,7 +199,8 @@ module Chat = struct
     else if ends_with "systemMessageDataEditGroup" ty then
       `Edit_group
         (Client.string_opt json "oldName", Client.string_opt json "newName")
-    else if ends_with "systemMessageDataCreateJoinLink" ty then `Create_join_link
+    else if ends_with "systemMessageDataCreateJoinLink" ty then
+      `Create_join_link
     else if ends_with "systemMessageDataEditJoinLink" ty then `Edit_join_link
     else if ends_with "systemMessageDataEnableJoinLink" ty then
       `Enable_join_link
@@ -577,7 +578,10 @@ module Chat = struct
     | `Join_request of join_request_convo
     | `Unknown of Yojson.Safe.t ]
 
-  type convo_requests = { cursor : string option; requests : convo_request list }
+  type convo_requests = {
+    cursor : string option;
+    requests : convo_request list;
+  }
 
   let parse_join_request_convo json : join_request_convo =
     {
@@ -600,11 +604,11 @@ module Chat = struct
     let ty = Option.value ~default:"" (Client.string_opt json "$type") in
     if
       ends_with "joinRequestConvoView" ty
-      || (Client.string_member json "convoId" <> ""
-         && Client.string_member json "id" = "")
+      || Client.string_member json "convoId" <> ""
+         && Client.string_member json "id" = ""
     then `Join_request (parse_join_request_convo json)
-    else if Client.string_member json "id" <> "" || ends_with "convoView" ty then
-      `Convo (parse_convo json)
+    else if Client.string_member json "id" <> "" || ends_with "convoView" ty
+    then `Convo (parse_convo json)
     else `Unknown json
 
   let parse_convo_requests json : convo_requests =
@@ -838,7 +842,8 @@ module Chat = struct
       requested_by =
         (match Yojson.Safe.Util.member "requestedBy" json with
         | `Assoc _ as m -> parse_member m
-        | _ -> { empty_member with did = Client.string_member json "requestedBy" });
+        | _ ->
+            { empty_member with did = Client.string_member json "requestedBy" });
       requested_at = Client.string_member json "requestedAt";
     }
 

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -15,13 +15,53 @@ module Chat = struct
 
   let proxy_headers ?(proxy = default_proxy) () = [ Xrpc.proxy_header proxy ]
 
+  let ends_with suffix s =
+    let n = String.length s and m = String.length suffix in
+    n >= m && String.sub s (n - m) m = suffix
+
+  type member_kind = [ `Direct | `Group | `Past | `Unknown of string ]
+
+  (* chat.bsky.actor.defs#profileViewBasic + #groupConvoMember extras. *)
   type member = {
     did : string;
     handle : string option;
     display_name : string option;
+    chat_disabled : bool option;
+    role : string option;
+    added_by : member option;
+    kind : member_kind option;
   }
 
+  let empty_member =
+    {
+      did = "";
+      handle = None;
+      display_name = None;
+      chat_disabled = None;
+      role = None;
+      added_by = None;
+      kind = None;
+    }
+
   type reaction = { value : string; sender_did : string; created_at : string }
+
+  (* chat.bsky.convo.defs#systemMessageReferredUser *)
+  type referred_user = { did : string }
+
+  type system_message_data =
+    [ `Add_member of referred_user * string * referred_user
+    | `Remove_member of referred_user * referred_user
+    | `Member_join of referred_user * string * referred_user option
+    | `Member_leave of referred_user
+    | `Lock of referred_user
+    | `Unlock of referred_user
+    | `Lock_permanently of referred_user
+    | `Edit_group of string option * string option
+    | `Create_join_link
+    | `Edit_join_link
+    | `Enable_join_link
+    | `Disable_join_link
+    | `Unknown of Yojson.Safe.t ]
 
   type message = {
     id : string;
@@ -30,6 +70,8 @@ module Chat = struct
     sender_did : string option;
     sent_at : string;
     deleted : bool;
+    is_system : bool;
+    system : system_message_data option;
     facets : Facet.facet list;
     reactions : reaction list;
     embed : Embed.embed option;
@@ -38,6 +80,16 @@ module Chat = struct
   }
 
   type last_reaction = { message : message; reaction : reaction }
+
+  (* chat.bsky.group.defs#joinLinkView — also used on #groupConvo.joinLink. *)
+  type join_link = {
+    code : string;
+    enabled_status : string;
+    require_approval : bool;
+    join_rule : string;
+    created_at : string;
+    original : Yojson.Safe.t;
+  }
 
   type convo = {
     id : string;
@@ -52,6 +104,10 @@ module Chat = struct
     lock_status : string option;
     lock_status_moderation_override : bool option;
     member_count : int option;
+    member_limit : int option;
+    join_request_count : int option;
+    created_at : string option;
+    join_link : join_link option;
     group_name : string option;
     original : Yojson.Safe.t;
   }
@@ -64,12 +120,92 @@ module Chat = struct
     related_profiles : member list;
   }
 
-  let parse_member json : member =
+  let rec parse_member json : member =
+    let kind_json =
+      match Yojson.Safe.Util.member "kind" json with
+      | `Assoc _ as k -> Some k
+      | _ -> None
+    in
+    let kind_src = match kind_json with Some k -> k | None -> json in
+    let kind =
+      match kind_json with
+      | None -> None
+      | Some k ->
+          let ty = Option.value ~default:"" (Client.string_opt k "$type") in
+          if ends_with "pastGroupConvoMember" ty then Some `Past
+          else if ends_with "groupConvoMember" ty then Some `Group
+          else if ends_with "directConvoMember" ty then Some `Direct
+          else if ty = "" then None
+          else Some (`Unknown ty)
+    in
     {
       did = Client.string_member json "did";
       handle = Client.string_opt json "handle";
       display_name = Client.string_opt json "displayName";
+      chat_disabled = Client.bool_opt json "chatDisabled";
+      role = Client.string_opt kind_src "role";
+      added_by =
+        (match Yojson.Safe.Util.member "addedBy" kind_src with
+        | `Assoc _ as m -> Some (parse_member m)
+        | _ -> None);
+      kind;
     }
+
+  let parse_join_link json : join_link =
+    {
+      code = Client.string_member json "code";
+      enabled_status = Client.string_member json "enabledStatus";
+      require_approval = Client.bool_member json "requireApproval";
+      join_rule = Client.string_member json "joinRule";
+      created_at = Client.string_member json "createdAt";
+      original = json;
+    }
+
+  let parse_referred_user json : referred_user =
+    { did = Client.string_member json "did" }
+
+  let referred_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `Assoc _ as u -> Some (parse_referred_user u)
+    | _ -> None
+
+  let referred_req json field =
+    match Yojson.Safe.Util.member field json with
+    | `Assoc _ as u -> parse_referred_user u
+    | _ -> { did = Client.string_member json field }
+
+  let parse_system_data json : system_message_data =
+    let ty = Option.value ~default:"" (Client.string_opt json "$type") in
+    if ends_with "systemMessageDataAddMember" ty then
+      `Add_member
+        ( referred_req json "member",
+          Client.string_member json "role",
+          referred_req json "addedBy" )
+    else if ends_with "systemMessageDataRemoveMember" ty then
+      `Remove_member (referred_req json "member", referred_req json "removedBy")
+    else if ends_with "systemMessageDataMemberJoin" ty then
+      `Member_join
+        ( referred_req json "member",
+          Client.string_member json "role",
+          referred_opt json "approvedBy" )
+    else if ends_with "systemMessageDataMemberLeave" ty then
+      `Member_leave (referred_req json "member")
+    else if ends_with "systemMessageDataLockConvoPermanently" ty then
+      `Lock_permanently (referred_req json "lockedBy")
+    else if ends_with "systemMessageDataLockConvo" ty then
+      `Lock (referred_req json "lockedBy")
+    else if ends_with "systemMessageDataUnlockConvo" ty then
+      `Unlock (referred_req json "unlockedBy")
+    else if ends_with "systemMessageDataEditGroup" ty then
+      `Edit_group
+        (Client.string_opt json "oldName", Client.string_opt json "newName")
+    else if ends_with "systemMessageDataCreateJoinLink" ty then `Create_join_link
+    else if ends_with "systemMessageDataEditJoinLink" ty then `Edit_join_link
+    else if ends_with "systemMessageDataEnableJoinLink" ty then
+      `Enable_join_link
+    else if ends_with "systemMessageDataDisableJoinLink" ty then
+      `Disable_join_link
+    else `Unknown json
 
   let parse_reaction json : reaction =
     let sender_did =
@@ -97,11 +233,19 @@ module Chat = struct
 
   let parse_message json : message =
     let ty = Client.string_opt json "$type" in
-    let deleted =
+    let is_system =
       match ty with
-      | Some t ->
-          let n = String.length t in
-          n >= 19 && String.sub t (n - 19) 19 = "deletedMessageView"
+      | Some t -> ends_with "systemMessageView" t
+      | None -> (
+          match Yojson.Safe.Util.member "data" json with
+          | `Assoc _ -> true
+          | _ -> false)
+    in
+    let deleted =
+      (not is_system)
+      &&
+      match ty with
+      | Some t -> ends_with "deletedMessageView" t
       | None ->
           Client.string_member json "text" = ""
           && Client.string_member json "id" <> ""
@@ -118,6 +262,11 @@ module Chat = struct
       sender_did;
       sent_at = Client.string_member json "sentAt";
       deleted;
+      is_system;
+      system =
+        (match Yojson.Safe.Util.member "data" json with
+        | `Assoc _ as d -> Some (parse_system_data d)
+        | _ -> None);
       facets = parse_message_facets json;
       reactions = List.map parse_reaction (Client.list_member json "reactions");
       embed = Embed.parse_embed_option json;
@@ -176,6 +325,23 @@ module Chat = struct
         (match kind with
         | `Assoc _ -> Client.int_opt kind "memberCount"
         | _ -> Client.int_opt json "memberCount");
+      member_limit =
+        (match kind with
+        | `Assoc _ -> Client.int_opt kind "memberLimit"
+        | _ -> Client.int_opt json "memberLimit");
+      join_request_count =
+        (match kind with
+        | `Assoc _ -> Client.int_opt kind "joinRequestCount"
+        | _ -> Client.int_opt json "joinRequestCount");
+      created_at =
+        (match kind with
+        | `Assoc _ -> Client.string_opt kind "createdAt"
+        | _ -> Client.string_opt json "createdAt");
+      join_link =
+        (let src = match kind with `Assoc _ -> kind | _ -> json in
+         match Yojson.Safe.Util.member "joinLink" src with
+         | `Assoc _ as j -> Some (parse_join_link j)
+         | _ -> None);
       group_name =
         (match kind with
         | `Assoc _ -> Client.string_opt kind "name"
@@ -326,6 +492,10 @@ module Chat = struct
     type_ : string;
     convo_id : string option;
     rev : string option;
+    message : message option;
+    related_profiles : member list;
+    member : member option;
+    reaction : reaction option;
     original : Yojson.Safe.t;
   }
 
@@ -360,6 +530,20 @@ module Chat = struct
       type_ = Client.string_member json "$type";
       convo_id = Client.string_opt json "convoId";
       rev = Client.string_opt json "rev";
+      message =
+        (match Yojson.Safe.Util.member "message" json with
+        | `Assoc _ as m -> Some (parse_message m)
+        | _ -> None);
+      related_profiles =
+        List.map parse_member (Client.list_member json "relatedProfiles");
+      member =
+        (match Yojson.Safe.Util.member "member" json with
+        | `Assoc _ as m -> Some (parse_member m)
+        | _ -> None);
+      reaction =
+        (match Yojson.Safe.Util.member "reaction" json with
+        | `Assoc _ as r -> Some (parse_reaction r)
+        | _ -> None);
       original = json;
     }
 
@@ -377,14 +561,69 @@ module Chat = struct
 
   let parse_accept json : accept_result = { rev = Client.string_opt json "rev" }
 
+  (* chat.bsky.group.defs#joinRequestConvoView — requester's view in listConvoRequests. *)
+  type join_request_convo = {
+    convo_id : string;
+    name : string;
+    owner : member;
+    member_count : int;
+    member_limit : int;
+    requested_at : string option;
+    original : Yojson.Safe.t;
+  }
+
+  type convo_request =
+    [ `Convo of convo
+    | `Join_request of join_request_convo
+    | `Unknown of Yojson.Safe.t ]
+
+  type convo_requests = { cursor : string option; requests : convo_request list }
+
+  let parse_join_request_convo json : join_request_convo =
+    {
+      convo_id = Client.string_member json "convoId";
+      name = Client.string_member json "name";
+      owner =
+        (match Yojson.Safe.Util.member "owner" json with
+        | `Assoc _ as o -> parse_member o
+        | _ -> empty_member);
+      member_count = Client.int_member json "memberCount";
+      member_limit = Client.int_member json "memberLimit";
+      requested_at =
+        (match Yojson.Safe.Util.member "viewer" json with
+        | `Assoc _ as v -> Client.string_opt v "requestedAt"
+        | _ -> None);
+      original = json;
+    }
+
+  let parse_convo_request json : convo_request =
+    let ty = Option.value ~default:"" (Client.string_opt json "$type") in
+    if
+      ends_with "joinRequestConvoView" ty
+      || (Client.string_member json "convoId" <> ""
+         && Client.string_member json "id" = "")
+    then `Join_request (parse_join_request_convo json)
+    else if Client.string_member json "id" <> "" || ends_with "convoView" ty then
+      `Convo (parse_convo json)
+    else `Unknown json
+
+  let parse_convo_requests json : convo_requests =
+    {
+      cursor = Client.string_opt json "cursor";
+      requests =
+        List.map parse_convo_request
+          (match Yojson.Safe.Util.member "requests" json with
+          | `List xs -> xs
+          | _ -> Client.list_member json "convos");
+    }
+
   let parse_requests json : convos =
     {
       cursor = Client.string_opt json "cursor";
       convos =
-        List.map parse_convo
-          (match Yojson.Safe.Util.member "requests" json with
-          | `List xs -> xs
-          | _ -> Client.list_member json "convos");
+        List.filter_map
+          (function `Convo c -> Some c | _ -> None)
+          (parse_convo_requests json).requests;
     }
 
   let accept_convo (s : Session.session) ?proxy ~convo_id () : accept_result =
@@ -455,11 +694,11 @@ module Chat = struct
     |> parse_unread_counts
 
   let list_convo_requests (s : Session.session) ?proxy ?limit ?cursor () :
-      convos =
+      convo_requests =
     Client.get_json ~session:s ~extra:(proxy_headers ?proxy ())
       "chat.bsky.convo.listConvoRequests"
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
-    |> parse_requests
+    |> parse_convo_requests
 
   let send_message_batch (s : Session.session) ?proxy ~items () : message list =
     let payload =
@@ -553,15 +792,6 @@ module Chat = struct
 
   type members_page = { cursor : string option; members : member list }
 
-  type join_link = {
-    code : string;
-    enabled_status : string;
-    require_approval : bool;
-    join_rule : string;
-    created_at : string;
-    original : Yojson.Safe.t;
-  }
-
   type join_request = {
     convo_id : string;
     requested_by : member;
@@ -579,6 +809,7 @@ module Chat = struct
     member_limit : int;
     require_approval : bool;
     join_rule : string;
+    requested_at : string option;
     convo : convo option;
   }
 
@@ -596,16 +827,6 @@ module Chat = struct
       members = List.map parse_member (Client.list_member json "members");
     }
 
-  let parse_join_link json : join_link =
-    {
-      code = Client.string_member json "code";
-      enabled_status = Client.string_member json "enabledStatus";
-      require_approval = Client.bool_member json "requireApproval";
-      join_rule = Client.string_member json "joinRule";
-      created_at = Client.string_member json "createdAt";
-      original = json;
-    }
-
   let unwrap_join_link json : join_link =
     match Yojson.Safe.Util.member "joinLink" json with
     | `Assoc _ as j -> parse_join_link j
@@ -617,12 +838,7 @@ module Chat = struct
       requested_by =
         (match Yojson.Safe.Util.member "requestedBy" json with
         | `Assoc _ as m -> parse_member m
-        | _ ->
-            {
-              did = Client.string_member json "requestedBy";
-              handle = None;
-              display_name = None;
-            });
+        | _ -> { empty_member with did = Client.string_member json "requestedBy" });
       requested_at = Client.string_member json "requestedAt";
     }
 
@@ -655,11 +871,15 @@ module Chat = struct
           owner =
             (match Yojson.Safe.Util.member "owner" json with
             | `Assoc _ as o -> parse_member o
-            | _ -> { did = ""; handle = None; display_name = None });
+            | _ -> empty_member);
           member_count = Client.int_member json "memberCount";
           member_limit = Client.int_member json "memberLimit";
           require_approval = Client.bool_member json "requireApproval";
           join_rule = Client.string_member json "joinRule";
+          requested_at =
+            (match Yojson.Safe.Util.member "viewer" json with
+            | `Assoc _ as v -> Client.string_opt v "requestedAt"
+            | _ -> None);
           convo =
             (match Yojson.Safe.Util.member "convo" json with
             | `Assoc _ as c -> Some (parse_convo c)

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -453,6 +453,21 @@ module Lexicon = struct
   let official_get_messages =
     {|{"lexicon":1,"id":"chat.bsky.convo.getMessages","defs":{"main":{"type":"query","description":"Returns a page of messages from a conversation.","parameters":{"type":"params","required":["convoId"],"properties":{"convoId":{"type":"string"}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["messages"],"properties":{"messages":{"type":"array"},"relatedProfiles":{"type":"array"}}}}}}}|}
 
+  let official_convo_system_messages =
+    {|{"lexicon":1,"id":"chat.bsky.convo.defs","defs":{"systemMessageReferredUser":{"type":"object","required":["did"],"properties":{"did":{"type":"string"}}},"systemMessageDataAddMember":{"type":"object","required":["member","role","addedBy"],"properties":{"member":{"type":"ref"},"role":{"type":"ref"},"addedBy":{"type":"ref"}}},"systemMessageDataRemoveMember":{"type":"object","required":["member","removedBy"],"properties":{"member":{"type":"ref"},"removedBy":{"type":"ref"}}},"systemMessageDataUnlockConvo":{"type":"object","required":["unlockedBy"],"properties":{"unlockedBy":{"type":"ref"}}},"groupConvo":{"type":"object","required":["createdAt","lockStatus","memberCount","memberLimit","name"],"properties":{"createdAt":{"type":"string"},"joinLink":{"type":"ref"},"joinRequestCount":{"type":"integer"},"memberLimit":{"type":"integer"}}}}}|}
+
+  let official_chat_actor_member =
+    {|{"lexicon":1,"id":"chat.bsky.actor.defs","defs":{"groupConvoMember":{"type":"object","required":["role"],"properties":{"addedBy":{"type":"ref","ref":"#profileViewBasic"},"role":{"type":"ref","ref":"#memberRole"}}},"profileViewBasic":{"type":"object","required":["did","handle"],"properties":{"chatDisabled":{"type":"boolean"},"kind":{"type":"union","refs":["#directConvoMember","#groupConvoMember","#pastGroupConvoMember"]}}}}}|}
+
+  let official_list_convo_requests =
+    {|{"lexicon":1,"id":"chat.bsky.convo.listConvoRequests","defs":{"main":{"type":"query","description":"Returns incoming conversation requests. Direct convo requests are convoView; group join requests made by the user are joinRequestConvoView.","output":{"encoding":"application/json","schema":{"type":"object","required":["requests"],"properties":{"requests":{"type":"array"}}}}}}}|}
+
+  let official_join_request_convo =
+    {|{"lexicon":1,"id":"chat.bsky.group.defs","defs":{"joinRequestConvoView":{"type":"object","required":["convoId","name","owner","memberCount","memberLimit","viewer"],"properties":{"convoId":{"type":"string"},"name":{"type":"string"},"owner":{"type":"ref"},"memberCount":{"type":"integer"},"memberLimit":{"type":"integer"},"viewer":{"type":"ref","ref":"#joinLinkViewerState"}}},"joinLinkViewerState":{"type":"object","properties":{"requestedAt":{"type":"string"}}}}}|}
+
+  let official_ageassurance_event =
+    {|{"lexicon":1,"id":"app.bsky.ageassurance.defs","defs":{"event":{"type":"object","required":["createdAt","status","access","attemptId","countryCode"],"properties":{"initIp":{"type":"string"},"initUa":{"type":"string"},"completeIp":{"type":"string"},"completeUa":{"type":"string"}}}}}|}
+
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -497,6 +512,11 @@ module Lexicon = struct
       ("com.atproto.server.checkAccountStatus", official_check_account_status);
       ("com.atproto.label.defs", official_label_value_definition);
       ("chat.bsky.convo.getMessages", official_get_messages);
+      ("chat.bsky.convo.defs", official_convo_system_messages);
+      ("chat.bsky.actor.defs", official_chat_actor_member);
+      ("chat.bsky.convo.listConvoRequests", official_list_convo_requests);
+      ("chat.bsky.group.defs", official_join_request_convo);
+      ("app.bsky.ageassurance.defs", official_ageassurance_event);
     ]
 
   let official_documents () : document list =

--- a/test/test_ageassurance.ml
+++ b/test/test_ageassurance.ml
@@ -102,10 +102,18 @@ let test_parse_event _ =
           ("access", `String "full");
           ("countryCode", `String "US");
           ("email", `String "user@example.com");
+          ("initIp", `String "203.0.113.10");
+          ("initUa", `String "atproto-test/1.0");
+          ("completeIp", `String "203.0.113.11");
+          ("completeUa", `String "atproto-test/1.1");
         ])
   in
   OUnit2.assert_equal ~printer:(fun x -> x) "assured" ev.status;
-  OUnit2.assert_equal ~printer:(fun x -> x) "full" ev.access
+  OUnit2.assert_equal ~printer:(fun x -> x) "full" ev.access;
+  OUnit2.assert_equal (Some "203.0.113.10") ev.init_ip;
+  OUnit2.assert_equal (Some "atproto-test/1.0") ev.init_ua;
+  OUnit2.assert_equal (Some "203.0.113.11") ev.complete_ip;
+  OUnit2.assert_equal (Some "atproto-test/1.1") ev.complete_ua
 
 let test_get_config_live _ =
   try

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -635,7 +635,8 @@ let test_parse_system_messages_and_members _ =
                 ( "$type",
                   `String "chat.bsky.convo.defs#systemMessageDataAddMember" );
                 ( "member",
-                  `Assoc [ ("did", `String "did:plc:member0000000000000001") ] );
+                  `Assoc [ ("did", `String "did:plc:member0000000000000001") ]
+                );
                 ("role", `String "standard");
                 ( "addedBy",
                   `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
@@ -658,7 +659,8 @@ let test_parse_system_messages_and_members _ =
       (`Assoc
         [
           ("$type", `String "chat.bsky.convo.defs#systemMessageDataMemberJoin");
-          ("member", `Assoc [ ("did", `String "did:plc:member0000000000000001") ]);
+          ( "member",
+            `Assoc [ ("did", `String "did:plc:member0000000000000001") ] );
           ("role", `String "standard");
           ( "approvedBy",
             `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
@@ -689,9 +691,9 @@ let test_parse_system_messages_and_members _ =
     Chat.parse_system_data
       (`Assoc
         [
-          ( "$type",
-            `String "chat.bsky.convo.defs#systemMessageDataRemoveMember" );
-          ("member", `Assoc [ ("did", `String "did:plc:member0000000000000001") ]);
+          ("$type", `String "chat.bsky.convo.defs#systemMessageDataRemoveMember");
+          ( "member",
+            `Assoc [ ("did", `String "did:plc:member0000000000000001") ] );
           ( "removedBy",
             `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
         ])
@@ -866,7 +868,8 @@ let test_parse_log_and_convo_requests _ =
           ("memberLimit", `Int 100);
           ("requireApproval", `Bool true);
           ("joinRule", `String "anyone");
-          ("viewer", `Assoc [ ("requestedAt", `String "2026-01-03T00:00:00.000Z") ]);
+          ( "viewer",
+            `Assoc [ ("requestedAt", `String "2026-01-03T00:00:00.000Z") ] );
         ])
   in
   match preview with

--- a/test/test_chat.ml
+++ b/test/test_chat.ml
@@ -589,6 +589,291 @@ let test_group_join_parsers _ =
   in
   OUnit2.assert_equal 1 (List.length members.members)
 
+let test_parse_system_messages_and_members _ =
+  let member_json =
+    `Assoc
+      [
+        ("did", `String "did:plc:member0000000000000001");
+        ("handle", `String "bob.test");
+        ("displayName", `String "Bob");
+        ("chatDisabled", `Bool false);
+        ( "kind",
+          `Assoc
+            [
+              ("$type", `String "chat.bsky.actor.defs#groupConvoMember");
+              ("role", `String "standard");
+              ( "addedBy",
+                `Assoc
+                  [
+                    ("did", `String "did:plc:owner0000000000000001");
+                    ("handle", `String "alice.test");
+                  ] );
+            ] );
+      ]
+  in
+  let member = Chat.parse_member member_json in
+  OUnit2.assert_equal (Some "standard") member.role;
+  OUnit2.assert_equal (Some false) member.chat_disabled;
+  OUnit2.assert_equal (Some `Group) member.kind;
+  (match member.added_by with
+  | Some added ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:owner0000000000000001" added.did
+  | None -> OUnit2.assert_failure "expected addedBy");
+  let add =
+    Chat.parse_message
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.convo.defs#systemMessageView");
+          ("id", `String "s1");
+          ("rev", `String "r1");
+          ("sentAt", `String "2026-01-01T00:00:00.000Z");
+          ( "data",
+            `Assoc
+              [
+                ( "$type",
+                  `String "chat.bsky.convo.defs#systemMessageDataAddMember" );
+                ( "member",
+                  `Assoc [ ("did", `String "did:plc:member0000000000000001") ] );
+                ("role", `String "standard");
+                ( "addedBy",
+                  `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
+              ] );
+        ])
+  in
+  OUnit2.assert_equal true add.is_system;
+  OUnit2.assert_equal false add.deleted;
+  (match add.system with
+  | Some (`Add_member (member, "standard", added_by)) ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:member0000000000000001" member.did;
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:owner0000000000000001" added_by.did
+  | _ -> OUnit2.assert_failure "expected add-member system data");
+  let join =
+    Chat.parse_system_data
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.convo.defs#systemMessageDataMemberJoin");
+          ("member", `Assoc [ ("did", `String "did:plc:member0000000000000001") ]);
+          ("role", `String "standard");
+          ( "approvedBy",
+            `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
+        ])
+  in
+  (match join with
+  | `Member_join (_, "standard", Some approved) ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:owner0000000000000001" approved.did
+  | _ -> OUnit2.assert_failure "expected member-join approvedBy");
+  let unlock =
+    Chat.parse_system_data
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.convo.defs#systemMessageDataUnlockConvo");
+          ( "unlockedBy",
+            `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
+        ])
+  in
+  (match unlock with
+  | `Unlock u ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:owner0000000000000001" u.did
+  | _ -> OUnit2.assert_failure "expected unlock system data");
+  let remove =
+    Chat.parse_system_data
+      (`Assoc
+        [
+          ( "$type",
+            `String "chat.bsky.convo.defs#systemMessageDataRemoveMember" );
+          ("member", `Assoc [ ("did", `String "did:plc:member0000000000000001") ]);
+          ( "removedBy",
+            `Assoc [ ("did", `String "did:plc:owner0000000000000001") ] );
+        ])
+  in
+  match remove with
+  | `Remove_member (_, removed_by) ->
+      OUnit2.assert_equal
+        ~printer:(fun x -> x)
+        "did:plc:owner0000000000000001" removed_by.did
+  | _ -> OUnit2.assert_failure "expected remove-member system data"
+
+let test_parse_group_convo_leftover_fields _ =
+  let json =
+    `Assoc
+      [
+        ("id", `String "g2");
+        ("rev", `String "r9");
+        ("muted", `Bool false);
+        ("unreadCount", `Int 0);
+        ( "kind",
+          `Assoc
+            [
+              ("$type", `String "chat.bsky.convo.defs#groupConvo");
+              ("name", `String "mods");
+              ("createdAt", `String "2026-01-01T00:00:00.000Z");
+              ("lockStatus", `String "locked");
+              ("lockStatusModerationOverride", `Bool false);
+              ("memberCount", `Int 8);
+              ("memberLimit", `Int 50);
+              ("joinRequestCount", `Int 3);
+              ("unreadJoinRequestCount", `Int 1);
+              ( "joinLink",
+                `Assoc
+                  [
+                    ("code", `String "abc123");
+                    ("enabledStatus", `String "enabled");
+                    ("requireApproval", `Bool true);
+                    ("joinRule", `String "followedByOwner");
+                    ("createdAt", `String "2026-01-02T00:00:00.000Z");
+                  ] );
+            ] );
+      ]
+  in
+  let convo = Chat.parse_convo json in
+  OUnit2.assert_equal (Some "2026-01-01T00:00:00.000Z") convo.created_at;
+  OUnit2.assert_equal (Some 50) convo.member_limit;
+  OUnit2.assert_equal (Some 3) convo.join_request_count;
+  match convo.join_link with
+  | Some link ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "abc123" link.code;
+      OUnit2.assert_equal true link.require_approval
+  | None -> OUnit2.assert_failure "expected group convo joinLink"
+
+let test_parse_log_and_convo_requests _ =
+  let logs =
+    Chat.parse_logs
+      (`Assoc
+        [
+          ( "logs",
+            `List
+              [
+                `Assoc
+                  [
+                    ("$type", `String "chat.bsky.convo.defs#logAddMember");
+                    ("convoId", `String "g1");
+                    ("rev", `String "r3");
+                    ( "message",
+                      `Assoc
+                        [
+                          ( "$type",
+                            `String "chat.bsky.convo.defs#systemMessageView" );
+                          ("id", `String "s2");
+                          ("rev", `String "r3");
+                          ("sentAt", `String "2026-01-01T00:00:00.000Z");
+                          ( "data",
+                            `Assoc
+                              [
+                                ( "$type",
+                                  `String
+                                    "chat.bsky.convo.defs#systemMessageDataAddMember"
+                                );
+                                ( "member",
+                                  `Assoc
+                                    [
+                                      ( "did",
+                                        `String "did:plc:member0000000000000001"
+                                      );
+                                    ] );
+                                ("role", `String "standard");
+                                ( "addedBy",
+                                  `Assoc
+                                    [
+                                      ( "did",
+                                        `String "did:plc:owner0000000000000001"
+                                      );
+                                    ] );
+                              ] );
+                        ] );
+                    ( "relatedProfiles",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("did", `String "did:plc:member0000000000000001");
+                              ("handle", `String "bob.test");
+                            ];
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length logs.logs);
+  let entry = List.hd logs.logs in
+  OUnit2.assert_equal 1 (List.length entry.related_profiles);
+  (match entry.message with
+  | Some m -> OUnit2.assert_equal true m.is_system
+  | None -> OUnit2.assert_failure "expected log message");
+  let page =
+    Chat.parse_convo_requests
+      (`Assoc
+        [
+          ( "requests",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `String "c1");
+                    ("rev", `String "r0");
+                    ("muted", `Bool false);
+                    ("unreadCount", `Int 1);
+                    ("members", `List []);
+                  ];
+                `Assoc
+                  [
+                    ( "$type",
+                      `String "chat.bsky.group.defs#joinRequestConvoView" );
+                    ("convoId", `String "g9");
+                    ("name", `String "Friends");
+                    ( "owner",
+                      `Assoc
+                        [
+                          ("did", `String "did:plc:owner0000000000000001");
+                          ("handle", `String "alice.test");
+                        ] );
+                    ("memberCount", `Int 4);
+                    ("memberLimit", `Int 100);
+                    ( "viewer",
+                      `Assoc
+                        [ ("requestedAt", `String "2026-01-03T00:00:00.000Z") ]
+                    );
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 2 (List.length page.requests);
+  (match List.nth page.requests 1 with
+  | `Join_request jr ->
+      OUnit2.assert_equal ~printer:(fun x -> x) "Friends" jr.name;
+      OUnit2.assert_equal (Some "2026-01-03T00:00:00.000Z") jr.requested_at;
+      OUnit2.assert_equal 100 jr.member_limit
+  | _ -> OUnit2.assert_failure "expected joinRequestConvoView");
+  let preview =
+    Chat.parse_join_preview
+      (`Assoc
+        [
+          ("$type", `String "chat.bsky.group.defs#joinLinkPreviewView");
+          ("convoId", `String "g9");
+          ("code", `String "joinme");
+          ("name", `String "Friends");
+          ("owner", `Assoc [ ("did", `String "did:plc:owner0000000000000001") ]);
+          ("memberCount", `Int 4);
+          ("memberLimit", `Int 100);
+          ("requireApproval", `Bool true);
+          ("joinRule", `String "anyone");
+          ("viewer", `Assoc [ ("requestedAt", `String "2026-01-03T00:00:00.000Z") ]);
+        ])
+  in
+  match preview with
+  | `Preview p ->
+      OUnit2.assert_equal (Some "2026-01-03T00:00:00.000Z") p.requested_at
+  | _ -> OUnit2.assert_failure "expected join preview viewer.requestedAt"
+
 let test_list_convos_auth_skipped _ =
   skip_if
     (not Auth.has_live_credentials)
@@ -619,6 +904,12 @@ let suite =
          "test_moderation_parsers" >:: test_moderation_parsers;
          "test_subscribe_mod_events" >:: test_subscribe_mod_events;
          "test_group_join_parsers" >:: test_group_join_parsers;
+         "test_parse_system_messages_and_members"
+         >:: test_parse_system_messages_and_members;
+         "test_parse_group_convo_leftover_fields"
+         >:: test_parse_group_convo_leftover_fields;
+         "test_parse_log_and_convo_requests"
+         >:: test_parse_log_and_convo_requests;
          "test_list_convos_auth_skipped" >:: test_list_convos_auth_skipped;
        ]
 

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -174,6 +174,19 @@ let test_union_codegen_and_official_bundle _ =
        (fun (d : Lexicon.document) ->
          d.id = "chat.bsky.moderation.subscribeModEvents")
        docs);
+  OUnit2.assert_bool "convo.defs bundled"
+    (List.exists
+       (fun (d : Lexicon.document) -> d.id = "chat.bsky.convo.defs")
+       docs);
+  OUnit2.assert_bool "listConvoRequests bundled"
+    (List.exists
+       (fun (d : Lexicon.document) ->
+         d.id = "chat.bsky.convo.listConvoRequests")
+       docs);
+  OUnit2.assert_bool "ageassurance.defs bundled"
+    (List.exists
+       (fun (d : Lexicon.document) -> d.id = "app.bsky.ageassurance.defs")
+       docs);
   List.iter
     (fun (doc : Lexicon.document) ->
       OUnit2.assert_equal 1 doc.lexicon;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Already based on current `main` (`ca12a1e`, #88). No rebase required. Does **not** redo #88 leftover field parsers (external-embed hydration, `grandparentAuthor` / `includePins`, graph list-block URIs / `listItemsSample`, `checkAccountStatus` repo stats, `labelValueDefinition`, chat `relatedProfiles` / lock / lastReaction, admin invite/threat).

Surveyed current official lexicons (`bluesky-social/atproto` `lexicons/`) against `main` after #70–#88. Public XRPC NSIDs and records were already covered; remaining unique gaps were typed parsers for newer official chat and age-assurance properties.

## What this adds (unique vs #88)

- **Chat system messages:** `getMessages` / `lastMessage` / `getLog` parse `#systemMessageView` data (`addedBy`, `removedBy`, `approvedBy`, `unlockedBy`, `lockedBy`, member, role, edit-group names)
- **Group members:** `profileViewBasic.kind` `#groupConvoMember` parses `role`, `addedBy`, `chatDisabled`
- **Group convo leftovers after #88:** `createdAt`, `joinLink`, `joinRequestCount`, `memberLimit`
- **`listConvoRequests`:** typed `convoView` / `joinRequestConvoView` union (requester view includes `viewer.requestedAt`)
- **`getLog`:** message, `relatedProfiles`, member, reaction
- **Join-link preview:** `viewer.requestedAt`
- **Age assurance:** stash `#event` parses `initIp` / `initUa` / `completeIp` / `completeUa`
- Bundled official lexicon snippets + fixture tests. No invented credentials.

`list_convo_requests` now returns the official union instead of flattening every item as `convoView`.

Re-scan after this stack: no remaining public official property names are missing from the library (Ozone privileged operator view fields still omitted).

## Verification

Local `dune build` and `OUNIT_RUNNER=sequential dune runtest --force` passed. Auth/admin/ozone live suites skip without real `ATP_AUTH`.

## Still leftover (not invented here)

- Deprecated `com.atproto.temp.fetchLabels`, `com.atproto.sync.getCheckout` / `getHead`
- `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission documents (not XRPC)
- `internal.bsky.actor.getProfiles`
- Hosted OAuth/PDS/Tap/transcoder/archive token/LtHash
- Internal `debug` fields and deprecated `entities` / `isFallback`
- Privileged Ozone operator view fields (clients exist; live operator session not invented)

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9fed27a-0b8a-41ed-9502-d5cc33fa01b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9fed27a-0b8a-41ed-9502-d5cc33fa01b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

