### PR TITLE
Align ozone privileged writes with official safelink and verification lexicons

### DIFF
--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -534,8 +534,19 @@ module Ozone = struct
         ("cid", `String cid);
       ]
 
+  let report_action ?ids ?(types = []) ?all ?note () : Yojson.Safe.t =
+    `Assoc
+      ((match ids with
+       | Some xs -> [ ("ids", `List (List.map (fun n -> `Int n) xs)) ]
+       | None -> [])
+      @ (match types with
+        | [] -> []
+        | xs -> [ ("types", `List (List.map (fun s -> `String s) xs)) ])
+      @ (match all with Some b -> [ ("all", `Bool b) ] | None -> [])
+      @ match note with Some n -> [ ("note", `String n) ] | None -> [])
+
   let emit_event_body ~event ~subject ~created_by ?subject_blob_cids
-      ?external_id () : Yojson.Safe.t =
+      ?external_id ?mod_tool ?report_action () : Yojson.Safe.t =
     let fields =
       [
         ("event", event); ("subject", subject); ("createdBy", `String created_by);
@@ -544,10 +555,12 @@ module Ozone = struct
         | Some cids ->
             [ ("subjectBlobCids", `List (List.map (fun c -> `String c) cids)) ]
         | None -> [])
+      @ (match external_id with
+        | Some id -> [ ("externalId", `String id) ]
+        | None -> [])
+      @ (match mod_tool with Some t -> [ ("modTool", t) ] | None -> [])
       @
-      match external_id with
-      | Some id -> [ ("externalId", `String id) ]
-      | None -> []
+      match report_action with Some r -> [ ("reportAction", r) ] | None -> []
     in
     `Assoc fields
 
@@ -600,12 +613,12 @@ module Ozone = struct
     |> parse_events
 
   let emit_event (s : Session.session) ~proxy ?host ~event ~subject ~created_by
-      ?subject_blob_cids ?external_id () : mod_event =
+      ?subject_blob_cids ?external_id ?mod_tool ?report_action () : mod_event =
     Client.post_json ~session:s ?host ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.emitEvent"
       (Yojson.Safe.to_string
          (emit_event_body ~event ~subject ~created_by ?subject_blob_cids
-            ?external_id ()))
+            ?external_id ?mod_tool ?report_action ()))
     |> parse_mod_event
 
   let get_event (s : Session.session) ~proxy ~id () : mod_event =
@@ -1199,11 +1212,12 @@ module Ozone = struct
 
   let parse_url_rule json : url_rule =
     {
-      url =
-        (match Client.string_opt json "url" with
-        | Some s -> s
-        | None -> Client.string_member json "pattern");
-      pattern_type = Client.string_opt json "patternType";
+      url = Client.string_member json "url";
+      (* Official tools.ozone.safelink.defs#urlRule uses `pattern`. *)
+      pattern_type =
+        (match Client.string_opt json "pattern" with
+        | Some s -> Some s
+        | None -> Client.string_opt json "patternType");
       action = Client.string_opt json "action";
       reason = Client.string_opt json "reason";
       created_by = Client.string_opt json "createdBy";
@@ -1250,60 +1264,37 @@ module Ozone = struct
       (Yojson.Safe.to_string body)
     |> parse_url_rules
 
-  let add_safelink_rule (s : Session.session) ~proxy ~url ~pattern_type ~action
-      ?reason ?comment () : url_rule =
-    Client.post_json ~session:s ~extra:(proxy_headers proxy)
-      "tools.ozone.safelink.addRule"
-      (Yojson.Safe.to_string
-         (`Assoc
-           ([
-              ("url", `String url);
-              ("patternType", `String pattern_type);
-              ("action", `String action);
-            ]
-           @ (match reason with
-             | Some r -> [ ("reason", `String r) ]
-             | None -> [])
-           @
-           match comment with
-           | Some c -> [ ("comment", `String c) ]
-           | None -> [])))
-    |> parse_url_rule
+  (* Official addRule / updateRule / removeRule take `pattern` (not
+     patternType) and return tools.ozone.safelink.defs#event. *)
+  let add_safelink_rule_body ~url ~pattern ~action ~reason ?comment ?created_by
+      () : Yojson.Safe.t =
+    `Assoc
+      (("url", `String url)
+       :: ("pattern", `String pattern)
+       :: ("action", `String action)
+       :: ("reason", `String reason)
+       ::
+       (match comment with Some c -> [ ("comment", `String c) ] | None -> [])
+      @
+      match created_by with
+      | Some d -> [ ("createdBy", `String d) ]
+      | None -> [])
 
-  let update_safelink_rule (s : Session.session) ~proxy ~url ~pattern_type
-      ?action ?reason ?comment () : url_rule =
-    Client.post_json ~session:s ~extra:(proxy_headers proxy)
-      "tools.ozone.safelink.updateRule"
-      (Yojson.Safe.to_string
-         (`Assoc
-           (("url", `String url)
-            :: ("patternType", `String pattern_type)
-            ::
-            (match action with
-            | Some a -> [ ("action", `String a) ]
-            | None -> [])
-           @ (match reason with
-             | Some r -> [ ("reason", `String r) ]
-             | None -> [])
-           @
-           match comment with
-           | Some c -> [ ("comment", `String c) ]
-           | None -> [])))
-    |> parse_url_rule
+  let update_safelink_rule_body ~url ~pattern ~action ~reason ?comment
+      ?created_by () : Yojson.Safe.t =
+    add_safelink_rule_body ~url ~pattern ~action ~reason ?comment ?created_by ()
 
-  let remove_safelink_rule (s : Session.session) ~proxy ~url ~pattern_type
-      ?comment () : url_rule =
-    Client.post_json ~session:s ~extra:(proxy_headers proxy)
-      "tools.ozone.safelink.removeRule"
-      (Yojson.Safe.to_string
-         (`Assoc
-           (("url", `String url)
-           :: ("patternType", `String pattern_type)
-           ::
-           (match comment with
-           | Some c -> [ ("comment", `String c) ]
-           | None -> []))))
-    |> parse_url_rule
+  let remove_safelink_rule_body ~url ~pattern ?comment ?created_by () :
+      Yojson.Safe.t =
+    `Assoc
+      (("url", `String url)
+       :: ("pattern", `String pattern)
+       ::
+       (match comment with Some c -> [ ("comment", `String c) ] | None -> [])
+      @
+      match created_by with
+      | Some d -> [ ("createdBy", `String d) ]
+      | None -> [])
 
   type safelink_event = {
     id : int;
@@ -1345,6 +1336,32 @@ module Ozone = struct
       cursor = Client.string_opt json "cursor";
       events = List.map parse_safelink_event (Client.list_member json "events");
     }
+
+  let add_safelink_rule (s : Session.session) ~proxy ~url ~pattern ~action
+      ~reason ?comment ?created_by () : safelink_event =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.safelink.addRule"
+      (Yojson.Safe.to_string
+         (add_safelink_rule_body ~url ~pattern ~action ~reason ?comment
+            ?created_by ()))
+    |> parse_safelink_event
+
+  let update_safelink_rule (s : Session.session) ~proxy ~url ~pattern ~action
+      ~reason ?comment ?created_by () : safelink_event =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.safelink.updateRule"
+      (Yojson.Safe.to_string
+         (update_safelink_rule_body ~url ~pattern ~action ~reason ?comment
+            ?created_by ()))
+    |> parse_safelink_event
+
+  let remove_safelink_rule (s : Session.session) ~proxy ~url ~pattern ?comment
+      ?created_by () : safelink_event =
+    Client.post_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.safelink.removeRule"
+      (Yojson.Safe.to_string
+         (remove_safelink_rule_body ~url ~pattern ?comment ?created_by ()))
+    |> parse_safelink_event
 
   let query_safelink_events_body ?cursor ?limit ?(urls = []) ?pattern_type
       ?sort_direction () : Yojson.Safe.t =
@@ -1424,7 +1441,11 @@ module Ozone = struct
     issuer : string option;
     subject : string option;
     handle : string option;
+    display_name : string option;
+    created_at : string option;
+    revoke_reason : string option;
     revoked_at : string option;
+    revoked_by : string option;
     original : Yojson.Safe.t;
   }
 
@@ -1433,13 +1454,30 @@ module Ozone = struct
     verifications : verification_view list;
   }
 
+  type grant_error = { error : string; subject : string }
+  type revoke_error = { uri : string; error : string }
+
+  type grant_verifications_result = {
+    verifications : verification_view list;
+    failed_verifications : grant_error list;
+  }
+
+  type revoke_verifications_result = {
+    revoked_verifications : string list;
+    failed_revocations : revoke_error list;
+  }
+
   let parse_verification_view json : verification_view =
     {
       uri = Client.string_member json "uri";
       issuer = Client.string_opt json "issuer";
       subject = Client.string_opt json "subject";
       handle = Client.string_opt json "handle";
+      display_name = Client.string_opt json "displayName";
+      created_at = Client.string_opt json "createdAt";
+      revoke_reason = Client.string_opt json "revokeReason";
       revoked_at = Client.string_opt json "revokedAt";
+      revoked_by = Client.string_opt json "revokedBy";
       original = json;
     }
 
@@ -1450,6 +1488,61 @@ module Ozone = struct
         List.map parse_verification_view
           (Client.list_member json "verifications");
     }
+
+  let parse_grant_error json : grant_error =
+    {
+      error = Client.string_member json "error";
+      subject = Client.string_member json "subject";
+    }
+
+  let parse_revoke_error json : revoke_error =
+    {
+      uri = Client.string_member json "uri";
+      error = Client.string_member json "error";
+    }
+
+  let parse_grant_verifications json : grant_verifications_result =
+    {
+      verifications =
+        List.map parse_verification_view
+          (Client.list_member json "verifications");
+      failed_verifications =
+        List.map parse_grant_error
+          (Client.list_member json "failedVerifications");
+    }
+
+  let parse_revoke_verifications json : revoke_verifications_result =
+    {
+      revoked_verifications =
+        List.filter_map
+          (function `String s -> Some s | _ -> None)
+          (Client.list_member json "revokedVerifications");
+      failed_revocations =
+        List.map parse_revoke_error
+          (Client.list_member json "failedRevocations");
+    }
+
+  let verification_input ~subject ~handle ~display_name ?created_at () :
+      Yojson.Safe.t =
+    `Assoc
+      (("subject", `String subject)
+      :: ("handle", `String handle)
+      :: ("displayName", `String display_name)
+      ::
+      (match created_at with
+      | Some t -> [ ("createdAt", `String t) ]
+      | None -> []))
+
+  let grant_verifications_body ~verifications () : Yojson.Safe.t =
+    `Assoc [ ("verifications", `List verifications) ]
+
+  let revoke_verifications_body ~uris ?revoke_reason () : Yojson.Safe.t =
+    `Assoc
+      (("uris", `List (List.map (fun u -> `String u) uris))
+      ::
+      (match revoke_reason with
+      | Some r -> [ ("revokeReason", `String r) ]
+      | None -> []))
 
   let list_verifications (s : Session.session) ~proxy ?cursor ?limit
       ?(issuers = []) ?(subjects = []) () : verifications =
@@ -1462,25 +1555,19 @@ module Ozone = struct
     |> parse_verifications
 
   let grant_verifications (s : Session.session) ~proxy ~verifications () :
-      verifications =
+      grant_verifications_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.verification.grantVerifications"
-      (Yojson.Safe.to_string
-         (`Assoc [ ("verifications", `List verifications) ]))
-    |> parse_verifications
+      (Yojson.Safe.to_string (grant_verifications_body ~verifications ()))
+    |> parse_grant_verifications
 
   let revoke_verifications (s : Session.session) ~proxy ~uris ?revoke_reason ()
-      : verifications =
+      : revoke_verifications_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.verification.revokeVerifications"
       (Yojson.Safe.to_string
-         (`Assoc
-           ([ ("uris", `List (List.map (fun u -> `String u) uris)) ]
-           @
-           match revoke_reason with
-           | Some r -> [ ("revokeReason", `String r) ]
-           | None -> [])))
-    |> parse_verifications
+         (revoke_verifications_body ~uris ?revoke_reason ()))
+    |> parse_revoke_verifications
 
   type account_history_event = {
     created_at : string option;

--- a/test/test_local_ozone.ml
+++ b/test/test_local_ozone.ml
@@ -4,6 +4,7 @@ open Atproto.Ozone
 open Atproto.Label
 open Atproto.Client
 open Atproto.Error
+open Atproto.Moderation
 open Ozone
 open Label
 
@@ -67,12 +68,49 @@ let no_xrpc_error json =
   | Some _ -> failwith ("XRPC error: " ^ Error.to_string (Error.of_json json))
   | None -> ()
 
+let message_has hay needle =
+  let h = String.lowercase_ascii hay and n = String.lowercase_ascii needle in
+  let rec aux i =
+    if i + String.length n > String.length h then false
+    else if String.sub h i (String.length n) = n then true
+    else aux (i + 1)
+  in
+  aux 0
+
+let cannot_moderate json =
+  match Error.check_for_error json with
+  | None -> false
+  | Some _ when Error.is_not_served_json json -> true
+  | Some err ->
+      let e = String.lowercase_ascii err in
+      let msg = String.lowercase_ascii (Error.to_string (Error.of_json json)) in
+      List.exists
+        (fun n -> e = n || message_has msg n)
+        [
+          "authenticationrequired";
+          "authmissing";
+          "forbidden";
+          "unauthorized";
+          "accessdenied";
+          "accounttakedown";
+        ]
+      || message_has msg "not authorized"
+      || message_has msg "not a moderator"
+      || message_has msg "insufficient"
+      || message_has msg "permission"
+      || message_has msg "not a verifier"
+      || message_has msg "verifier"
+
 let served json =
-  if Error.is_not_served_json json then false
+  if Error.is_not_served_json json || cannot_moderate json then false
   else
     match Error.check_for_error json with
     | Some _ -> failwith ("XRPC error: " ^ Error.to_string (Error.of_json json))
     | None -> true
+
+let leftover_tag () =
+  Printf.sprintf "ocaml-leftover-%d"
+    (int_of_float (Unix.gettimeofday () *. 1000.) mod 100_000_000)
 
 let test_get_config _ =
   let s = admin_session () in
@@ -331,6 +369,134 @@ let test_leftover_ozone _ =
       OUnit2.assert_bool "listScheduledActions" (List.length listed.actions >= 0)
   | _ -> ()
 
+let ozone_post s p nsid body =
+  Client.post_json ~session:s ~extra:(Ozone.proxy_headers p) nsid
+    (Yojson.Safe.to_string body)
+
+let test_privileged_writes _ =
+  let s = admin_session () in
+  let p = proxy () in
+  let alice = Session.create_session "alice.test" "hunter2" in
+  let bob = Session.create_session "bob.test" "hunter2" in
+  let tag = leftover_tag () in
+  (* emitEvent with official reportAction. Skip if not served / cannot moderate. *)
+  (match
+     ozone_post s p "tools.ozone.moderation.emitEvent"
+       (Ozone.emit_event_body
+          ~event:(Ozone.comment_event ("privileged " ^ tag))
+          ~subject:(Ozone.repo_ref alice.auth.did)
+          ~created_by:s.auth.did
+          ~report_action:(Ozone.report_action ~all:true ~note:tag ())
+          ())
+   with
+  | json when served json ->
+      let ev = Ozone.parse_mod_event json in
+      no_xrpc_error ev.original
+  | _ -> ());
+  (* Queue mutations. A single-node TestNetwork may 501 these NSIDs. *)
+  let queue_name = "ocaml-queue-" ^ tag in
+  (match
+     ozone_post s p "tools.ozone.queue.createQueue"
+       (Ozone.create_queue_body ~name:queue_name ~subject_types:[ "account" ] ())
+   with
+  | json when served json ->
+      let created = Ozone.parse_queue_result json in
+      OUnit2.assert_bool "createQueue id" (created.id >= 0);
+      let updated =
+        Ozone.update_queue s ~proxy:p ~queue_id:created.id
+          ~description:("updated " ^ tag) ()
+      in
+      OUnit2.assert_equal created.id updated.id;
+      let deleted = Ozone.delete_queue s ~proxy:p ~queue_id:created.id () in
+      OUnit2.assert_bool "deleteQueue" deleted.deleted
+  | _ -> ());
+  (* Report mutations: PDS createReport, then ozone createActivity if served. *)
+  (match
+     ozone_json s p "tools.ozone.report.queryReports"
+       [ ("status", "open"); ("limit", "10") ]
+   with
+  | json when served json -> (
+      let report_json =
+        Client.post_json ~session:alice "com.atproto.moderation.createReport"
+          (Moderation.create_report_data_from_repo_ref Moderation.reason_other
+             ~reason:("ocaml leftover " ^ tag)
+             { Moderation.did = bob.auth.did })
+      in
+      match report_json with
+      | rjson when served rjson -> (
+          let reports =
+            Ozone.query_reports s ~proxy:p ~status:"open" ~did:bob.auth.did
+              ~limit:10 ()
+          in
+          match reports.reports with
+          | [] -> ()
+          | report :: _ -> (
+              match
+                ozone_post s p "tools.ozone.report.createActivity"
+                  (Ozone.create_activity_body ~activity:(Ozone.note_activity ())
+                     ~report_id:report.id ~internal_note:tag ())
+              with
+              | ajson when served ajson ->
+                  let activity = Ozone.parse_activity_result ajson in
+                  OUnit2.assert_bool "createActivity"
+                    (match activity.report_id with
+                    | Some id -> id = report.id
+                    | None -> true)
+              | _ -> ()))
+      | _ -> ())
+  | _ -> ());
+  (* Safelink add / update / remove — official `pattern` field. *)
+  let url = "https://" ^ tag ^ ".leftover.test" in
+  (match
+     ozone_post s p "tools.ozone.safelink.addRule"
+       (Ozone.add_safelink_rule_body ~url ~pattern:"domain" ~action:"warn"
+          ~reason:"spam" ~comment:tag ())
+   with
+  | json when served json ->
+      let added = Ozone.parse_safelink_event json in
+      OUnit2.assert_equal ~printer:(fun x -> x) url added.url;
+      OUnit2.assert_equal (Some "domain") added.pattern;
+      let updated =
+        Ozone.update_safelink_rule s ~proxy:p ~url ~pattern:"domain"
+          ~action:"block" ~reason:"phishing" ~comment:("upd " ^ tag) ()
+      in
+      OUnit2.assert_equal (Some "block") updated.action;
+      let removed =
+        Ozone.remove_safelink_rule s ~proxy:p ~url ~pattern:"domain"
+          ~comment:("rm " ^ tag) ()
+      in
+      OUnit2.assert_equal ~printer:(fun x -> x) url removed.url
+  | _ -> ());
+  (* Grant / revoke verification. Skip if ozone is not a verifier. *)
+  match
+    ozone_post s p "tools.ozone.verification.grantVerifications"
+      (Ozone.grant_verifications_body
+         ~verifications:
+           [
+             Ozone.verification_input ~subject:alice.auth.did
+               ~handle:alice.username ~display_name:"Alice" ();
+           ]
+         ())
+  with
+  | json when served json -> (
+      let granted = Ozone.parse_grant_verifications json in
+      OUnit2.assert_bool "grantVerifications parsed"
+        (List.length granted.verifications
+         + List.length granted.failed_verifications
+        >= 0);
+      match granted.verifications with
+      | [] -> ()
+      | v :: _ ->
+          let revoked =
+            Ozone.revoke_verifications s ~proxy:p ~uris:[ v.uri ]
+              ~revoke_reason:("ocaml leftover " ^ tag) ()
+          in
+          OUnit2.assert_bool "revokeVerifications parsed"
+            (List.length revoked.revoked_verifications
+             + List.length revoked.failed_revocations
+            >= 0))
+  | _ -> ()
+
 let suite =
   "local_ozone"
   >::: [
@@ -339,6 +505,7 @@ let suite =
          "test_query_labels" >:: test_query_labels;
          "test_more_ozone" >:: test_more_ozone;
          "test_leftover_ozone" >:: test_leftover_ozone;
+         "test_privileged_writes" >:: test_privileged_writes;
        ]
 
 let () =

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -572,6 +572,135 @@ let test_parse_server_config_leftovers _ =
   OUnit2.assert_equal (Some "did:plc:verifier000111222333444555")
     cfg.verifier_did
 
+let test_official_safelink_and_verification_bodies _ =
+  let open Yojson.Safe.Util in
+  let add =
+    Ozone.add_safelink_rule_body ~url:"https://phish.example" ~pattern:"domain"
+      ~action:"block" ~reason:"phishing" ~comment:"caught" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "domain"
+    (add |> member "pattern" |> to_string);
+  OUnit2.assert_equal `Null (member "patternType" add);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "phishing"
+    (add |> member "reason" |> to_string);
+  let remove =
+    Ozone.remove_safelink_rule_body ~url:"https://phish.example"
+      ~pattern:"domain" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "domain"
+    (remove |> member "pattern" |> to_string);
+  let rules =
+    Ozone.parse_url_rules
+      (`Assoc
+        [
+          ( "rules",
+            `List
+              [
+                `Assoc
+                  [
+                    ("url", `String "https://evil.example");
+                    ("pattern", `String "url");
+                    ("action", `String "warn");
+                    ("reason", `String "spam");
+                    ("createdBy", `String "did:plc:mod000111222333444555666");
+                    ("createdAt", `String "2026-01-01T00:00:00.000Z");
+                    ("updatedAt", `String "2026-01-01T00:00:00.000Z");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal (Some "url") (List.hd rules.rules).pattern_type;
+  let grant_in =
+    Ozone.verification_input ~subject:"did:plc:abc123xyz0001112223333"
+      ~handle:"alice.test" ~display_name:"Alice" ()
+  in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "Alice"
+    (grant_in |> member "displayName" |> to_string);
+  let granted =
+    Ozone.parse_grant_verifications
+      (`Assoc
+        [
+          ( "verifications",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:mod000111222333444555666/app.bsky.graph.verification/3jzfcijpj2z2a"
+                    );
+                    ("issuer", `String "did:plc:mod000111222333444555666");
+                    ("subject", `String "did:plc:abc123xyz0001112223333");
+                    ("handle", `String "alice.test");
+                    ("displayName", `String "Alice");
+                    ("createdAt", `String "2026-01-01T00:00:00.000Z");
+                  ];
+              ] );
+          ( "failedVerifications",
+            `List
+              [
+                `Assoc
+                  [
+                    ("error", `String "already verified");
+                    ("subject", `String "did:plc:bob000111222333444555666");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length granted.verifications);
+  OUnit2.assert_equal (Some "Alice")
+    (List.hd granted.verifications).display_name;
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "already verified" (List.hd granted.failed_verifications).error;
+  let revoked =
+    Ozone.parse_revoke_verifications
+      (`Assoc
+        [
+          ( "revokedVerifications",
+            `List
+              [
+                `String
+                  "at://did:plc:mod000111222333444555666/app.bsky.graph.verification/3jzfcijpj2z2a";
+              ] );
+          ( "failedRevocations",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "uri",
+                      `String
+                        "at://did:plc:mod000111222333444555666/app.bsky.graph.verification/missing"
+                    );
+                    ("error", `String "not found");
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length revoked.revoked_verifications);
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "not found" (List.hd revoked.failed_revocations).error;
+  let emit =
+    Ozone.emit_event_body
+      ~event:(Ozone.comment_event "linked")
+      ~subject:(Ozone.repo_ref "did:plc:abc123xyz0001112223333")
+      ~created_by:"did:plc:mod000111222333444555666"
+      ~report_action:(Ozone.report_action ~ids:[ 11 ] ~note:"seen" ())
+      ()
+  in
+  OUnit2.assert_equal ~printer:string_of_int 11
+    (emit |> member "reportAction" |> member "ids" |> to_list |> List.hd
+   |> to_int)
+
 let test_parse_assignment_moderator _ =
   let asg =
     Ozone.parse_assignment_view
@@ -628,6 +757,8 @@ let suite =
          "test_parse_server_config_leftovers"
          >:: test_parse_server_config_leftovers;
          "test_parse_assignment_moderator" >:: test_parse_assignment_moderator;
+         "test_official_safelink_and_verification_bodies"
+         >:: test_official_safelink_and_verification_bodies;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked leftover unique protocol work on #96 (`cursor/leftover-unique-protocol-b7df`). MST invert / firehose-diff, HTTP/2, CAR, and repo-sync leftovers were already present on that branch and are not repeated here.

## Unique leftovers shipped

### Official safelink mutation bodies
`tools.ozone.safelink.addRule` / `updateRule` / `removeRule` now send the official `pattern` field (not `patternType`) with required `action` / `reason` on add and update. Outputs parse as `tools.ozone.safelink.defs#event`. Query filters still use official `patternType`. `urlRule` parsers read `pattern`.

### Official grant / revoke verification
`grantVerifications` parses `verifications` plus `failedVerifications`. `revokeVerifications` parses `revokedVerifications` plus `failedRevocations`. Typed `verification_input` builder matches `#verificationInput` (`subject`, `handle`, `displayName`).

### emitEvent `reportAction`
`emit_event` / `emit_event_body` accept official `reportAction` (and optional `modTool`).

### Local ozone privileged writes
`test_local_ozone` uses the existing TestNetwork moderator (`admin-mod.test` / `admin-mod-pass`, or `ATP_AUTH_OZONE`): emitEvent, queue create/update/delete, report `createActivity`, safelink add/update/remove, grant/revoke verification. Skip-if-not-served for MethodNotImplemented / flag-off / Unknown lexicon type, and when the session cannot moderate. No invented operator.

## Intentionally not shipped
- MST invert / firehose-diff (already complete on #96)
- HTTP/2 / CAR / repo-sync holes (already present)
- Deprecated `fetchLabels` / `getCheckout` / `getHead`
- Internal `getProfiles`, fake chat server, video transcoder
- Draft / contact / ageassurance required local tests
- `@atproto/dev-env` bump

## Tests
- `dune build`
- `ocamlformat 0.25.1` on edited files
- `dune runtest`
- local Ozone: `test_local_ozone` (skips without local stack)

No backwards compatibility for unused APIs. Chat remains skippable live.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c8cb6b-ded1-434f-8068-696effde953a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c8cb6b-ded1-434f-8068-696effde953a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

