### PR TITLE
Add official getFollows/getFollowers sort knownValues and cursor

### DIFF
--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -5,14 +5,20 @@ open Actor
 open Label
 
 module Graph = struct
+  (* Official app.bsky.graph.getFollows / getFollowers `sort` knownValues. *)
+  let sort_latest = "latest"
+  let sort_top = "top"
+
   type followers = {
     subject : Actor.short_profile;
     followers : Actor.short_profile list;
+    cursor : string option;
   }
 
   type follows = {
     subject : Actor.short_profile;
     follows : Actor.short_profile list;
+    cursor : string option;
   }
 
   type blocks = { blocks : Actor.block_profile list; cursor : string }
@@ -25,6 +31,11 @@ module Graph = struct
     let json = Yojson.Safe.from_string body in
     json
 
+  let string_opt json field =
+    match Yojson.Safe.Util.member field json with
+    | `String s -> Some s
+    | _ -> None
+
   let parse_followers json : followers =
     let open Yojson.Safe.Util in
     let subject = json |> member "subject" |> Actor.parse_short_profile in
@@ -32,7 +43,7 @@ module Graph = struct
       json |> member "followers" |> to_list
       |> List.map Actor.parse_short_profile
     in
-    { subject; followers }
+    { subject; followers; cursor = string_opt json "cursor" }
 
   let parse_follows json : follows =
     let open Yojson.Safe.Util in
@@ -40,7 +51,13 @@ module Graph = struct
     let follows =
       json |> member "follows" |> to_list |> List.map Actor.parse_short_profile
     in
-    { subject; follows }
+    { subject; follows; cursor = string_opt json "cursor" }
+
+  (* Official getFollows / getFollowers query params, including `sort`. *)
+  let follow_page_pairs ~actor ?limit ?cursor ?sort () =
+    (("actor", actor) :: Client.Client.opt_int "limit" limit)
+    @ Client.Client.opt_pair "cursor" cursor
+    @ Client.Client.opt_pair "sort" sort
 
   let parse_blocks json : blocks =
     let open Yojson.Safe.Util in
@@ -104,6 +121,12 @@ module Graph = struct
     in
     followers |> convert_body_to_json |> parse_followers
 
+  let get_followers_page ?session ?host ~actor ?limit ?cursor ?sort () :
+      followers =
+    Client.Client.get_json ?session ?host "app.bsky.graph.getFollowers"
+      (follow_page_pairs ~actor ?limit ?cursor ?sort ())
+    |> parse_followers
+
   let get_follows (s : Session.session) (actor : string) (limit : int) : follows
       =
     let bearer_token = Session.bearer_token_from_session s in
@@ -125,6 +148,11 @@ module Graph = struct
            headers)
     in
     follows |> convert_body_to_json |> parse_follows
+
+  let get_follows_page ?session ?host ~actor ?limit ?cursor ?sort () : follows =
+    Client.Client.get_json ?session ?host "app.bsky.graph.getFollows"
+      (follow_page_pairs ~actor ?limit ?cursor ?sort ())
+    |> parse_follows
 
   let get_mutes (s : Session.session) (limit : int) : mutes =
     let bearer_token = Session.bearer_token_from_session s in

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -481,6 +481,12 @@ module Lexicon = struct
   let official_mute_actor =
     {|{"lexicon":1,"id":"app.bsky.graph.muteActor","defs":{"main":{"type":"procedure","description":"Creates a mute relationship for the specified account.","input":{"encoding":"application/json","schema":{"type":"object","required":["actor"],"properties":{"actor":{"type":"string"},"onlyReposts":{"type":"boolean"},"onlyQuoteposts":{"type":"boolean"}}}}}}}|}
 
+  let official_get_follows =
+    {|{"lexicon":1,"id":"app.bsky.graph.getFollows","defs":{"main":{"type":"query","description":"Enumerates accounts which a specified account (actor) follows.","parameters":{"type":"params","required":["actor"],"properties":{"actor":{"type":"string"},"limit":{"type":"integer"},"cursor":{"type":"string"},"sort":{"type":"string","knownValues":["latest","top"]}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["subject","follows"],"properties":{"subject":{"type":"ref","ref":"app.bsky.actor.defs#profileView"},"cursor":{"type":"string"},"follows":{"type":"array"}}}}}}}|}
+
+  let official_get_followers =
+    {|{"lexicon":1,"id":"app.bsky.graph.getFollowers","defs":{"main":{"type":"query","description":"Enumerates accounts which follow a specified account (actor).","parameters":{"type":"params","required":["actor"],"properties":{"actor":{"type":"string"},"limit":{"type":"integer"},"cursor":{"type":"string"},"sort":{"type":"string","knownValues":["latest","top"]}}},"output":{"encoding":"application/json","schema":{"type":"object","required":["subject","followers"],"properties":{"subject":{"type":"ref","ref":"app.bsky.actor.defs#profileView"},"cursor":{"type":"string"},"followers":{"type":"array"}}}}}}}|}
+
   let official_actor_defs =
     {|{"lexicon":1,"id":"app.bsky.actor.defs","defs":{"viewerState":{"type":"object","properties":{"muted":{"type":"boolean"},"mutedOnlyReposts":{"type":"boolean"},"mutedOnlyQuoteposts":{"type":"boolean"},"blocking":{"type":"string"},"knownFollowers":{"type":"ref","ref":"#knownFollowers"}}},"profileAssociatedGerm":{"type":"object","required":["showButtonTo","messageMeUrl"],"properties":{"showButtonTo":{"type":"string"},"messageMeUrl":{"type":"string"}}},"profileAssociated":{"type":"object","properties":{"germ":{"type":"ref","ref":"#profileAssociatedGerm"}}},"profileViewDetailed":{"type":"object","required":["did","handle"],"properties":{"joinedViaStarterPack":{"type":"ref","ref":"app.bsky.graph.defs#starterPackViewBasic"}}}}}|}
 
@@ -595,6 +601,8 @@ module Lexicon = struct
       ("app.bsky.embed.video", official_embed_video);
       ("com.atproto.lexicon.schema", official_lexicon_schema);
       ("app.bsky.graph.muteActor", official_mute_actor);
+      ("app.bsky.graph.getFollows", official_get_follows);
+      ("app.bsky.graph.getFollowers", official_get_followers);
       ("app.bsky.actor.defs", official_actor_defs);
       ("com.atproto.server.createSession", official_create_session);
       ("com.atproto.server.createAccount", official_create_account);

--- a/test/test_graph.ml
+++ b/test/test_graph.ml
@@ -113,6 +113,64 @@ let test_mute_actor_body _ =
   OUnit2.assert_equal true (scoped |> member "onlyReposts" |> to_bool);
   OUnit2.assert_equal false (scoped |> member "onlyQuoteposts" |> to_bool)
 
+let test_follow_page_sort_and_cursor _ =
+  OUnit2.assert_equal ~printer:(fun x -> x) "latest" Graph.sort_latest;
+  OUnit2.assert_equal ~printer:(fun x -> x) "top" Graph.sort_top;
+  let pairs =
+    Graph.follow_page_pairs ~actor:"alice.test" ~limit:10 ~cursor:"abc"
+      ~sort:Graph.sort_latest ()
+  in
+  OUnit2.assert_equal (Some "alice.test") (List.assoc_opt "actor" pairs);
+  OUnit2.assert_equal (Some "10") (List.assoc_opt "limit" pairs);
+  OUnit2.assert_equal (Some "abc") (List.assoc_opt "cursor" pairs);
+  OUnit2.assert_equal (Some "latest") (List.assoc_opt "sort" pairs);
+  let top_pairs =
+    Graph.follow_page_pairs ~actor:"bob.test" ~sort:Graph.sort_top ()
+  in
+  OUnit2.assert_equal (Some "top") (List.assoc_opt "sort" top_pairs);
+  OUnit2.assert_equal None (List.assoc_opt "cursor" top_pairs);
+  let subject =
+    `Assoc
+      [
+        ("did", `String "did:plc:abc123xyz0001112223333");
+        ("handle", `String "alice.test");
+      ]
+  in
+  let follows =
+    Graph.parse_follows
+      (`Assoc
+        [
+          ("subject", subject);
+          ( "follows",
+            `List
+              [
+                `Assoc
+                  [
+                    ("did", `String "did:plc:xyz789aaa0001112223333");
+                    ("handle", `String "bob.test");
+                  ];
+              ] );
+          ("cursor", `String "next-follows");
+        ])
+  in
+  OUnit2.assert_equal ~printer:(fun x -> x) "alice.test" follows.subject.handle;
+  OUnit2.assert_equal 1 (List.length follows.follows);
+  OUnit2.assert_equal (Some "next-follows") follows.cursor;
+  let followers =
+    Graph.parse_followers
+      (`Assoc
+        [
+          ("subject", subject);
+          ("followers", `List []);
+          ("cursor", `String "next-followers");
+        ])
+  in
+  OUnit2.assert_equal (Some "next-followers") followers.cursor;
+  let no_cursor =
+    Graph.parse_follows (`Assoc [ ("subject", subject); ("follows", `List []) ])
+  in
+  OUnit2.assert_equal None no_cursor.cursor
+
 let test_parse_list _ =
   let json =
     `Assoc
@@ -534,6 +592,7 @@ let suite =
          "test_mute_actor" >:: test_mute_actor;
          "test_unmute_actor" >:: test_unmute_actor;
          "test_mute_actor_body" >:: test_mute_actor_body;
+         "test_follow_page_sort_and_cursor" >:: test_follow_page_sort_and_cursor;
          "test_parse_list" >:: test_parse_list;
          "test_parse_list_opt_out_fields" >:: test_parse_list_opt_out_fields;
          "test_parse_starter_pack" >:: test_parse_starter_pack;

--- a/test/test_lexicon.ml
+++ b/test/test_lexicon.ml
@@ -247,6 +247,8 @@ let test_union_codegen_and_official_bundle _ =
               "app.bsky.embed.video";
               "com.atproto.lexicon.schema";
               "app.bsky.graph.muteActor";
+              "app.bsky.graph.getFollows";
+              "app.bsky.graph.getFollowers";
               "app.bsky.actor.defs";
               "com.atproto.server.createSession";
               "com.atproto.server.createAccount";
@@ -369,11 +371,41 @@ let test_union_codegen_and_official_bundle _ =
           in
           match Lexicon.main mute with
           | None -> OUnit2.assert_failure "missing muteActor main"
-          | Some main ->
+          | Some main -> (
               OUnit2.assert_bool "onlyReposts"
                 (List.exists
                    (fun (name, _) -> name = "onlyReposts")
-                   main.input.properties)))
+                   main.input.properties);
+              let get_follows =
+                List.find
+                  (fun (d : Lexicon.document) ->
+                    d.id = "app.bsky.graph.getFollows")
+                  docs
+              in
+              match Lexicon.main get_follows with
+              | None -> OUnit2.assert_failure "missing getFollows main"
+              | Some follows_main -> (
+                  OUnit2.assert_bool "getFollows sort"
+                    (List.exists
+                       (fun (name, _) -> name = "sort")
+                       follows_main.properties);
+                  OUnit2.assert_bool "getFollows cursor"
+                    (List.exists
+                       (fun (name, _) -> name = "cursor")
+                       follows_main.properties);
+                  let get_followers =
+                    List.find
+                      (fun (d : Lexicon.document) ->
+                        d.id = "app.bsky.graph.getFollowers")
+                      docs
+                  in
+                  match Lexicon.main get_followers with
+                  | None -> OUnit2.assert_failure "missing getFollowers main"
+                  | Some followers_main ->
+                      OUnit2.assert_bool "getFollowers sort"
+                        (List.exists
+                           (fun (name, _) -> name = "sort")
+                           followers_main.properties)))))
 
 let test_parse_resolved_lexicon _ =
   let json =

--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -662,6 +662,30 @@ let test_leftover_appview _ =
           (Graph.mute_actor_body ~actor:"carla.test" ~only_reposts:true
              ~only_quoteposts:false ())));
   (match
+     av_get_if_served "app.bsky.graph.getFollows"
+       (Graph.follow_page_pairs ~actor:"alice.test" ~limit:10
+          ~sort:Graph.sort_latest ())
+   with
+  | None -> ()
+  | Some json ->
+      let page = Graph.parse_follows json in
+      OUnit2.assert_bool "getFollows sort=latest"
+        (List.length page.follows >= 0);
+      OUnit2.assert_bool "getFollows cursor optional"
+        (match page.cursor with Some _ | None -> true));
+  (match
+     av_get_if_served "app.bsky.graph.getFollowers"
+       (Graph.follow_page_pairs ~actor:"alice.test" ~limit:10
+          ~sort:Graph.sort_top ())
+   with
+  | None -> ()
+  | Some json ->
+      let page = Graph.parse_followers json in
+      OUnit2.assert_bool "getFollowers sort=top"
+        (List.length page.followers >= 0);
+      OUnit2.assert_bool "getFollowers cursor optional"
+        (match page.cursor with Some _ | None -> true));
+  (match
      av_get_if_served ~session:s "app.bsky.graph.getListsWithMembership"
        [ ("actor", "alice.test"); ("limit", "5") ]
    with

--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -669,8 +669,7 @@ let test_leftover_appview _ =
   | None -> ()
   | Some json ->
       let page = Graph.parse_follows json in
-      OUnit2.assert_bool "getFollows sort=latest"
-        (List.length page.follows >= 0);
+      OUnit2.assert_bool "getFollows sort=latest" (List.length page.follows >= 0);
       OUnit2.assert_bool "getFollows cursor optional"
         (match page.cursor with Some _ | None -> true));
   (match


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked leftover unique protocol work on #97 (`cursor/leftover-unique-protocol-953a`), not main.

Compared this branch to official `bluesky-social/atproto` lexicons. Method coverage through #97 is already complete for public XRPC. The unique leftover that is still real protocol is official `sort` on `app.bsky.graph.getFollows` / `getFollowers` (knownValues `latest` / `top`, added 2026-07-22) plus the official output `cursor` those parsers dropped.

## Unique leftovers shipped

### Official `sort` knownValues
`Graph.sort_latest` / `Graph.sort_top` (`latest` / `top`). `follow_page_pairs` and `get_follows_page` / `get_followers_page` send the official query param.

### Official output `cursor`
`parse_follows` / `parse_followers` (and therefore `getKnownFollowers`) now keep `cursor`.

### Bundled official lexicons
`app.bsky.graph.getFollows` and `app.bsky.graph.getFollowers` include `sort` and `cursor`.

### Local AppView
`test_leftover_appview` calls getFollows `sort=latest` and getFollowers `sort=top`. Skip-if-not-served for MethodNotImplemented / flag-off / Unknown lexicon type.

## Intentionally not shipped
- Ozone safelink / verification / emitEvent `reportAction` (already #97)
- Local subscribeRepos / sync host XRPCs (already #96)
- APP-2933 views, `app.bsky.auth*`, bookmarks, scoped muteActor (already #95)
- Deprecated `fetchLabels` / `getCheckout` / `getHead`
- Internal `getProfiles`, fake chat, video transcoder
- Draft / contact / ageassurance required local tests
- `com.atproto.sync.notifyOfUpdate` (officially deprecated; use `requestCrawl`)

## Tests
- `dune build`
- `ocamlformat 0.25.1` on edited files
- `dune runtest`
- local AppView leftover sort calls (skips without local stack)

No backwards compatibility for unused APIs. Chat remains skippable live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e973b87f-d961-4ab9-a26b-0d282d3316c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e973b87f-d961-4ab9-a26b-0d282d3316c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

