### PR TITLE
Document 0.1.0 in CHANGELOG after #106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+Notes for the packaged **0.1.0** library. This file records what actually
+shipped through pull request [#106](https://github.com/david-engelmann/atproto/pull/106)
+(merge `79aeb75c`, 2026-09-01).
+
+This package is **not** published to the public
+[opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
+pinning the GitHub repository (see the README).
+
+## 0.1.0 — 2026-09-01
+
+First installable opam package (`dune-project` / `atproto.opam` version
+`0.1.0`, OCaml `>= 4.14.1`). `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`
+exposes `(libraries atproto)`. That pin is not an opam-repository publish.
+
+### Protocol client
+
+- XRPC GET/POST (Cohttp) plus HTTP/2 TLS (`Http_client`) for public HTTPS
+- Session / JWT (`Auth`, `Session`), including `authFactorToken` /
+  `allowTakendown` and typed `getSession`
+- AppView: actor, feed, graph, bookmark, notification, labeler, unspecced,
+  video (client only — no hosted transcoder), drafts, contacts, age
+  assurance
+- Chat / DM client (`chat.bsky.*`) with `atproto-proxy` (no OSS chat
+  backend in `@atproto/dev-env` 0.6.4)
+- Ozone (`tools.ozone.*`) and `com.atproto.admin` clients
+- Repo writes and typed record builders (`Repo`, `Records`)
+- Identity, DID PLC/web/key, CID/CAR/DAG-CBOR, MST, TID, AT URI, firehose
+- Lexicon 1 parse / validate / `to_ocaml`, including bundled official
+  documents
+- OAuth / DPoP (`Oauth`, `Oauth_scope`): PKCE S256, PAR, token, refresh,
+  RFC 7009 revoke, granular scopes, official `app.bsky.auth*` /
+  `chat.bsky.authFullChatClient` permission-sets
+- Jetstream v2 tail + `.jss` v1 decode (no invented archive token)
+- TAP-like local repo sync helpers (`Repo_sync`) — not a hosted Tap
+- `site.standard.*` and `com.germnetwork.declaration` record builders
+
+### Local TestNetwork (#90–#106)
+
+CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
+(`TestNetwork.create()`: PLC + PDS + AppView + Ozone + bsync).
+`ATP_REQUIRE_LOCAL_PDS=1` fails hard on real protocol errors.
+
+- Leftover served XRPC on that stack, including APP-2933
+  `app.bsky.graph.referencelistoptout`
+- Live local OAuth: loopback client-metadata, AS discovery, PAR, browser
+  authorize GET, `~api/sign-in` / `~api/consent` with real cookies, token,
+  DPoP `getSession`, refresh, RFC 7009 revoke
+- AppView service-auth minted from the OAuth DPoP token (`getServiceAuth`)
+- Ozone privileged writes as `admin-mod.test` via OAuth DPoP
+  `getServiceAuth` + `Ozone.emit_event_service` (DPoP cannot be proxied)
+- `com.atproto.server.createAppPassword` POSTs official `{ "name" }`
+  (optional `privileged`). This `@atproto/pds` 0.5.x TestNetwork build
+  still 500s on that valid body; the local suite keeps an isolated assert
+
+### Packaging and quality (#101, #106)
+
+- `public_name atproto`, generated `atproto.opam`, `opam lint`,
+  `dune build -p atproto` / `dune runtest -p atproto`
+- GitHub Actions `pull_request` is a sibling of `push`
+- Node 24 drop-in action majors: `actions/checkout@v5`,
+  `actions/cache@v5`, `actions/setup-node@v5`,
+  `actions/upload-artifact@v6`
+- Unused `open`s are errors (`-w +33 -warn-error +33`) on the library,
+  tests, and `examples/offline.ml`
+- Module-level odoc on public modules
+- `examples/offline.ml` typechecks against the public API under
+  `dune build` / `dune runtest`
+
+### Not in this release
+
+- Public opam-repository publish
+- Hosted public HTTPS client-metadata / production browser login against a
+  remote PDS
+- Hosted Tap service or video transcoder
+- Official OSS chat backend (TestNetwork does not start one)
+- Newly published official lexicons after bluesky-social/atproto
+  `60c4395` (APP-2933) — none on official `main` as of this date

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ In a dependent `dune` stanza:
 
 `opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. That does not publish the package to opam-repository.
 
+Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106)) are in [CHANGELOG.md](CHANGELOG.md).
+
 ## Environment
 
 Create a `.env` (see `sample.env`) with at least:
@@ -174,7 +176,7 @@ These are product-level, not missing protocol cores:
 
 #70–#90 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, leftover official field parsers, and the official `@atproto/dev-env` local network in CI.
 
-This stack fills leftover *library* holes after #90–#105: live local OAuth through token (loopback client-metadata + AS discovery + PAR/DPoP + authorize GET + `~api/sign-in`/`consent` with real cookies + token / DPoP `getSession` / DPoP `getServiceAuth` / AppView `getTimeline` / Ozone `emitEvent` via service-auth / refresh / RFC 7009 revoke), official `app.bsky.graph.referencelistoptout`, OAuth PAR `prompt=create` / RFC 7638 `dpop_jkt`, typed official permission-set lexicons (`include:app.bsky.auth*`), `Client.post_json_h2`, DAG-CBOR IPLD JSON (`$link`/`$bytes`), offline `Repo_sync.write_signed_repo`, and more local PDS/AppView/Ozone XRPC the stack actually serves. Chat still has no OSS server in TestNetwork; skippable live `chat.bsky.*` tests keep `atproto-proxy`.
+This stack fills leftover *library* holes after #90–#106: live local OAuth through token (loopback client-metadata + AS discovery + PAR/DPoP + authorize GET + `~api/sign-in`/`consent` with real cookies + token / DPoP `getSession` / DPoP `getServiceAuth` / AppView `getTimeline` / Ozone `emitEvent` via service-auth / refresh / RFC 7009 revoke), official `app.bsky.graph.referencelistoptout`, OAuth PAR `prompt=create` / RFC 7638 `dpop_jkt`, typed official permission-set lexicons (`include:app.bsky.auth*`), `Client.post_json_h2`, DAG-CBOR IPLD JSON (`$link`/`$bytes`), offline `Repo_sync.write_signed_repo`, unused opens as errors, public module odoc, and more local PDS/AppView/Ozone XRPC the stack actually serves. Chat still has no OSS server in TestNetwork; skippable live `chat.bsky.*` tests keep `atproto-proxy`.
 
 Production admin/ozone operator sessions are not invented here. Local TestNetwork `admin-mod.test` completes OAuth DPoP and writes through `getServiceAuth` (DPoP + `atproto-proxy` is rejected).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Version notes for the installable **0.1.0** package after #106 merged to `main` as `79aeb75c`.

Investigated current `main` in the requested order. The other holes are already closed:

1. **GitHub Actions Node 20** — already on Node 24 drop-in majors (`actions/checkout@v5`, `actions/cache@v5`, `actions/setup-node@v5`, `actions/upload-artifact@v6`). Later majors (`checkout@v7`, `upload-artifact@v7`) are not drop-ins. `pull_request` stays a sibling of `push`. Left alone.
2. **CHANGELOG / version notes** — this PR. Matches `0.1.0` and what actually shipped through #106. Does **not** claim opam-repository publish.
3. **odoc / examples / README remaining-gaps** — module-level odoc and `examples/offline.ml` landed in #106. Remaining-gaps still said #90–#105 after that merge; it now names #90–#106 (unused opens as errors, public module odoc) and the Install section points at `CHANGELOG.md`.
4. **createAppPassword** — library POST is still official `{ name, privileged? }`. The isolated `@atproto/pds` 0.5.x 500 assert stays.
5. **Official lexicons since `60c4395`** — none on bluesky-social/atproto `main` after APP-2933.

Does not bump `@atproto/dev-env` (still 0.6.4). Does not fake chat or a video transcoder.

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13d4b7f5-2893-4cd6-aded-69bcbc18202f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13d4b7f5-2893-4cd6-aded-69bcbc18202f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

