### PR TITLE
Lexicon coverage gate, OCaml < 5.0, and odoc CI artifact

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -88,6 +88,20 @@ jobs:
       - name: Lint doc
         uses: ocaml/setup-ocaml/lint-doc@v3
 
+      - name: Install doc dependencies
+        run: opam install . --deps-only --with-doc
+
+      - name: Build odoc HTML
+        run: opam exec -- dune build @doc
+
+      - name: Upload odoc HTML
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: odoc-html
+          path: _build/default/_doc/_html
+          if-no-files-found: warn
+
   lint-fmt:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Notes for the packaged **0.1.0** library. This file records what actually
 shipped through pull request [#106](https://github.com/david-engelmann/atproto/pull/106)
-(merge `79aeb75c`, 2026-09-01).
+(merge `79aeb75c`, 2026-09-01), changelog
+[#107](https://github.com/david-engelmann/atproto/pull/107) (merge `3a7bd82f`,
+2026-09-02), and the lexicon-coverage / compiler-bound / odoc-artifact work
+on this branch.
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
@@ -11,7 +14,7 @@ pinning the GitHub repository (see the README).
 ## 0.1.0 — 2026-09-01
 
 First installable opam package (`dune-project` / `atproto.opam` version
-`0.1.0`, OCaml `>= 4.14.1`). `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`
+`0.1.0`, OCaml `>= 4.14.1` and `< 5.0`). `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`
 exposes `(libraries atproto)`. That pin is not an opam-repository publish.
 
 ### Protocol client
@@ -54,7 +57,7 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   (optional `privileged`). This `@atproto/pds` 0.5.x TestNetwork build
   still 500s on that valid body; the local suite keeps an isolated assert
 
-### Packaging and quality (#101, #106)
+### Packaging and quality (#101, #106, #107)
 
 - `public_name atproto`, generated `atproto.opam`, `opam lint`,
   `dune build -p atproto` / `dune runtest -p atproto`
@@ -64,9 +67,15 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `actions/upload-artifact@v6`
 - Unused `open`s are errors (`-w +33 -warn-error +33`) on the library,
   tests, and `examples/offline.ml`
-- Module-level odoc on public modules
+- Module-level odoc on public modules; TestSuite `lint-doc` runs
+  `dune build @doc` and uploads HTML as the `odoc-html` artifact (no
+  GitHub Pages site)
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
+- Official lexicon pin bluesky-social/atproto `60c4395951` (APP-2933) as
+  `lexicons/official-nsids.json`, plus TestSuite `test_lexicon_coverage`
+  (client helper / record builder / bundled permission-set / explicit skip)
+- OCaml constraint `(and (>= 4.14.1) (< 5.0))` — CI tests 4.14.1 only
 
 ### Not in this release
 
@@ -76,4 +85,5 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
 - Hosted Tap service or video transcoder
 - Official OSS chat backend (TestNetwork does not start one)
 - Newly published official lexicons after bluesky-social/atproto
-  `60c4395` (APP-2933) — none on official `main` as of this date
+  `60c4395951` (APP-2933) — the coverage gate fails until the pin
+  snapshot and bindings (or an explicit skip) are updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Notes for the packaged **0.1.0** library. This file records what actually
 shipped through pull request [#106](https://github.com/david-engelmann/atproto/pull/106)
 (merge `79aeb75c`, 2026-09-01), changelog
 [#107](https://github.com/david-engelmann/atproto/pull/107) (merge `3a7bd82f`,
-2026-09-02), and the lexicon-coverage / compiler-bound / odoc-artifact work
-on this branch.
+2026-09-02), and
+[#108](https://github.com/david-engelmann/atproto/pull/108)
+(lexicon pin `60c4395951`, coverage gate, OCaml `< 5.0`, odoc artifact).
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
@@ -57,7 +58,7 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   (optional `privileged`). This `@atproto/pds` 0.5.x TestNetwork build
   still 500s on that valid body; the local suite keeps an isolated assert
 
-### Packaging and quality (#101, #106, #107)
+### Packaging and quality (#101, #106, #107, #108)
 
 - `public_name atproto`, generated `atproto.opam`, `opam lint`,
   `dune build -p atproto` / `dune runtest -p atproto`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OCaml toolkit for the [AT Protocol](https://atproto.com) (XRPC, lexicons, repo s
 
 ## Install
 
-This library is **not** published to the public [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by pinning this GitHub repo (OCaml **4.14.1**, package version **0.1.0**):
+This library is **not** published to the public [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by pinning this GitHub repo (OCaml **>= 4.14.1 and < 5.0**, package version **0.1.0**). CI tests **4.14.1** only; Jane Street `core` / `async` / `ppx_jane` without a version pin are not treated as OCaml 5-ready:
 
 ```shell
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
@@ -27,7 +27,7 @@ In a dependent `dune` stanza:
 
 `opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. That does not publish the package to opam-repository.
 
-Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106)) are in [CHANGELOG.md](CHANGELOG.md).
+Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106), changelog [#107](https://github.com/david-engelmann/atproto/pull/107), and the lexicon-coverage / odoc-artifact work in this tree) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
 
 ## Environment
 
@@ -168,6 +168,7 @@ Pinned `@atproto/dev-env@0.6.4` `TestNetwork.create()` does **not** start a `cha
 
 These are product-level, not missing protocol cores:
 
+- Official lexicons are pinned at bluesky-social/atproto [`60c4395951`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf) (APP-2933). `lexicons/official-nsids.json` is the compact NSID snapshot (`query` / `procedure` / `subscription` / `record` / `permission-set`); `scripts/gen-official-nsids.py` rebuilds it against a SHA. TestSuite `test_lexicon_coverage` fails if that pin grows and a public client NSID is missing a helper, record builder, bundled permission-set, or an explicit one-line skip. Hosted-only *servers* (no OSS chat backend, no video transcoder, no Tap host) are not skip reasons.
 - Hosting a **public HTTPS client-metadata document** and completing a **production browser login** against a remote PDS. Local TestNetwork serves a loopback metadata document and runs discovery + PAR + DPoP + authorize GET + `~api/sign-in` / `~api/consent` (real `csrf-token` / `dev-id` / `ses-id` cookies) through token exchange, DPoP `getSession`, DPoP `getServiceAuth`, authed AppView `getTimeline` / `listNotifications` (service-auth JWT, not the DPoP token), Ozone privileged `emitEvent` as `admin-mod.test` (`getServiceAuth` + `Ozone.emit_event_service` on `:2587`; DPoP + `atproto-proxy` is rejected), refresh, and RFC 7009 revoke in CI (`test/test_local_oauth.ml`). The local authorize GET is still an HTML SPA (no `code` on the first navigation); the code is minted by the sign-in/consent APIs, not by faking a browser document.
 - A hosted Tap service or hosted video transcoder (client request/response types, video byte-upload + job poll, TAP-like repo sync helpers, and proxy headers are implemented). Local TestNetwork Ozone privileged writes use OAuth DPoP `getServiceAuth` + `Ozone.emit_event_service` as `admin-mod.test` (not a production operator session). A **local PDS + PLC** stack is included for `com.atproto.*` integration tests; it is not a public host.
 - Jetstream Network Replay / HTTP snapshot **download** against Bluesky's gated archive (planner, `listSegments` types, cutover cursor, Range resume, skippable unauthenticated HTTP, and `.jss` v1 decode are implemented; a live archive download still needs an operator token this library does not invent, and zstd frames need an injected decompressor)
@@ -176,15 +177,15 @@ These are product-level, not missing protocol cores:
 
 #70–#90 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, leftover official field parsers, and the official `@atproto/dev-env` local network in CI.
 
-This stack fills leftover *library* holes after #90–#106: live local OAuth through token (loopback client-metadata + AS discovery + PAR/DPoP + authorize GET + `~api/sign-in`/`consent` with real cookies + token / DPoP `getSession` / DPoP `getServiceAuth` / AppView `getTimeline` / Ozone `emitEvent` via service-auth / refresh / RFC 7009 revoke), official `app.bsky.graph.referencelistoptout`, OAuth PAR `prompt=create` / RFC 7638 `dpop_jkt`, typed official permission-set lexicons (`include:app.bsky.auth*`), `Client.post_json_h2`, DAG-CBOR IPLD JSON (`$link`/`$bytes`), offline `Repo_sync.write_signed_repo`, unused opens as errors, public module odoc, and more local PDS/AppView/Ozone XRPC the stack actually serves. Chat still has no OSS server in TestNetwork; skippable live `chat.bsky.*` tests keep `atproto-proxy`.
+This stack fills leftover *library* holes after #90–#107: live local OAuth through token (loopback client-metadata + AS discovery + PAR/DPoP + authorize GET + `~api/sign-in`/`consent` with real cookies + token / DPoP `getSession` / DPoP `getServiceAuth` / AppView `getTimeline` / Ozone `emitEvent` via service-auth / refresh / RFC 7009 revoke), official `app.bsky.graph.referencelistoptout`, OAuth PAR `prompt=create` / RFC 7638 `dpop_jkt`, typed official permission-set lexicons (`include:app.bsky.auth*`), `Client.post_json_h2`, DAG-CBOR IPLD JSON (`$link`/`$bytes`), offline `Repo_sync.write_signed_repo`, unused opens as errors, public module odoc (HTML as a CI artifact, not GitHub Pages), official lexicon pin `60c4395` with a coverage gate, OCaml `< 5.0`, and more local PDS/AppView/Ozone XRPC the stack actually serves. Chat still has no OSS server in TestNetwork; skippable live `chat.bsky.*` tests keep `atproto-proxy`. This package is **not** on opam-repository.
 
 Production admin/ozone operator sessions are not invented here. Local TestNetwork `admin-mod.test` completes OAuth DPoP and writes through `getServiceAuth` (DPoP + `atproto-proxy` is rejected).
 
 Still leftover vs current lexicons (not invented here):
 
-- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`)
-- Deprecated `com.atproto.sync.getCheckout` / `getHead` (use `getRepo` / `getLatestCommit`)
-- `internal.bsky.actor.getProfiles` (service-to-service AppView query, not a public client surface)
+- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`; coverage skip)
+- Deprecated `com.atproto.sync.getCheckout` / `getHead` / `notifyOfUpdate` (use `getRepo` / `getLatestCommit` / `requestCrawl`; coverage skips)
+- `internal.bsky.actor.getProfiles` (service-to-service AppView query, not a public client surface; coverage skip)
 - Internal `debug` fields and deprecated `entities` / `isFallback`
 - Privileged Ozone operator view fields (clients exist; production operator session not invented; local admin-mod OAuth DPoP `getServiceAuth` is)
 - `com.atproto.server.createAppPassword` 500 on this `@atproto/pds` 0.5.x TestNetwork build (library request matches the official lexicon; the local suite asserts the isolated 500)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In a dependent `dune` stanza:
 
 `opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. That does not publish the package to opam-repository.
 
-Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106), changelog [#107](https://github.com/david-engelmann/atproto/pull/107), and the lexicon-coverage / odoc-artifact work in this tree) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
+Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106), changelog [#107](https://github.com/david-engelmann/atproto/pull/107), and [#108](https://github.com/david-engelmann/atproto/pull/108)) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
 
 ## Environment
 

--- a/atproto.opam
+++ b/atproto.opam
@@ -9,7 +9,7 @@ Public modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video, Unspe
 
 Video support is a client for the hosted video service (byte upload + job-status poll). This package does not host a PDS, OAuth client-metadata document, browser login, or video transcoder.
 
-This package is not published to the public opam-repository; pin the GitHub repository (see the README). Requires OCaml 4.14.1."""
+This package is not published to the public opam-repository; pin the GitHub repository (see the README). Requires OCaml >= 4.14.1 and < 5.0."""
 maintainer: ["david-engelmann <david.engelmann44@gmail.com>"]
 authors: ["david-engelmann <david.engelmann44@gmail.com>"]
 license: "MIT"
@@ -19,7 +19,7 @@ doc: "https://github.com/david-engelmann/atproto"
 bug-reports: "https://github.com/david-engelmann/atproto/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.14.1"}
+  "ocaml" {>= "4.14.1" & < "5.0"}
   "core"
   "async"
   "uri" {>= "4.2.0"}

--- a/dune-project
+++ b/dune-project
@@ -14,12 +14,12 @@
  (name atproto)
  (synopsis "OCaml toolkit for the AT Protocol")
  (description
-  "OCaml client and protocol library for the AT Protocol (XRPC, lexicons, repo sync, identity, AppView, Ozone, chat, site.standard, and com.germnetwork records). An HTTP/2 TLS client is included for XRPC calls that need status and response headers.\n\nPublic modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video, Unspecced, Labeler, Chat, Ozone, Admin, Repo, Repo_sync, Server, Identity, Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri, Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc, Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact, Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and Response. Chat convo/actor clients always send atproto-proxy (default did:web:api.bsky.chat#bsky_chat, the session DID-document #bsky_chat service, or ATP_CHAT_DID).\n\nVideo support is a client for the hosted video service (byte upload + job-status poll). This package does not host a PDS, OAuth client-metadata document, browser login, or video transcoder.\n\nThis package is not published to the public opam-repository; pin the GitHub repository (see the README). Requires OCaml 4.14.1.")
+  "OCaml client and protocol library for the AT Protocol (XRPC, lexicons, repo sync, identity, AppView, Ozone, chat, site.standard, and com.germnetwork records). An HTTP/2 TLS client is included for XRPC calls that need status and response headers.\n\nPublic modules include Auth, Session, Actor, Feed, Graph, Bookmark, Video, Unspecced, Labeler, Chat, Ozone, Admin, Repo, Repo_sync, Server, Identity, Did_plc, Did_web, Did_key, Sync, Cid, Car, Dag_cbor, Mst, Tid, At_uri, Lexicon, Temp, Firehose, Websocket, Jetstream, Oauth, Oauth_scope, Label, Xrpc, Error, Syntax, Embed, Facet, Records, Notification, Draft, Contact, Ageassurance, Moderation, Site, Germnetwork, Http_client, Request, and Response. Chat convo/actor clients always send atproto-proxy (default did:web:api.bsky.chat#bsky_chat, the session DID-document #bsky_chat service, or ATP_CHAT_DID).\n\nVideo support is a client for the hosted video service (byte upload + job-status poll). This package does not host a PDS, OAuth client-metadata document, browser login, or video transcoder.\n\nThis package is not published to the public opam-repository; pin the GitHub repository (see the README). Requires OCaml >= 4.14.1 and < 5.0.")
  (tags
   (atproto bluesky xrpc lexicon))
  (depends
   (ocaml
-   (>= 4.14.1))
+   (and (>= 4.14.1) (< 5.0)))
   core
   async
   (uri

--- a/lexicons/coverage-skips.json
+++ b/lexicons/coverage-skips.json
@@ -1,0 +1,24 @@
+{
+  "skips": [
+    {
+      "id": "com.atproto.sync.getCheckout",
+      "reason": "Deprecated leftover; Sync.get_checkout wraps getRepo and does not send getCheckout."
+    },
+    {
+      "id": "com.atproto.sync.getHead",
+      "reason": "Deprecated leftover; Sync.get_head wraps getLatestCommit and does not send getHead."
+    },
+    {
+      "id": "com.atproto.sync.notifyOfUpdate",
+      "reason": "Deprecated leftover; Sync.notify_of_update fails and points callers at requestCrawl."
+    },
+    {
+      "id": "com.atproto.temp.fetchLabels",
+      "reason": "Deprecated leftover; use Label.query_labels / subscribeLabels."
+    },
+    {
+      "id": "internal.bsky.actor.getProfiles",
+      "reason": "Service-to-service AppView query, not a public client surface."
+    }
+  ]
+}

--- a/lexicons/official-nsids.json
+++ b/lexicons/official-nsids.json
@@ -1,0 +1,1458 @@
+{
+  "source": "https://github.com/bluesky-social/atproto",
+  "sha": "60c439595101fbcbe612463e6f23200590c5daaf",
+  "main_types": [
+    "query",
+    "procedure",
+    "subscription",
+    "record",
+    "permission-set"
+  ],
+  "lexicon_json_count": 403,
+  "nsid_count": 359,
+  "counts": {
+    "query": 177,
+    "procedure": 142,
+    "subscription": 3,
+    "record": 27,
+    "permission-set": 10
+  },
+  "nsids": [
+    {
+      "id": "app.bsky.actor.contentVisibilityDeclaration",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.actor.getPreferences",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.getProfile",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.getProfiles",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.getSuggestions",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.profile",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.actor.putPreferences",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.actor.searchActors",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.searchActorsTypeahead",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.actor.status",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.ageassurance.begin",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.ageassurance.getConfig",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.ageassurance.getState",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.authCreatePosts",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authDeleteContent",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authFullApp",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authManageFeedDeclarations",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authManageLabelerService",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authManageModeration",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authManageNotifications",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authManageProfile",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.authViewAll",
+      "type": "permission-set"
+    },
+    {
+      "id": "app.bsky.bookmark.createBookmark",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.bookmark.deleteBookmark",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.bookmark.getBookmarks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.contact.dismissMatch",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.contact.getMatches",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.contact.getSyncStatus",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.contact.importContacts",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.contact.removeData",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.contact.sendNotification",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.contact.startPhoneVerification",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.contact.verifyPhone",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.draft.createDraft",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.draft.deleteDraft",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.draft.getDrafts",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.draft.updateDraft",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.embed.getEmbedExternalView",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.describeFeedGenerator",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.generator",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.feed.getActorFeeds",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getActorLikes",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getAuthorFeed",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getFeed",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getFeedGenerator",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getFeedGenerators",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getFeedSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getLikes",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getListFeed",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getPostThread",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getPosts",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getQuotes",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getRepostedBy",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getSuggestedFeeds",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.getTimeline",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.like",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.feed.post",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.feed.postgate",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.feed.repost",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.feed.searchPosts",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.searchPostsV2",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.feed.sendInteractions",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.feed.threadgate",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.block",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.follow",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.getActorStarterPacks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getBlocks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getFollowers",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getFollows",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getKnownFollowers",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getList",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getListBlocks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getListMutes",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getLists",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getListsWithMembership",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getMutes",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getRelationships",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getStarterPack",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getStarterPacks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getStarterPacksWithMembership",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.getSuggestedFollowsByActor",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.list",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.listblock",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.listitem",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.muteActor",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.muteActorList",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.muteThread",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.referencelistoptout",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.searchStarterPacks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.searchStarterPacksV2",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.graph.starterpack",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.graph.unmuteActor",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.unmuteActorList",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.unmuteThread",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.graph.verification",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.labeler.getServices",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.labeler.service",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.notification.declaration",
+      "type": "record"
+    },
+    {
+      "id": "app.bsky.notification.getPreferences",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.notification.getUnreadCount",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.notification.listActivitySubscriptions",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.notification.listNotifications",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.notification.putActivitySubscription",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.notification.putPreferences",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.notification.putPreferencesV2",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.notification.registerPush",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.notification.unregisterPush",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.notification.updateSeen",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.unspecced.getAgeAssuranceState",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getConfig",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getOnboardingSuggestedStarterPacks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getOnboardingSuggestedStarterPacksSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getOnboardingSuggestedUsersSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getPopularFeedGenerators",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getPostThreadOtherV2",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getPostThreadV2",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedFeeds",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedFeedsSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedOnboardingUsers",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedStarterPacks",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedStarterPacksSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsers",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForDiscover",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForDiscoverSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForExplore",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForExploreSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForSeeMore",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersForSeeMoreSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestedUsersSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getSuggestionsSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getTaggedSuggestions",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getTrendingTopics",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getTrends",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.getTrendsSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.initAgeAssurance",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.unspecced.searchActorsSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.searchPostsSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.unspecced.searchStarterPacksSkeleton",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.video.abortUpload",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.video.finishUpload",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.video.getJobStatus",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.video.getUploadLimits",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.video.getUploadStatus",
+      "type": "query"
+    },
+    {
+      "id": "app.bsky.video.startUpload",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.video.uploadPart",
+      "type": "procedure"
+    },
+    {
+      "id": "app.bsky.video.uploadVideo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.actor.declaration",
+      "type": "record"
+    },
+    {
+      "id": "chat.bsky.actor.deleteAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.actor.exportAccountData",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.actor.getStatus",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.authFullChatClient",
+      "type": "permission-set"
+    },
+    {
+      "id": "chat.bsky.convo.acceptConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.addReaction",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.deleteMessageForSelf",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.getConvo",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getConvoAvailability",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getConvoForMembers",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getConvoMembers",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getLog",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getMessages",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.getUnreadCounts",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.leaveConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.listConvoRequests",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.listConvos",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.convo.lockConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.muteConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.removeReaction",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.sendMessage",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.sendMessageBatch",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.unlockConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.unmuteConvo",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.updateAllRead",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.convo.updateRead",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.addMembers",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.approveJoinRequest",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.createGroup",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.createJoinLink",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.disableJoinLink",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.editGroup",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.editJoinLink",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.enableJoinLink",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.getJoinLinkPreviews",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.group.listJoinRequests",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.group.listMutualGroups",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.group.rejectJoinRequest",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.removeMembers",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.requestJoin",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.updateJoinRequestsRead",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.group.withdrawJoinRequest",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.moderation.getActorMetadata",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.moderation.getConvo",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.moderation.getConvoMembers",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.moderation.getConvos",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.moderation.getMessageContext",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.moderation.subscribeModEvents",
+      "type": "subscription"
+    },
+    {
+      "id": "chat.bsky.moderation.updateActorAccess",
+      "type": "procedure"
+    },
+    {
+      "id": "chat.bsky.notification.getPreferences",
+      "type": "query"
+    },
+    {
+      "id": "chat.bsky.notification.putPreferences",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.deleteAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.disableAccountInvites",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.disableInviteCodes",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.enableAccountInvites",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.getAccountInfo",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.admin.getAccountInfos",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.admin.getInviteCodes",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.admin.getSubjectStatus",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.admin.searchAccounts",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.admin.sendEmail",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.updateAccountEmail",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.updateAccountHandle",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.updateAccountPassword",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.updateAccountSigningKey",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.admin.updateSubjectStatus",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.identity.getRecommendedDidCredentials",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.identity.refreshIdentity",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.identity.requestPlcOperationSignature",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.identity.resolveDid",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.identity.resolveHandle",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.identity.resolveIdentity",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.identity.signPlcOperation",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.identity.submitPlcOperation",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.identity.updateHandle",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.label.queryLabels",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.label.subscribeLabels",
+      "type": "subscription"
+    },
+    {
+      "id": "com.atproto.lexicon.resolveLexicon",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.lexicon.schema",
+      "type": "record"
+    },
+    {
+      "id": "com.atproto.moderation.createReport",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.applyWrites",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.createRecord",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.deleteRecord",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.describeRepo",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.repo.getRecord",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.repo.importRepo",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.listMissingBlobs",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.repo.listRecords",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.repo.putRecord",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.repo.uploadBlob",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.activateAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.checkAccountStatus",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.confirmEmail",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.createAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.createAppPassword",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.createInviteCode",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.createInviteCodes",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.createSession",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.deactivateAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.deleteAccount",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.deleteSession",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.describeServer",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.getAccountInviteCodes",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.getServiceAuth",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.getSession",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.listAppPasswords",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.server.refreshSession",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.requestAccountDelete",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.requestEmailConfirmation",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.requestEmailUpdate",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.requestPasswordReset",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.reserveSigningKey",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.resetPassword",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.revokeAppPassword",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.server.updateEmail",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.sync.getBlob",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getBlocks",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getCheckout",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getHead",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getHostStatus",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getLatestCommit",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getRecord",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getRepo",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.getRepoStatus",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.listBlobs",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.listHosts",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.listRepos",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.listReposByCollection",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.sync.notifyOfUpdate",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.sync.requestCrawl",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.sync.subscribeRepos",
+      "type": "subscription"
+    },
+    {
+      "id": "com.atproto.temp.addReservedHandle",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.temp.checkHandleAvailability",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.temp.checkSignupQueue",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.temp.dereferenceScope",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.temp.fetchLabels",
+      "type": "query"
+    },
+    {
+      "id": "com.atproto.temp.requestPhoneVerification",
+      "type": "procedure"
+    },
+    {
+      "id": "com.atproto.temp.revokeAccountCredentials",
+      "type": "procedure"
+    },
+    {
+      "id": "com.germnetwork.declaration",
+      "type": "record"
+    },
+    {
+      "id": "internal.bsky.actor.getProfiles",
+      "type": "query"
+    },
+    {
+      "id": "site.standard.document",
+      "type": "record"
+    },
+    {
+      "id": "site.standard.graph.recommend",
+      "type": "record"
+    },
+    {
+      "id": "site.standard.graph.subscription",
+      "type": "record"
+    },
+    {
+      "id": "site.standard.publication",
+      "type": "record"
+    },
+    {
+      "id": "site.standard.theme.basic",
+      "type": "record"
+    },
+    {
+      "id": "tools.ozone.communication.createTemplate",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.communication.deleteTemplate",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.communication.listTemplates",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.communication.updateTemplate",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.hosting.getAccountHistory",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.cancelScheduledActions",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.moderation.emitEvent",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.moderation.getAccountTimeline",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getEvent",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getRecord",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getRecords",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getRepo",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getReporterStats",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getRepos",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.getSubjects",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.listScheduledActions",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.moderation.queryEvents",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.queryStatuses",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.moderation.scheduleAction",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.moderation.searchRepos",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.queue.assignModerator",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.queue.createQueue",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.queue.deleteQueue",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.queue.getAssignments",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.queue.listQueues",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.queue.routeReports",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.queue.unassignModerator",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.queue.updateQueue",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.assignModerator",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.closeReports",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.createActivity",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.getAssignments",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.getHistoricalStats",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.getLatestReport",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.getLiveStats",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.getReport",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.listActivities",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.queryActivities",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.queryReports",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.report.reassignQueue",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.refreshStats",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.report.unassignModerator",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.safelink.addRule",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.safelink.queryEvents",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.safelink.queryRules",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.safelink.removeRule",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.safelink.updateRule",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.server.getConfig",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.set.addValues",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.set.deleteSet",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.set.deleteValues",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.set.getValues",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.set.querySets",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.set.upsertSet",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.setting.listOptions",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.setting.removeOptions",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.setting.upsertOption",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.signature.findCorrelation",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.signature.findRelatedAccounts",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.signature.searchAccounts",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.team.addMember",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.team.deleteMember",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.team.listMembers",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.team.updateMember",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.verification.grantVerifications",
+      "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.verification.listVerifications",
+      "type": "query"
+    },
+    {
+      "id": "tools.ozone.verification.revokeVerifications",
+      "type": "procedure"
+    }
+  ]
+}

--- a/scripts/gen-official-nsids.py
+++ b/scripts/gen-official-nsids.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate lexicons/official-nsids.json from bluesky-social/atproto.
+
+Re-run against a SHA (default: the APP-2933 pin) after official lexicon JSON
+changes. This writes a compact NSID + main-def-type snapshot, not the 403
+lexicon JSON bodies.
+
+Usage:
+  scripts/gen-official-nsids.py
+  scripts/gen-official-nsids.py 60c4395951
+  scripts/gen-official-nsids.py 60c4395951 /path/to/atproto/lexicons
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+DEFAULT_SHA = "60c439595101fbcbe612463e6f23200590c5daaf"
+MAIN_TYPES = ("query", "procedure", "subscription", "record", "permission-set")
+TARBALL_URL = "https://codeload.github.com/bluesky-social/atproto/tar.gz/{sha}"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def load_lexicon_dir(lexicon_dir: Path) -> tuple[list[dict], int]:
+    files = sorted(lexicon_dir.rglob("*.json"))
+    entries: list[dict] = []
+    for path in files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        nsid = data.get("id")
+        main = (data.get("defs") or {}).get("main")
+        if not isinstance(nsid, str) or not isinstance(main, dict):
+            continue
+        kind = main.get("type")
+        if kind in MAIN_TYPES:
+            entries.append({"id": nsid, "type": kind})
+    entries.sort(key=lambda e: (e["id"], e["type"]))
+    return entries, len(files)
+
+
+def fetch_lexicon_dir(sha: str, dest: Path) -> Path:
+    url = TARBALL_URL.format(sha=sha)
+    tarball = dest / "atproto.tar.gz"
+    with urllib.request.urlopen(url) as resp, tarball.open("wb") as out:
+        out.write(resp.read())
+    with tarfile.open(tarball, "r:gz") as tar:
+        tar.extractall(dest)
+    matches = list(dest.glob("*/lexicons"))
+    if not matches:
+        raise SystemExit(f"no lexicons/ directory in tarball for {sha}")
+    return matches[0]
+
+
+def write_manifest(sha: str, lexicon_dir: Path, out: Path) -> None:
+    entries, json_count = load_lexicon_dir(lexicon_dir)
+    counts: dict[str, int] = {t: 0 for t in MAIN_TYPES}
+    for e in entries:
+        counts[e["type"]] += 1
+    manifest = {
+        "source": "https://github.com/bluesky-social/atproto",
+        "sha": sha,
+        "main_types": list(MAIN_TYPES),
+        "lexicon_json_count": json_count,
+        "nsid_count": len(entries),
+        "counts": counts,
+        "nsids": entries,
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"wrote {out} ({len(entries)} NSIDs from {json_count} lexicon JSON files at {sha})"
+    )
+
+
+def main(argv: list[str]) -> int:
+    sha = argv[1] if len(argv) > 1 else DEFAULT_SHA
+    out = repo_root() / "lexicons" / "official-nsids.json"
+    if len(argv) > 2:
+        lexicon_dir = Path(argv[2]).resolve()
+        if lexicon_dir.name != "lexicons":
+            candidate = lexicon_dir / "lexicons"
+            if candidate.is_dir():
+                lexicon_dir = candidate
+        if not lexicon_dir.is_dir():
+            raise SystemExit(f"lexicon tree not found: {argv[2]}")
+        write_manifest(sha, lexicon_dir, out)
+        return 0
+    with tempfile.TemporaryDirectory(prefix="atproto-lexicons-") as tmp:
+        lexicon_dir = fetch_lexicon_dir(sha, Path(tmp))
+        write_manifest(sha, lexicon_dir, out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test/dune
+++ b/test/dune
@@ -154,3 +154,15 @@
   test_download_image
   test_video
   test_xrpc))
+
+(tests
+ (package atproto)
+ (flags
+  (:standard -w +33 -warn-error +33))
+ (names test_lexicon_coverage)
+ (modules test_lexicon_coverage)
+ (deps
+  ../lexicons/official-nsids.json
+  ../lexicons/coverage-skips.json
+  (source_tree ../src))
+ (libraries unix yojson ounit2 atproto))

--- a/test/test_lexicon_coverage.ml
+++ b/test/test_lexicon_coverage.ml
@@ -1,0 +1,304 @@
+open OUnit2
+
+(* Drift gate for official lexicon NSIDs pinned at bluesky-social/atproto
+   60c4395951 (APP-2933). Re-run scripts/gen-official-nsids.py against a newer
+   SHA to refresh lexicons/official-nsids.json; this test then fails until each
+   new NSID has a client helper, record builder, bundled permission-set, or an
+   explicit skip with a one-line reason. Hosted-only *servers* are not a reason
+   to skip a public client NSID. *)
+
+let expected_pin = "60c439595101fbcbe612463e6f23200590c5daaf"
+
+let covered_types =
+  [ "query"; "procedure"; "subscription"; "record"; "permission-set" ]
+
+let endpoint_prefixes =
+  [
+    ("create_server_endpoint", "com.atproto.server");
+    ("create_sync_endpoint", "com.atproto.sync");
+    ("create_repo_endpoint", "com.atproto.repo");
+    ("create_notification_endpoint", "app.bsky.notification");
+    ("create_graph_endpoint", "app.bsky.graph");
+    ("create_feed_endpoint", "app.bsky.feed");
+    ("create_actor_endpoint", "app.bsky.actor");
+    ("create_moderation_endpoint", "com.atproto.moderation");
+    ("create_label_endpoint", "com.atproto.label");
+    ("create_identity_endpoint", "com.atproto.identity");
+  ]
+
+(* Public client surfaces that must stay bound even when the matching host
+   is not OSS (chat backend, video transcoder). *)
+let never_skip_prefixes = [ "chat.bsky."; "app.bsky.video." ]
+
+let rec parents_of dir =
+  let parent = Filename.dirname dir in
+  if parent = dir then [ dir ] else dir :: parents_of parent
+
+let search_roots () =
+  let cwd = Sys.getcwd () in
+  [
+    cwd;
+    Filename.concat cwd "..";
+    Filename.concat cwd "../..";
+    Filename.concat cwd "../../..";
+  ]
+  @ parents_of cwd
+
+let find_file rel =
+  let rec go = function
+    | [] ->
+        failwith
+          ("lexicon coverage: cannot find " ^ rel ^ " (cwd=" ^ Sys.getcwd ()
+         ^ ")")
+    | root :: rest ->
+        let path = Filename.concat root rel in
+        if Sys.file_exists path && not (Sys.is_directory path) then path
+        else go rest
+  in
+  go (search_roots ())
+
+let find_src () =
+  let rec go = function
+    | [] ->
+        failwith
+          ("lexicon coverage: cannot find src/lexicon.ml (cwd=" ^ Sys.getcwd ()
+         ^ ")")
+    | root :: rest ->
+        let path = Filename.concat root "src/lexicon.ml" in
+        if Sys.file_exists path then Filename.concat root "src" else go rest
+  in
+  go (search_roots ())
+
+let rec collect_ml acc dir =
+  Array.fold_left
+    (fun acc name ->
+      let path = Filename.concat dir name in
+      if Sys.is_directory path then collect_ml acc path
+      else if Filename.check_suffix name ".ml" then path :: acc
+      else acc)
+    acc (Sys.readdir dir)
+
+let read_file path =
+  let ic = open_in_bin path in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
+let is_ident_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' -> true
+  | _ -> false
+
+let is_nsid s =
+  let n = String.length s in
+  if n < 5 then false
+  else
+    let dots = ref 0 in
+    let ok = ref true in
+    let i = ref 0 in
+    while !i < n && !ok do
+      let c = s.[!i] in
+      if c = '.' then (
+        incr dots;
+        if !i = 0 || !i = n - 1 || s.[!i - 1] = '.' then ok := false)
+      else if not (is_ident_char c) then ok := false;
+      incr i
+    done;
+    !ok && !dots >= 2
+
+let extract_quoted text =
+  let n = String.length text in
+  let acc = ref [] in
+  let i = ref 0 in
+  while !i < n do
+    if text.[!i] = '"' then (
+      incr i;
+      let start = !i in
+      while !i < n && text.[!i] <> '"' && text.[!i] <> '\n' do
+        incr i
+      done;
+      if !i < n && text.[!i] = '"' then (
+        let s = String.sub text start (!i - start) in
+        if is_nsid s then acc := s :: !acc;
+        incr i))
+    else incr i
+  done;
+  !acc
+
+let extract_after_needle text needle suffix_of =
+  let n = String.length text in
+  let fl = String.length needle in
+  let acc = ref [] in
+  let i = ref 0 in
+  while !i + fl <= n do
+    if String.sub text !i fl = needle then (
+      let j = ref (!i + fl) in
+      while
+        !j < n && (text.[!j] = ' ' || text.[!j] = '\n' || text.[!j] = '\t')
+      do
+        incr j
+      done;
+      (match suffix_of text !j with Some s -> acc := s :: !acc | None -> ());
+      i := !i + fl)
+    else incr i
+  done;
+  !acc
+
+let read_quoted text j =
+  if j < String.length text && text.[j] = '"' then (
+    let k = ref (j + 1) in
+    while !k < String.length text && text.[!k] <> '"' do
+      incr k
+    done;
+    if !k < String.length text then Some (String.sub text (j + 1) (!k - j - 1))
+    else None)
+  else None
+
+let extract_endpoint_calls text =
+  List.concat
+    (List.map
+       (fun (fn, prefix) ->
+         List.filter_map
+           (fun name -> if name = "" then None else Some (prefix ^ "." ^ name))
+           (extract_after_needle text fn read_quoted))
+       endpoint_prefixes)
+
+let read_xrpc_nsid text j =
+  let n = String.length text in
+  if j >= n then None
+  else
+    let k = ref j in
+    while !k < n && (is_ident_char text.[!k] || text.[!k] = '.') do
+      incr k
+    done;
+    let s = String.sub text j (!k - j) in
+    if is_nsid s then Some s else None
+
+let extract_xrpc_urls text = extract_after_needle text "/xrpc/" read_xrpc_nsid
+
+module SSet = Set.Make (String)
+
+let implemented_nsids src_dir =
+  collect_ml [] src_dir
+  |> List.fold_left
+       (fun acc path ->
+         let text = read_file path in
+         let found =
+           extract_quoted text
+           @ extract_endpoint_calls text
+           @ extract_xrpc_urls text
+         in
+         List.fold_left (fun acc id -> SSet.add id acc) acc found)
+       SSet.empty
+
+let string_field json name =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> s
+  | _ -> failwith ("missing string field " ^ name)
+
+let int_field json name =
+  match Yojson.Safe.Util.member name json with
+  | `Int n -> n
+  | _ -> failwith ("missing int field " ^ name)
+
+type official = { id : string; kind : string }
+type skip = { id : string; reason : string }
+
+let load_official path =
+  let json = Yojson.Safe.from_file path in
+  let sha = string_field json "sha" in
+  let nsid_count = int_field json "nsid_count" in
+  let nsids =
+    match Yojson.Safe.Util.member "nsids" json with
+    | `List xs ->
+        List.map
+          (fun x -> { id = string_field x "id"; kind = string_field x "type" })
+          xs
+    | _ -> failwith "manifest.nsids must be an array"
+  in
+  (sha, nsid_count, nsids)
+
+let load_skips path =
+  match Yojson.Safe.Util.member "skips" (Yojson.Safe.from_file path) with
+  | `List xs ->
+      List.map
+        (fun x ->
+          { id = string_field x "id"; reason = string_field x "reason" })
+        xs
+  | _ -> failwith "coverage-skips.skips must be an array"
+
+let has_newline s =
+  try
+    ignore (String.index s '\n');
+    true
+  with Not_found -> false
+
+let starts_with prefix s =
+  let n = String.length prefix in
+  String.length s >= n && String.sub s 0 n = prefix
+
+let test_official_nsid_coverage _ =
+  let sha, nsid_count, official =
+    load_official (find_file "lexicons/official-nsids.json")
+  in
+  let skips = load_skips (find_file "lexicons/coverage-skips.json") in
+  let implemented = implemented_nsids (find_src ()) in
+  OUnit2.assert_equal ~printer:(fun x -> x) expected_pin sha;
+  OUnit2.assert_equal ~printer:string_of_int nsid_count (List.length official);
+  List.iter
+    (fun (e : official) ->
+      OUnit2.assert_bool
+        ("unsupported main type for " ^ e.id ^ ": " ^ e.kind)
+        (List.mem e.kind covered_types))
+    official;
+  let official_ids =
+    List.fold_left
+      (fun acc (e : official) -> SSet.add e.id acc)
+      SSet.empty official
+  in
+  let skip_ids =
+    List.fold_left
+      (fun acc (s : skip) ->
+        OUnit2.assert_bool
+          (s.id ^ " skip reason must be a non-empty one-liner")
+          (String.trim s.reason <> "" && not (has_newline s.reason));
+        OUnit2.assert_bool
+          (s.id ^ " is not in the official pin; remove the skip")
+          (SSet.mem s.id official_ids);
+        OUnit2.assert_bool
+          (s.id
+         ^ " is already represented in src/; skip list must not hide a bound \
+            NSID")
+          (not (SSet.mem s.id implemented));
+        List.iter
+          (fun prefix ->
+            OUnit2.assert_bool
+              (s.id ^ " is a public client NSID (" ^ prefix
+             ^ "); hosted-only servers are not a skip reason")
+              (not (starts_with prefix s.id)))
+          never_skip_prefixes;
+        SSet.add s.id acc)
+      SSet.empty skips
+  in
+  let missing =
+    List.filter_map
+      (fun (e : official) ->
+        if SSet.mem e.id implemented || SSet.mem e.id skip_ids then None
+        else Some (e.kind ^ " " ^ e.id))
+      official
+  in
+  (match missing with
+  | [] -> ()
+  | xs ->
+      OUnit2.assert_failure
+        ("official NSIDs missing a client helper, record builder, bundled \
+          permission-set, or explicit skip:\n\
+         \  " ^ String.concat "\n  " xs));
+  let bound = List.length official - SSet.cardinal skip_ids in
+  OUnit2.assert_bool "expected official NSIDs to be bound" (bound > 0)
+
+let suite =
+  "lexicon_coverage"
+  >::: [ "test_official_nsid_coverage" >:: test_official_nsid_coverage ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Official lexicon JSON last changed at bluesky-social/atproto `60c4395951` (APP-2933). This PR adds a drift gate for that pin, tells the truth about the OCaml compiler bound, and publishes odoc HTML as a CI artifact. It does not rewrite OCaml clients from the manifest, invent a chat/video/Tap host, publish to opam-repository, or reopen leftover field parsers.

## Lexicon coverage CI

- Committed snapshot: `lexicons/official-nsids.json` (359 NSIDs of `query` / `procedure` / `subscription` / `record` / `permission-set` from 403 official JSON files at `60c439595101fbcbe612463e6f23200590c5daaf`).
- Regenerator: `scripts/gen-official-nsids.py [SHA]`.
- TestSuite check `test_lexicon_coverage` (existing `build` / `dune runtest -p atproto`, no new required job):
  1. Reads the committed manifest and asserts the pin SHA.
  2. Scans `src/` for client XRPC helpers, record builders, and bundled permission-sets.
  3. Requires every official NSID to be bound or listed in `lexicons/coverage-skips.json` with a one-line reason.
  4. Skip list is 5 entries (deprecated `getCheckout` / `getHead` / `notifyOfUpdate` / `fetchLabels`, plus internal `internal.bsky.actor.getProfiles`). Chat/video client NSIDs cannot be skipped because a host is hosted-only.

Re-running the generator against a newer SHA updates the snapshot; CI then fails until bindings or an explicit skip are added.

## OCaml constraint

CI only tests 4.14.1. `dune-project` is now `(ocaml (and (>= 4.14.1) (< 5.0)))`; `atproto.opam` was regenerated with dune (not hand-edited). No unverified 5.x matrix cell.

## odoc artifact

`lint-doc` still lints comments, then runs `dune build @doc` and uploads `_build/default/_doc/_html` via `actions/upload-artifact@v6`. `documentation` stays `https://github.com/david-engelmann/atproto` because GitHub Pages is 404.

## Docs

CHANGELOG notes #107 and this work. README remaining-gaps keep hosted-only items and add the `60c4395` pin + coverage gate.

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a12ec4cd-5b5c-44d9-8e40-bccf9465ab7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a12ec4cd-5b5c-44d9-8e40-bccf9465ab7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

