### PR TITLE
Docs/repo cleanup for packaged 0.1.0 (follows #110)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,45 @@
-Feel free to submit pull request
+# Contributing
+
+Pull requests are welcome. This package is **not** on
+[opam-repository](https://github.com/ocaml/opam-repository); depend on it by
+pinning the GitHub repository.
+
+## Toolchain
+
+- OCaml **4.14.x only** (`>= 4.14.1` and `< 5.0`). CI tests **4.14.1**.
+- ocamlformat **0.25.1** (see `.ocamlformat`). `lint-fmt` must stay green.
+- Package-style build (what `opam install` / a dependent sees):
+  `dune build -p atproto` and `dune runtest -p atproto`.
+
+Do not hand-edit `atproto.opam`; it is generated from `dune-project`.
+Documentation URL in `dune-project` is this GitHub repo (there is no
+GitHub Pages site).
+
+## Checks
+
+CI jobs: `build`, `lint-doc`, `lint-fmt`, `lint-opam`, `local-pds`.
+
+```shell
+opam install . --deps-only --with-test
+dune build -p atproto
+dune runtest -p atproto
+opam lint atproto.opam
+```
+
+`dune build` also typechecks `examples/offline.ml` against the public API.
+
+## Lexicon coverage
+
+Official lexicons are pinned at bluesky-social/atproto
+[`60c4395951`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf)
+(APP-2933). `scripts/gen-official-nsids.py` rebuilds
+`lexicons/official-nsids.json` against a SHA. TestSuite
+`test_lexicon_coverage` fails if a public client NSID is missing a helper,
+record builder, bundled permission-set, or an explicit one-line skip.
+
+Five deprecated/internal NSIDs are skipped in
+`lexicons/coverage-skips.json`: `com.atproto.temp.fetchLabels`,
+`com.atproto.sync.getCheckout`, `com.atproto.sync.getHead`,
+`com.atproto.sync.notifyOfUpdate`, and `internal.bsky.actor.getProfiles`.
+Hosted-only servers (no OSS chat backend, no video transcoder, no Tap
+host) are not skip reasons.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,4 +2,6 @@
 
 ## Reporting a Vulnerability
 
-No known vulnerabilities
+Report security issues privately via
+[GitHub Security Advisories](https://github.com/david-engelmann/atproto/security/advisories)
+on this repository. There are no known vulnerabilities in 0.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,20 @@
 # Changelog
 
 Notes for the packaged **0.1.0** library. This file records what actually
-shipped through pull request [#106](https://github.com/david-engelmann/atproto/pull/106)
-(merge `79aeb75c`, 2026-09-01), changelog
-[#107](https://github.com/david-engelmann/atproto/pull/107) (merge `3a7bd82f`,
-2026-09-02),
-[#108](https://github.com/david-engelmann/atproto/pull/108)
-(lexicon pin `60c4395951`, coverage gate, OCaml `< 5.0`, odoc artifact),
-[#109](https://github.com/david-engelmann/atproto/pull/109)
-(live Jetstream dict-zstd `subscribeEvents`), and
-[#110](https://github.com/david-engelmann/atproto/pull/110)
-(Jetstream v2 `xrpc.v1.json` WebSocket subprotocol negotiation).
+shipped through [#110](https://github.com/david-engelmann/atproto/pull/110)
+(Jetstream v2 `Sec-WebSocket-Protocol: xrpc.v1.json`), including
+[#109](https://github.com/david-engelmann/atproto/pull/109) (live Jetstream
+dict-zstd), [#108](https://github.com/david-engelmann/atproto/pull/108)
+(lexicon pin `60c4395951`, coverage gate, OCaml `< 5.0`, odoc HTML CI
+artifact), changelog [#107](https://github.com/david-engelmann/atproto/pull/107),
+and [#106](https://github.com/david-engelmann/atproto/pull/106).
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
-pinning the GitHub repository (see the README).
+pinning the GitHub repository (see the README). Requires OCaml `>= 4.14.1`
+and `< 5.0`.
 
-## 0.1.0 — 2026-09-01
+## 0.1.0 — 2026-09-02
 
 First installable opam package (`dune-project` / `atproto.opam` version
 `0.1.0`, OCaml `>= 4.14.1` and `< 5.0`). `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`
@@ -40,24 +38,26 @@ exposes `(libraries atproto)`. That pin is not an opam-repository publish.
 - OAuth / DPoP (`Oauth`, `Oauth_scope`): PKCE S256, PAR, token, refresh,
   RFC 7009 revoke, granular scopes, official `app.bsky.auth*` /
   `chat.bsky.authFullChatClient` permission-sets
-- Jetstream v2 tail + live dict-zstd `subscribeEvents` (`getZstdDictionary`,
-  Jane Street `zstandard` v0.16) + `.jss` v1 decode (no invented archive
-  token). v2 `subscribe` / `subscribe_one` offer
-  `Sec-WebSocket-Protocol: xrpc.v1.json` through `Websocket.connect
-  ~extra_headers`; RFC 6455 §4.1 fails the handshake unless the 101
-  echoes that exact protocol. Unoffered connections (v1 `/subscribe`,
-  firehose) are unchanged. v2 stays server-push only (no client data
-  frames; v1 `options_update` / `requireHello` are not sent)
+- Jetstream v2 tail + live dict-zstd `subscribeEvents`
+  ([#109](https://github.com/david-engelmann/atproto/pull/109): Jane Street
+  `zstandard` v0.16, `getZstdDictionary`, v2 `zstdDictionary=<id>`; no
+  invented archive token) + `.jss` v1 decode.
+  [#110](https://github.com/david-engelmann/atproto/pull/110): v2 `subscribe`
+  / `subscribe_one` offer `Sec-WebSocket-Protocol: xrpc.v1.json` through
+  `Websocket.connect ~extra_headers`; RFC 6455 §4.1 fails the handshake
+  unless the 101 echoes that exact protocol. Unoffered connections (v1
+  `/subscribe`, firehose) are unchanged. v2 stays server-push only (no
+  client data frames; v1 `options_update` / `requireHello` are not sent)
 - TAP-like local repo sync helpers (`Repo_sync`) — not a hosted Tap
 - `site.standard.*` and `com.germnetwork.declaration` record builders
 
-### Local TestNetwork (#90–#106)
+### Local TestNetwork
 
 CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
 (`TestNetwork.create()`: PLC + PDS + AppView + Ozone + bsync).
 `ATP_REQUIRE_LOCAL_PDS=1` fails hard on real protocol errors.
 
-- Leftover served XRPC on that stack, including APP-2933
+- Served XRPC on that stack, including APP-2933
   `app.bsky.graph.referencelistoptout`
 - Live local OAuth: loopback client-metadata, AS discovery, PAR, browser
   authorize GET, `~api/sign-in` / `~api/consent` with real cookies, token,
@@ -69,7 +69,7 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   (optional `privileged`). This `@atproto/pds` 0.5.x TestNetwork build
   still 500s on that valid body; the local suite keeps an isolated assert
 
-### Packaging and quality (#101, #106, #107, #108)
+### Packaging and quality
 
 - `public_name atproto`, generated `atproto.opam`, `opam lint`,
   `dune build -p atproto` / `dune runtest -p atproto`
@@ -79,15 +79,16 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `actions/upload-artifact@v6`
 - Unused `open`s are errors (`-w +33 -warn-error +33`) on the library,
   tests, and `examples/offline.ml`
-- Module-level odoc on public modules; TestSuite `lint-doc` runs
-  `dune build @doc` and uploads HTML as the `odoc-html` artifact (no
-  GitHub Pages site)
+- Module-level odoc on public modules
+- [#108](https://github.com/david-engelmann/atproto/pull/108): official
+  lexicon pin bluesky-social/atproto `60c4395951` (APP-2933) as
+  `lexicons/official-nsids.json`, plus TestSuite `test_lexicon_coverage`
+  (client helper / record builder / bundled permission-set / explicit
+  skip); OCaml constraint `(and (>= 4.14.1) (< 5.0))` — CI tests 4.14.1
+  only; TestSuite `lint-doc` runs `dune build @doc` and uploads HTML as
+  the `odoc-html` artifact (no GitHub Pages site)
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
-- Official lexicon pin bluesky-social/atproto `60c4395951` (APP-2933) as
-  `lexicons/official-nsids.json`, plus TestSuite `test_lexicon_coverage`
-  (client helper / record builder / bundled permission-set / explicit skip)
-- OCaml constraint `(and (>= 4.14.1) (< 5.0))` — CI tests 4.14.1 only
 
 ### Not in this release
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In a dependent `dune` stanza:
 
 `opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. That does not publish the package to opam-repository.
 
-Version notes for **0.1.0** (what shipped through [#106](https://github.com/david-engelmann/atproto/pull/106), changelog [#107](https://github.com/david-engelmann/atproto/pull/107), [#108](https://github.com/david-engelmann/atproto/pull/108), [#109](https://github.com/david-engelmann/atproto/pull/109) live dict-zstd, and [#110](https://github.com/david-engelmann/atproto/pull/110) v2 `xrpc.v1.json` subprotocol negotiation) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
+Version notes for **0.1.0** (the packaged surface through [#110](https://github.com/david-engelmann/atproto/pull/110)) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
 
 ## Environment
 
@@ -166,31 +166,17 @@ Pinned `@atproto/dev-env@0.6.4` `TestNetwork.create()` does **not** start a `cha
 
 ## Remaining gaps
 
-These are product-level, not missing protocol cores:
+These are product-level, not missing protocol cores.
 
-- Official lexicons are pinned at bluesky-social/atproto [`60c4395951`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf) (APP-2933). `lexicons/official-nsids.json` is the compact NSID snapshot (`query` / `procedure` / `subscription` / `record` / `permission-set`); `scripts/gen-official-nsids.py` rebuilds it against a SHA. TestSuite `test_lexicon_coverage` fails if that pin grows and a public client NSID is missing a helper, record builder, bundled permission-set, or an explicit one-line skip. Hosted-only *servers* (no OSS chat backend, no video transcoder, no Tap host) are not skip reasons.
-- Hosting a **public HTTPS client-metadata document** and completing a **production browser login** against a remote PDS. Local TestNetwork serves a loopback metadata document and runs discovery + PAR + DPoP + authorize GET + `~api/sign-in` / `~api/consent` (real `csrf-token` / `dev-id` / `ses-id` cookies) through token exchange, DPoP `getSession`, DPoP `getServiceAuth`, authed AppView `getTimeline` / `listNotifications` (service-auth JWT, not the DPoP token), Ozone privileged `emitEvent` as `admin-mod.test` (`getServiceAuth` + `Ozone.emit_event_service` on `:2587`; DPoP + `atproto-proxy` is rejected), refresh, and RFC 7009 revoke in CI (`test/test_local_oauth.ml`). The local authorize GET is still an HTML SPA (no `code` on the first navigation); the code is minted by the sign-in/consent APIs, not by faking a browser document.
-- A hosted Tap service or hosted video transcoder (client request/response types, video byte-upload + job poll, TAP-like repo sync helpers, and proxy headers are implemented). Local TestNetwork Ozone privileged writes use OAuth DPoP `getServiceAuth` + `Ozone.emit_event_service` as `admin-mod.test` (not a production operator session). A **local PDS + PLC** stack is included for `com.atproto.*` integration tests; it is not a public host.
-- Jetstream Network Replay / HTTP snapshot **download** against Bluesky's gated archive (planner, `listSegments` types, cutover cursor, Range resume, skippable unauthenticated HTTP, and `.jss` v1 decode are implemented; live compressed `subscribeEvents` dict-zstd and v2 `xrpc.v1.json` subprotocol negotiation are implemented). A live archive download still needs an operator token this library does not invent.
-- Permissioned data / spaces / LtHash (no stable public spec to implement yet)
-- Official `com.atproto.sync.getRepo` **lexicon** still has no `collection` parameter (client-side subset export from a full CAR is implemented; servers that reject unknown query params are unchanged)
+**What 0.1.0 covers.** The packaged client through [#110](https://github.com/david-engelmann/atproto/pull/110): XRPC, official lexicon pin `60c4395951` with a coverage gate, repo sync, identity, AppView, Ozone, chat client, live local OAuth/DPoP, and Jetstream v2 (`xrpc.v1.json` + dict-zstd). Pin this GitHub repo; it is **not** on opam-repository. See [CHANGELOG.md](CHANGELOG.md).
 
-#70–#90 covered protocol core, AppView/chat/ozone/temp, Jetstream, video, OAuth scopes, thread v2 / drafts / contacts, remaining preference kinds, ozone queue/report, `site.standard.*`, leftover admin, HTTP/2, server email/activate, leftover official field parsers, and the official `@atproto/dev-env` local network in CI.
-
-This stack fills leftover *library* holes after #90–#109: live local OAuth through token (loopback client-metadata + AS discovery + PAR/DPoP + authorize GET + `~api/sign-in`/`consent` with real cookies + token / DPoP `getSession` / DPoP `getServiceAuth` / AppView `getTimeline` / Ozone `emitEvent` via service-auth / refresh / RFC 7009 revoke), official `app.bsky.graph.referencelistoptout`, OAuth PAR `prompt=create` / RFC 7638 `dpop_jkt`, typed official permission-set lexicons (`include:app.bsky.auth*`), `Client.post_json_h2`, DAG-CBOR IPLD JSON (`$link`/`$bytes`), offline `Repo_sync.write_signed_repo`, unused opens as errors, public module odoc (HTML as a CI artifact, not GitHub Pages), official lexicon pin `60c4395` with a coverage gate, OCaml `< 5.0`, live Jetstream dict-zstd + v2 `xrpc.v1.json` subprotocol negotiation, and more local PDS/AppView/Ozone XRPC the stack actually serves. Chat still has no OSS server in TestNetwork; skippable live `chat.bsky.*` tests keep `atproto-proxy`. This package is **not** on opam-repository.
-
-Production admin/ozone operator sessions are not invented here. Local TestNetwork `admin-mod.test` completes OAuth DPoP and writes through `getServiceAuth` (DPoP + `atproto-proxy` is rejected).
-
-Still leftover vs current lexicons (not invented here):
-
-- Deprecated `com.atproto.temp.fetchLabels` (use `Label.query_labels` / `subscribeLabels`; coverage skip)
-- Deprecated `com.atproto.sync.getCheckout` / `getHead` / `notifyOfUpdate` (use `getRepo` / `getLatestCommit` / `requestCrawl`; coverage skips)
-- `internal.bsky.actor.getProfiles` (service-to-service AppView query, not a public client surface; coverage skip)
-- Internal `debug` fields and deprecated `entities` / `isFallback`
-- Privileged Ozone operator view fields (clients exist; production operator session not invented; local admin-mod OAuth DPoP `getServiceAuth` is)
-- `com.atproto.server.createAppPassword` 500 on this `@atproto/pds` 0.5.x TestNetwork build (library request matches the official lexicon; the local suite asserts the isolated 500)
-
-Open PR `#69` (`de-sync-types`) is superseded by this work: it still targeted the removed `getCheckout` API and left CAR/CBOR unfinished.
+- Official lexicons are pinned at bluesky-social/atproto [`60c4395951`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf) (APP-2933). `lexicons/official-nsids.json` is the compact NSID snapshot (`query` / `procedure` / `subscription` / `record` / `permission-set`); `scripts/gen-official-nsids.py` rebuilds it against a SHA. TestSuite `test_lexicon_coverage` fails if that pin grows and a public client NSID is missing a helper, record builder, bundled permission-set, or an explicit one-line skip. Hosted-only *servers* (no OSS chat backend, no video transcoder, no Tap host) are not skip reasons. Five deprecated/internal NSIDs are skipped in `lexicons/coverage-skips.json`: `com.atproto.temp.fetchLabels`, `com.atproto.sync.getCheckout`, `com.atproto.sync.getHead`, `com.atproto.sync.notifyOfUpdate`, and `internal.bsky.actor.getProfiles`.
+- Hosting a **public HTTPS client-metadata document** and completing a **production browser login** against a remote PDS. Local TestNetwork already runs loopback metadata + PAR + DPoP through token, AppView service-auth, and Ozone privileged writes as `admin-mod.test`.
+- A hosted **Tap** service or hosted **video transcoder** (client types and TAP-like repo sync helpers are implemented). TestNetwork is a local PDS + AppView + Ozone stack, not a public host.
+- No official **OSS chat** backend in `@atproto/dev-env` 0.6.4 TestNetwork. `chat.bsky.*` clients still send `atproto-proxy`.
+- Jetstream archive HTTP **download** still needs an operator token this library does not invent (live dict-zstd `subscribeEvents` and v2 `xrpc.v1.json` are implemented).
+- Permissioned data / spaces / LtHash (no stable public spec yet)
+- This package is **not** on opam-repository
 
 ## Sample usage
 
@@ -255,7 +241,7 @@ let start =
 let _header, msg = Firehose.subscribe_one ()
 
 (* Jetstream v2 JSON tail — URL only here; subscribe_one talks to the public WS
-   and offers Sec-WebSocket-Protocol: xrpc.v1.json *)
+   and offers Sec-WebSocket-Protocol: xrpc.v1.json (RFC 6455 §4.1 echo) *)
 let _js =
   Jetstream.subscribe_url
     ~filter:
@@ -266,6 +252,10 @@ let _js =
       }
     ()
 let _headers = Jetstream.subscribe_extra_headers ()
+(* v2 dict-zstd: query zstdDictionary=<id>; header stays xrpc.v1.json *)
+let _js_zstd =
+  Jetstream.subscribe_url ~compress:true ~zstd_dictionary_id:20260811 ()
+let _headers_zstd = Jetstream.subscribe_extra_headers ~compress:true ()
 
 (* TAP-like local indexer: backfill a CAR, then apply firehose ops *)
 let acct =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#110 merged while this PR was open, so the base is now **main** (GitHub auto-retargeted; we kept it on main per the stack rule).

Docs/repo cleanup so packaged 0.1.0 reads as a finished library, not a leftover hunt.

## What this does

- **CHANGELOG.md**: record the packaged 0.1.0 surface through #110, not just #106.
  - #108: lexicon pin `60c4395951`, coverage gate, OCaml `< 5.0`, odoc HTML CI artifact
  - #109: live Jetstream dict-zstd (`zstandard` v0.16, `getZstdDictionary`, v2 `zstdDictionary=<id>`)
  - #110: v2 offers `Sec-WebSocket-Protocol: xrpc.v1.json` and fails the handshake unless echoed (RFC 6455 §4.1)
  - Honest constraints stay: not on opam-repository; pin GitHub; OCaml `>= 4.14.1` and `< 5.0`
- **README remaining-gaps**: short and product-level. Hosted-only items stay (public HTTPS client-metadata / production browser OAuth, Tap host, video transcoder, no OSS chat in TestNetwork, Jetstream archive token we do not invent, permissioned data / spaces / LtHash, not on opam-repository). Coverage-gate paragraph kept (pin SHA, `lexicons/official-nsids.json`, skip list of 5 deprecated/internal NSIDs). Historical “#70–#107 leftover holes” essay and the stale “Open PR #69 is superseded” note are gone. Sample usage keeps the public Jetstream subprotocol + `~compress` helpers.
- **CONTRIBUTING.md**: `dune build -p atproto`, ocamlformat 0.25.1, coverage gate (`scripts/gen-official-nsids.py`, pin SHA), OCaml 4.14.x only.
- **SECURITY.md**: report via GitHub Security Advisories.
- `dune-project` documentation URL stays the GitHub repo (Pages is 404). `atproto.opam` was not hand-edited.

## Out of scope

No leftover view-field hunt, no opam-repository publish, no OCaml 5, no invented chat/video/Tap host or Jetstream archive token, no protocol-client rewrite, no `cursor/*` branch deletes.

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b507aa7b-9512-4db7-b0bf-7399fc0404fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b507aa7b-9512-4db7-b0bf-7399fc0404fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

