### PR TITLE
Deploy odoc HTML to GitHub Pages on main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,12 +12,18 @@ pinning the GitHub repository.
   `dune build -p atproto` and `dune runtest -p atproto`.
 
 Do not hand-edit `atproto.opam`; it is generated from `dune-project`.
-Documentation URL in `dune-project` is this GitHub repo (there is no
-GitHub Pages site).
+odoc HTML is a CI artifact (`odoc-html`) on pull requests. On push to
+`main`, TestSuite deploys `_build/default/_doc/_html` with GitHub
+Actions Pages. GitHub Pages is not enabled yet (API enable returned
+403); turn it on once under Settings → Pages → Source: GitHub
+Actions. Until then, `dune-project` `documentation` stays this GitHub
+repo (do not point `doc:` at a 404 Pages URL).
 
 ## Checks
 
 CI jobs: `build`, `lint-doc`, `lint-fmt`, `lint-opam`, `local-pds`.
+On push to `main`, `deploy-pages` publishes odoc HTML after Pages is
+enabled.
 
 ```shell
 opam install . --deps-only --with-test

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -108,6 +108,33 @@ jobs:
           path: _build/default/_doc/_html
           if-no-files-found: warn
 
+      # PRs keep the odoc-html artifact above. Pages deploy is main-only.
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _build/default/_doc/_html
+
+  # Official GitHub Actions Pages path. Skipped on PRs so CI stays green
+  # before Pages is enabled (Settings → Pages → Source: GitHub Actions).
+  deploy-pages:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: lint-doc
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
   lint-fmt:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In a dependent `dune` stanza:
 
 `opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. That does not publish the package to opam-repository.
 
-Version notes for **0.1.0** (the packaged surface through [#110](https://github.com/david-engelmann/atproto/pull/110)) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact; there is no GitHub Pages site.
+Version notes for **0.1.0** (the packaged surface through [#110](https://github.com/david-engelmann/atproto/pull/110)) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact on pull requests. On push to `main`, the same HTML is deployed with GitHub Actions Pages (`actions/upload-pages-artifact` + `actions/deploy-pages`). GitHub Pages is not enabled on this repository yet (`POST /repos/david-engelmann/atproto/pages` with `build_type=workflow` returned 403). Enable it once under Settings → Pages → Source: GitHub Actions; after that the site is https://david-engelmann.github.io/atproto/. Until then, `dune-project` `documentation` still points at this GitHub repo.
 
 ## Environment
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unique remaining product hole after the 0.1.0 docs cleanup (#111): `lint-doc` already builds odoc HTML and uploads artifact `odoc-html`, but GitHub Pages is 404 (`GET /repos/david-engelmann/atproto/pages`) and `dune-project` `documentation` still points at the GitHub repo.

## What this does

- **TestSuite `lint-doc`**: keep the existing `odoc-html` artifact upload on every run (PRs still produce HTML without deploying).
- **On push to `main` only** (not PRs): upload `_build/default/_doc/_html` with `actions/upload-pages-artifact@v5` and deploy with `actions/deploy-pages@v5` (current majors, matching `checkout@v5` / `upload-artifact@v6`).
- **`deploy-pages` job**: `permissions: pages: write` and `id-token: write`, `environment: github-pages`. Skipped on pull requests so this PR's CI stays green before Pages is enabled.
- **Pages enable**: `gh api POST /repos/david-engelmann/atproto/pages` with `build_type=workflow` returned **403** (`Resource not accessible by integration`). Workflow is landed; one-click enable is documented in README / CONTRIBUTING (Settings → Pages → Source: GitHub Actions).
- **`dune-project` `documentation`**: left as `https://github.com/david-engelmann/atproto` because enable failed. Do not point `doc:` at a 404 Pages URL. `atproto.opam` was not hand-edited.
- **README / CONTRIBUTING**: odoc HTML is a CI artifact on PRs and (once Pages is enabled) the Actions Pages site on main. Remaining-gaps hosted-only items stay. This package is **not** on opam-repository.

## Out of scope

No leftover view-field hunt, no opam-repository publish, no OCaml 5, no invented chat/video/Tap host or Jetstream archive token.

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ba54aee-8e31-4558-bb43-0060c2b369f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ba54aee-8e31-4558-bb43-0060c2b369f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

