### PR TITLE
Odoc landing page, Dependabot, and lexicon pin-drift CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @david-engelmann

--- a/.github/ISSUE_TEMPLATE/01-question.md
+++ b/.github/ISSUE_TEMPLATE/01-question.md
@@ -1,17 +1,16 @@
-Your Environment
-----------------
-<!-- Include details of your environment. -->
+---
+name: Question
+about: Ask about using the library
+title: ""
+labels: ""
+---
 
-*   Operating System:
-*   OCaml Version:
-*   Package Version:
+**Question**
+What are you trying to do?
 
+**Environment**
+- OCaml version (`>= 4.14.1` and `< 5.0`):
+- Install method (`opam pin` / local clone):
+- `ATP_HOST` / `ATP_SCHEME` (if this is a live call):
 
-
-How to reproduce the behaviour
-------------------------------
-<!-- Before submitting an issue, make sure to check the docs and closed issues
-and FAQ to see if any of the solutions work for you. -->
-
-<!-- Include a code example or the steps that led to the problem. Please try to be as
-specific as possible. -->
+Docs: https://david-engelmann.github.io/atproto/

--- a/.github/ISSUE_TEMPLATE/03-install.md
+++ b/.github/ISSUE_TEMPLATE/03-install.md
@@ -1,17 +1,23 @@
-Your Environment
-----------------
-<!-- Include details of your environment. -->
+---
+name: Install
+about: Pin, opam, or dune build problems
+title: ""
+labels: ""
+---
 
-*   Operating System:
-*   OCaml Version:
-*   Package Version:
+**What failed**
+`opam pin`, `opam install . --deps-only`, or `dune build -p atproto`.
 
+**Environment**
+- OCaml version (must be `>= 4.14.1` and `< 5.0`; CI is 4.14.1):
+- opam version / switch:
+- OS:
 
+**Command and output**
+Paste the command and the error.
 
-How to reproduce the behaviour
-------------------------------
-<!-- Before submitting an issue, make sure to check the docs and closed issues
-and FAQ to see if any of the solutions work for you. -->
+This package is not on the public opam-repository. The supported install is:
 
-<!-- Include a code example or the steps that led to the problem. Please try to
-be as specific as possible. -->
+```shell
+opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+```

--- a/.github/ISSUE_TEMPLATE/04-request.md
+++ b/.github/ISSUE_TEMPLATE/04-request.md
@@ -1,4 +1,19 @@
-Feature description
----------
-<!-- Please describe the feature: Which area of the library is it related to?
-What specific solution would you like? -->
+---
+name: Request
+about: A protocol client or docs change (not a hosted PDS/chat/video/Tap)
+title: ""
+labels: ""
+---
+
+**Request**
+Which public module or NSID? What should the client do?
+
+**Out of scope for this library**
+A hosted PDS, OSS chat backend, video transcoder, Tap service, opam-repository
+publish, or an invented Jetstream archive token. Official lexicons are pinned
+at `lexicons/official-nsids.json`; a pin bump needs `scripts/gen-official-nsids.py`
+plus coverage (or an explicit skip).
+
+**Environment** (if you already tried a call)
+- OCaml version:
+- `ATP_HOST` / `ATP_SCHEME`:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,24 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+about: Something in the OCaml client or protocol helpers is wrong
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what went wrong.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**To reproduce**
+Steps, a short OCaml snippet, or the XRPC NSID that failed.
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected instead.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment**
+- OCaml version (package requires `>= 4.14.1` and `< 5.0`; CI tests 4.14.1):
+- Install method (`opam pin add atproto git+https://github.com/david-engelmann/atproto.git` or a local clone):
+- `ATP_HOST` / `ATP_SCHEME` (if the call is live; leave blank for a pure library bug):
 
 **Additional context**
-Add any other context about the problem here.
+Logs, response JSON, or a link to the odoc page (https://david-engelmann.github.io/atproto/).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Library documentation
+    url: https://david-engelmann.github.io/atproto/
+    about: Live odoc HTML for the atproto OCaml package

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,15 @@
-# Description
+## Summary
 
-Provide a summary of the changes proposed and the reason for them. If any of the changes are not backwards compatible please provide those here. Any useful information, context or motivation can also be included. Mention any issues that the pull request fixes in the section below.
+<!-- What changed and why. Note any backwards-incompatible API shifts. -->
+
+## Checklist
+
+- [ ] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
+- [ ] Not an opam-repository publish
+- [ ] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
+- [ ] No fake OSS chat / video transcoder / Tap host
+- [ ] No invented Jetstream archive token
+- [ ] New public module has a module-level `(** ... *)` odoc comment
+- [ ] User-facing change is noted in CHANGELOG.md
 
 Fixes # (issue)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Version updates for GitHub Actions used by TestSuite and lexicon-pin.
+# docker/dev-env has compose.yaml (postgres/redis pinned to official
+# @atproto/dev-env) but no Dockerfiles; npm there is the pinned
+# @atproto/dev-env 0.6.4 TestNetwork and is left alone.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
-# Version updates for GitHub Actions used by TestSuite and lexicon-pin.
-# docker/dev-env has compose.yaml (postgres/redis pinned to official
-# @atproto/dev-env) but no Dockerfiles; npm there is the pinned
-# @atproto/dev-env 0.6.4 TestNetwork and is left alone.
+# github-actions: TestSuite + lexicon-pin.
+# npm: confirmed docker/dev-env/package.json (@atproto/dev-env 0.6.4).
+# No Dockerfiles under docker/dev-env; no gomod.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -14,3 +13,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: npm
+    directory: /docker/dev-env
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/lexicon-pin.yml
+++ b/.github/workflows/lexicon-pin.yml
@@ -1,0 +1,72 @@
+# Fail when bluesky-social/atproto lexicons/ moved past the SHA in
+# lexicons/official-nsids.json. Does not bump the pin.
+name: Lexicon pin drift
+
+on:
+  pull_request:
+  schedule:
+    # 13:30 UTC weekdays (9:30 AM ET)
+    - cron: "30 13 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lexicon-pin:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Compare official lexicons against the pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pin="$(jq -r '.sha' lexicons/official-nsids.json)"
+          if [[ ! "$pin" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            echo "Invalid pin SHA in lexicons/official-nsids.json: ${pin}"
+            exit 1
+          fi
+
+          head="$(gh api repos/bluesky-social/atproto --jq .default_branch)"
+          compare="$(gh api "repos/bluesky-social/atproto/compare/${pin}...${head}")"
+
+          ahead="$(jq -r '.ahead_by // 0' <<<"$compare")"
+          truncated="$(jq -r '.truncated // false' <<<"$compare")"
+          lexicon_files="$(
+            jq -r '
+              [.files[]? | select(.filename | startswith("lexicons/")) | .filename]
+              | unique
+              | .[]
+            ' <<<"$compare"
+          )"
+
+          if [[ "$truncated" == "true" ]]; then
+            echo "Compare API result is truncated; fetching trees to diff lexicons/."
+            workdir="$(mktemp -d)"
+            git init -q "$workdir"
+            git -C "$workdir" remote add origin https://github.com/bluesky-social/atproto.git
+            git -C "$workdir" fetch --depth=1 origin "${pin}:refs/heads/pin"
+            git -C "$workdir" fetch --depth=1 origin "${head}:refs/heads/official"
+            lexicon_files="$(
+              git -C "$workdir" diff --name-only pin official -- lexicons/ || true
+            )"
+          fi
+
+          echo "Official pin: ${pin}"
+          echo "Official ${head} is ${ahead} commit(s) ahead of the pin."
+
+          if [[ -z "${lexicon_files}" ]]; then
+            echo "No lexicons/ path changes since the pin. Pin is current."
+            exit 0
+          fi
+
+          echo "Official lexicons/ moved since pin ${pin}."
+          echo "Changed lexicon paths:"
+          printf '%s\n' "$lexicon_files"
+          echo
+          echo "This job does not bump the pin. Update lexicons/official-nsids.json"
+          echo "and the client bindings (or an explicit coverage skip) in a follow-up."
+          exit 1

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package atproto))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,76 @@
+{0 AT Protocol for OCaml}
+
+{!Atproto} is a typed client and protocol library for the
+{{:https://atproto.com}AT Protocol}: XRPC, lexicons, identity, repo
+sync, AppView, Ozone, and a chat client. The public surface tracks
+official lexicons at bluesky-social/atproto
+{{:https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf}[60c4395951]}.
+What remains is product-level and hosted-only — not a missing protocol
+core.
+
+This package does not host a PDS, an OSS chat backend, a video
+transcoder, or a Tap service. It is a library you pin and call.
+
+{1 Install}
+
+Not published to the public opam-repository. Pin the GitHub repository
+(OCaml [>= 4.14.1] and [< 5.0]; CI tests 4.14.1):
+
+{[
+opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+]}
+
+Then depend on [(libraries atproto)] from dune. [opam pin] builds
+[dune build -p atproto]; it is not an opam-repository release.
+
+{1 These pages}
+
+HTML from [dune build @doc] is published at
+{{:https://david-engelmann.github.io/atproto/}https://david-engelmann.github.io/atproto/}.
+Pull requests also upload the same tree as the [odoc-html] TestSuite
+artifact.
+
+{1 Public modules}
+
+{ul
+{- {b Auth / Session.} {!Atproto.Auth} and {!Atproto.Session} create
+   and inspect [com.atproto.server] sessions ([ATP_AUTH], [ATP_HOST],
+   JWT claims, [getSession]).}
+{- {b XRPC.} {!Atproto.Xrpc} is the header layer: [atproto-proxy],
+   accept-labelers, rate limits, and service-auth JWT mint/verify.}
+{- {b Identity / PLC.} {!Atproto.Identity} resolves handles and DIDs.
+   {!Atproto.Did_plc}, {!Atproto.Did_web}, and {!Atproto.Did_key} cover
+   the PLC directory, [did:web], and [did:key] (p256 / k256).}
+{- {b MST / CID / CAR.} {!Atproto.Mst} is the Merkle Search Tree.
+   {!Atproto.Cid}, {!Atproto.Car}, and {!Atproto.Dag_cbor} read and
+   write CIDv1, CARv1, and DAG-CBOR. {!Atproto.Repo_sync} is
+   library-shaped TAP-like backfill — not a hosted Tap.}
+{- {b Firehose / Jetstream.} {!Atproto.Firehose} decodes
+   [subscribeRepos] ([#commit] / [#sync] / [#identity] / [#account]).
+   {!Atproto.Jetstream} is the JSON tail (v2 [xrpc.v1.json], live
+   dict-zstd). Archive HTTP still needs an operator token this library
+   does not invent.}
+{- {b OAuth / DPoP.} {!Atproto.Oauth} and {!Atproto.Oauth_scope} are
+   PKCE S256, DPoP ES256, PAR, token/refresh/revoke, and granular
+   scopes. Local TestNetwork can run the loopback login; a public
+   HTTPS client-metadata document and production browser login are
+   application-level.}
+{- {b AppView.} {!Atproto.Actor}, {!Atproto.Feed}, {!Atproto.Graph},
+   {!Atproto.Bookmark}, {!Atproto.Notification}, {!Atproto.Labeler},
+   {!Atproto.Unspecced}, and {!Atproto.Video} speak [app.bsky.*].
+   Video is a client for the hosted upload service — no transcoder.}
+{- {b Ozone.} {!Atproto.Ozone} is the [tools.ozone.*] moderation
+   client (events, subjects, team, queue, report). Password sessions
+   proxy through the PDS; OAuth mints [getServiceAuth] and calls the
+   Ozone host (DPoP cannot be proxied).}
+{- {b Chat client.} {!Atproto.Chat} is [chat.bsky.*] with
+   [atproto-proxy] ([did:web:api.bsky.chat#bsky_chat], the session
+   [#bsky_chat] service, or [ATP_CHAT_DID]). There is no official OSS
+   chat backend in [@atproto/dev-env] 0.6.4.}}
+
+Related protocol pieces live beside that map: {!Atproto.Repo} and
+{!Atproto.Records} for writes, {!Atproto.Server} and {!Atproto.Sync}
+for account/repo HTTP, {!Atproto.Label} for [queryLabels],
+{!Atproto.Lexicon} for lexicon-1 parse/validate/codegen, and
+{!Atproto.Http_client} for HTTP/2 XRPC that keeps status and
+rate-limit headers.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,76 +1,67 @@
 {0 AT Protocol for OCaml}
 
 {!Atproto} is a typed client and protocol library for the
-{{:https://atproto.com}AT Protocol}: XRPC, lexicons, identity, repo
-sync, AppView, Ozone, and a chat client. The public surface tracks
-official lexicons at bluesky-social/atproto
+{{:https://atproto.com}AT Protocol}: XRPC, identity, repo sync,
+AppView, Ozone, and a chat client. Official lexicons are pinned at
+bluesky-social/atproto
 {{:https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf}[60c4395951]}.
-What remains is product-level and hosted-only — not a missing protocol
-core.
-
-This package does not host a PDS, an OSS chat backend, a video
-transcoder, or a Tap service. It is a library you pin and call.
+Leftovers are hosted-only (no PDS, OSS chat backend, video transcoder,
+or Tap in this package).
 
 {1 Install}
 
-Not published to the public opam-repository. Pin the GitHub repository
-(OCaml [>= 4.14.1] and [< 5.0]; CI tests 4.14.1):
+Not on the public opam-repository. Pin the GitHub repo (OCaml
+[>= 4.14.1] and [< 5.0]; CI tests 4.14.1):
 
 {[
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
 ]}
 
-Then depend on [(libraries atproto)] from dune. [opam pin] builds
-[dune build -p atproto]; it is not an opam-repository release.
+Then [(libraries atproto)] in dune.
 
-{1 These pages}
+{1 Documentation}
 
-HTML from [dune build @doc] is published at
-{{:https://david-engelmann.github.io/atproto/}https://david-engelmann.github.io/atproto/}.
-Pull requests also upload the same tree as the [odoc-html] TestSuite
-artifact.
+{{:https://david-engelmann.github.io/atproto/}https://david-engelmann.github.io/atproto/}
+([dune build @doc] on [main]; PRs also upload the [odoc-html] artifact).
 
 {1 Public modules}
 
-{ul
-{- {b Auth / Session.} {!Atproto.Auth} and {!Atproto.Session} create
-   and inspect [com.atproto.server] sessions ([ATP_AUTH], [ATP_HOST],
-   JWT claims, [getSession]).}
-{- {b XRPC.} {!Atproto.Xrpc} is the header layer: [atproto-proxy],
-   accept-labelers, rate limits, and service-auth JWT mint/verify.}
-{- {b Identity / PLC.} {!Atproto.Identity} resolves handles and DIDs.
-   {!Atproto.Did_plc}, {!Atproto.Did_web}, and {!Atproto.Did_key} cover
-   the PLC directory, [did:web], and [did:key] (p256 / k256).}
-{- {b MST / CID / CAR.} {!Atproto.Mst} is the Merkle Search Tree.
-   {!Atproto.Cid}, {!Atproto.Car}, and {!Atproto.Dag_cbor} read and
-   write CIDv1, CARv1, and DAG-CBOR. {!Atproto.Repo_sync} is
-   library-shaped TAP-like backfill — not a hosted Tap.}
-{- {b Firehose / Jetstream.} {!Atproto.Firehose} decodes
-   [subscribeRepos] ([#commit] / [#sync] / [#identity] / [#account]).
-   {!Atproto.Jetstream} is the JSON tail (v2 [xrpc.v1.json], live
-   dict-zstd). Archive HTTP still needs an operator token this library
-   does not invent.}
-{- {b OAuth / DPoP.} {!Atproto.Oauth} and {!Atproto.Oauth_scope} are
-   PKCE S256, DPoP ES256, PAR, token/refresh/revoke, and granular
-   scopes. Local TestNetwork can run the loopback login; a public
-   HTTPS client-metadata document and production browser login are
-   application-level.}
-{- {b AppView.} {!Atproto.Actor}, {!Atproto.Feed}, {!Atproto.Graph},
-   {!Atproto.Bookmark}, {!Atproto.Notification}, {!Atproto.Labeler},
-   {!Atproto.Unspecced}, and {!Atproto.Video} speak [app.bsky.*].
-   Video is a client for the hosted upload service — no transcoder.}
-{- {b Ozone.} {!Atproto.Ozone} is the [tools.ozone.*] moderation
-   client (events, subjects, team, queue, report). Password sessions
-   proxy through the PDS; OAuth mints [getServiceAuth] and calls the
-   Ozone host (DPoP cannot be proxied).}
-{- {b Chat client.} {!Atproto.Chat} is [chat.bsky.*] with
-   [atproto-proxy] ([did:web:api.bsky.chat#bsky_chat], the session
-   [#bsky_chat] service, or [ATP_CHAT_DID]). There is no official OSS
-   chat backend in [@atproto/dev-env] 0.6.4.}}
+Auth / Session
 
-Related protocol pieces live beside that map: {!Atproto.Repo} and
-{!Atproto.Records} for writes, {!Atproto.Server} and {!Atproto.Sync}
-for account/repo HTTP, {!Atproto.Label} for [queryLabels],
-{!Atproto.Lexicon} for lexicon-1 parse/validate/codegen, and
-{!Atproto.Http_client} for HTTP/2 XRPC that keeps status and
-rate-limit headers.
+{!modules: Atproto.Auth Atproto.Session}
+
+XRPC
+
+{!modules: Atproto.Xrpc}
+
+Identity / PLC
+
+{!modules: Atproto.Identity Atproto.Did_plc Atproto.Did_web Atproto.Did_key}
+
+MST / CID / CAR
+
+{!modules: Atproto.Mst Atproto.Cid Atproto.Car Atproto.Dag_cbor Atproto.Repo_sync}
+
+Firehose / Jetstream
+
+{!modules: Atproto.Firehose Atproto.Jetstream}
+
+OAuth / DPoP
+
+{!modules: Atproto.Oauth Atproto.Oauth_scope}
+
+AppView
+
+{!modules: Atproto.Actor Atproto.Feed Atproto.Graph Atproto.Bookmark Atproto.Notification Atproto.Labeler Atproto.Unspecced Atproto.Video}
+
+Ozone
+
+{!modules: Atproto.Ozone}
+
+Chat client
+
+{!modules: Atproto.Chat}
+
+Also {!Atproto.Repo}, {!Atproto.Records}, {!Atproto.Server},
+{!Atproto.Sync}, {!Atproto.Label}, {!Atproto.Lexicon}, and
+{!Atproto.Http_client}.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Independent of [#113](https://github.com/david-engelmann/atproto/pull/113): **new files and unused-by-#113 templates only**. Does not touch README, CONTRIBUTING, CHANGELOG, `dune-project`, `atproto.opam`, `test_suite.yml`, `Label.subscribe_url`, `jetstream_zstd_dictionary.ml`, or any other #113 path. Both PRs can merge independently.

The protocol client is complete at lexicon pin `60c4395951` except product-level hosted-only gaps. This PR is automation plus a real odoc landing page — not another protocol slice.

## What this adds

1. **`doc/index.mld` + `doc/dune`** (`(documentation (package atproto))`)
   - Replaces the default odoc package page with a landing: short pitch, `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`, OCaml `>= 4.14.1` and `< 5.0`, live docs at https://david-engelmann.github.io/atproto/, and a `{!modules: ...}` map (Auth/Session, XRPC, identity/PLC, MST/CID/CAR, firehose/Jetstream, OAuth/DPoP, AppView, Ozone, chat client).
   - Does not claim opam-repository. Does not claim a hosted PDS, OSS chat backend, video transcoder, or Tap.

2. **`.github/dependabot.yml`**
   - `github-actions`, weekly on Monday (weekday), grouped, PRs against `main`.
   - `npm` for `/docker/dev-env` (confirmed `package.json`: pinned `@atproto/dev-env@0.6.4`).
   - No `docker` ecosystem: `docker/dev-env` has compose.yaml but no Dockerfiles. No `gomod`.

3. **`.github/workflows/lexicon-pin.yml`**
   - `pull_request` + weekday cron `30 13 * * 1-5` (13:30 UTC / 9:30 AM ET) + `workflow_dispatch`.
   - Compares `bluesky-social/atproto` `lexicons/` against the SHA in `lexicons/official-nsids.json` via `gh api` compare (`actions/checkout@v5`, `contents: read`). Truncated compares fall back to two shallow `git fetch`s.
   - Zero lexicon-path changes → success (today: official is 4 commits ahead, 0 lexicon files).
   - Lexicon-path changes → fail and print the paths. Does **not** auto-bump the pin.
   - Does not rewrite `test_suite.yml`.

4. **Repo automation leftovers (still unused by #113)**
   - `.github/CODEOWNERS` — `* @david-engelmann`
   - `.github/PULL_REQUEST_TEMPLATE.md` — short checklist (OCaml 4.14 only, no opam-repository publish, no pin bump without `gen-official-nsids.py` + coverage, no fake chat/video/Tap, no invented Jetstream archive token, module odoc, CHANGELOG)
   - `.github/ISSUE_TEMPLATE/config.yml` — contact link to https://david-engelmann.github.io/atproto/
   - Existing issue templates get YAML front matter so GitHub lists them; stock Browser/iPhone fields replaced with OCaml / opam / `ATP_HOST`

## Out of scope

No opam-repository publish, no invented Jetstream archive token, no fake OSS chat, no leftover-field hunt, no lexicon pin bump, no `Label.subscribe_url`, no README/CONTRIBUTING rewrite.

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea5a97bf-5c7a-41ab-af32-23fe06c1c864?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea5a97bf-5c7a-41ab-af32-23fe06c1c864&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

