### PR TITLE
Odoc public entry points (resolve_handle, create_session, get_profile)

### DIFF
--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -498,6 +498,8 @@ module Actor = struct
   let create_actor_endpoint (query_name : string) : string =
     "app.bsky.actor" ^ "." ^ query_name
 
+  (** Profile view for [actor] (handle or DID) via
+      [app.bsky.actor.getProfile]. *)
   let get_profile (s : Session.session) (actor : string) : profile =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -517,6 +519,7 @@ module Actor = struct
     let profile_json = profile |> convert_body_to_json in
     profile_json |> parse_profile
 
+  (** Profile views for several actors via [app.bsky.actor.getProfiles]. *)
   let get_profiles (s : Session.session) (actors : string list) : profile list =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -888,6 +891,7 @@ module Actor = struct
   let put_preferences_body preferences : Yojson.Safe.t =
     `Assoc [ ("preferences", `List preferences) ]
 
+  (** The session's stored preferences ([app.bsky.actor.getPreferences]). *)
   let get_preferences (s : Session.session) : preferences =
     Client.Client.get_json ~session:s "app.bsky.actor.getPreferences" []
     |> parse_preferences

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -1056,6 +1056,9 @@ module Feed = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_generators
 
+  (** Paginated author feed ([app.bsky.feed.getAuthorFeed]). Works without a
+      session against public AppView. [filter] uses the lexicon knownValues
+      ([filter_posts_no_replies], ...). *)
   let get_author_feed_page ?session ?host ~actor ?limit ?cursor ?filter
       ?include_pins () : timeline =
     Client.Client.get_json ?session ?host "app.bsky.feed.getAuthorFeed"
@@ -1083,6 +1086,8 @@ module Feed = struct
       []
     |> parse_describe_feed_generator
 
+  (** Search posts ([app.bsky.feed.searchPosts]). Works without a session
+      against public AppView. *)
   let search_posts ?session ?host ~q ?sort ?since ?until ?mentions ?author ?lang
       ?domain ?url ?limit ?cursor () : search_posts =
     Client.Client.get_json ?session ?host "app.bsky.feed.searchPosts"

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -395,6 +395,8 @@ module Firehose = struct
            (Cid.to_string signed.data));
     tree
 
+  (** Receive one [com.atproto.sync.subscribeRepos] frame from the relay
+      (default [bsky.network]). Optional [host] and [cursor]. *)
   let subscribe_one ?host ?cursor () : header * message =
     let cell = ref None in
     subscribe ?host ?cursor ~max_messages:1 (fun frame -> cell := Some frame);

--- a/src/identity.ml
+++ b/src/identity.ml
@@ -92,6 +92,9 @@ module Identity = struct
     | None -> rest
     | Some i -> String.sub rest 0 i
 
+  (** Resolve [handle] to a DID via [com.atproto.identity.resolveHandle].
+      Optional [host] / [session] select the PDS; otherwise [ATP_HOST] or
+      [bsky.social]. *)
   let resolve_handle ?host ?session (handle : string) : resolved_handle =
     get_json ?host ?session
       (create_identity_endpoint "resolveHandle")
@@ -127,6 +130,9 @@ module Identity = struct
   let resolve_did_via_directory ?host ?session (did : string) : Yojson.Safe.t =
     `Assoc [ ("didDoc", document_json_of_did ?host ?session did) ]
 
+  (** Fetch a DID document via [com.atproto.identity.resolveDid].
+      Falls back to the PLC directory or did:web when the PDS returns
+      [MethodNotImplemented] (common on PDS 0.5.x). *)
   let resolve_did ?host ?session (did : string) : Yojson.Safe.t =
     let json =
       get_json_allow_error ?host ?session
@@ -226,6 +232,8 @@ module Identity = struct
         (try Some (document_json_of_did ?host ?session did) with _ -> None);
     }
 
+  (** Resolve a handle or DID to [did], [handle], and optional [didDoc].
+      Same XRPC-then-directory fallback as {!resolve_did}. *)
   let resolve_identity ?host ?session (identifier : string) : identity_info =
     let json =
       get_json_allow_error ?host ?session

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -338,9 +338,9 @@ module Oauth = struct
   let form_decode_value s =
     Uri.pct_decode (String.map (function '+' -> ' ' | c -> c) s)
 
-  (* Official loopback client_id. The AS synthesizes metadata from this query
-     ([atprotoLoopbackClientMetadata]); [scope] must list every scope PAR will
-     request. *)
+  (** Official loopback [client_id]. The authorization server synthesizes
+      metadata from this query ([atprotoLoopbackClientMetadata]); [scope]
+      must list every scope PAR will request. *)
   let loopback_client_id ?(redirect_uri = "http://127.0.0.1/")
       ?(scope = default_scope) () : string =
     "http://localhost?"
@@ -470,6 +470,8 @@ module Oauth = struct
   let contains_scope ~scope needle =
     List.mem needle (String.split_on_char ' ' scope)
 
+  (** Public client metadata for a hosted HTTPS [client_id]
+      ([token_endpoint_auth_method] = [none], DPoP-bound access tokens). *)
   let public_metadata ~client_id ~redirect_uris ?(scope = default_scope)
       ?(application_type = "web") ?client_name ?client_uri ?logo_uri ?tos_uri
       ?policy_uri () : client_metadata =

--- a/src/request.ml
+++ b/src/request.ml
@@ -26,6 +26,8 @@ module Request = struct
   let delete url ?(headers = []) ?body () : request =
     create ~method_:Http_method.Delete ~url ~headers ?body ()
 
+  (**/**)
+
   let sample_request_with_body : request =
     {
       method_ = Http_method.Get;
@@ -44,4 +46,6 @@ module Request = struct
 
   let test_get : Http_method.http_method = Http_method.Get
   let test_post : Http_method.http_method = Http_method.Post
+
+  (**/**)
 end

--- a/src/session.ml
+++ b/src/session.ml
@@ -68,6 +68,9 @@ module Session = struct
     in
     atp_host
 
+  (** Create a password session ([com.atproto.server.createSession]) on
+      [ATP_HOST] (default [bsky.social]). Optional [auth_factor_token] and
+      [allow_takendown] map to the lexicon inputs. *)
   let create_session ?auth_factor_token ?allow_takendown (username : string)
       (password : string) : session =
     let atp_host = atp_host_from_env in
@@ -111,6 +114,8 @@ module Session = struct
     in
     session
 
+  (** Current account info for [s] via [com.atproto.server.getSession]
+      (handle, DID, email flags, active/status). *)
   let get_session (s : session) : session_request =
     Yojson.Safe.from_string (get_session_request s) |> parse_session_request
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds function-level `(** *)` odoc on the public values a new user actually calls. Module-level comments were already present; the live Identity odoc page only showed that one-liner because the values had no attached docs.

## Documented

- `Identity.resolve_handle`, `resolve_did`, `resolve_identity`
- `Session.create_session`, `get_session`
- `Actor.get_profile`, `get_profiles`, `get_preferences`
- `Feed.search_posts`, `Feed.get_author_feed_page` (the public AppView helpers)
- `Oauth.public_metadata`, `Oauth.loopback_client_id` (existing loopback note promoted to odoc)
- `Firehose.subscribe_one`

Comments are 1–3 sentences, no behavior changes, no private helpers.

## Request test fixtures

`Request.sample_request_with_body` / `sample_request_without_body` / `test_get` / `test_post` are test fixtures (used by `test/test_request.ml`, not by `examples/offline.ml`). There are no `.mli` files, so removing them would be an unverified public API break. They stay callable; `(**/**)` hides them from generated odoc.

## Out of scope

No README, `index.mld`, opam, or pin changes. Files owned by #113 / #114 were not touched.

## CHANGELOG (not edited)

#113 owns `CHANGELOG.md`. After merge, a Docs bullet such as: function-level odoc on public entry points (`resolve_handle`, `create_session`, `get_profile`, `search_posts`, `get_author_feed_page`, `public_metadata`, `loopback_client_id`, `subscribe_one`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc822c25-1ab3-41bb-a804-53b9744a0c69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc822c25-1ab3-41bb-a804-53b9744a0c69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

