### PR TITLE
Quick start, make doc, and live ozone template/set writes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,8 @@ odoc HTML is a CI artifact (`odoc-html`) on pull requests. On push to
 Actions Pages. GitHub Pages is enabled (Settings → Pages → Source:
 GitHub Actions). The live site is
 https://david-engelmann.github.io/atproto/. `dune-project`
-`documentation` points at that URL.
+`documentation` points at that URL. Build odoc locally with
+`make doc`.
 
 ## Checks
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ clean:
 test:
 	dune runtest
 
+doc:
+	dune build @doc
+
 pds-up atproto-up:
 	./scripts/local-atproto.sh up
 
@@ -58,4 +61,4 @@ test-pds-run test-atproto-run:
 	dune exec -- test/test_local_ozone.exe; \
 	dune exec -- test/test_local_oauth.exe
 
-.PHONY: default install uninstall reinstall lint clean test pds-up pds-down pds-account pds-logs atproto-up atproto-down atproto-account atproto-logs test-pds test-atproto test-pds-run test-atproto-run
+.PHONY: default install uninstall reinstall lint clean test doc pds-up pds-down pds-account pds-logs atproto-up atproto-down atproto-account atproto-logs test-pds test-atproto test-pds-run test-atproto-run

--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ In a dependent `dune` stanza:
 
 Version notes for **0.1.0** (the packaged surface through [#113](https://github.com/david-engelmann/atproto/pull/113)) are in [CHANGELOG.md](CHANGELOG.md). Module HTML from `dune build @doc` is uploaded as the `odoc-html` TestSuite artifact on pull requests. On push to `main`, the same HTML is deployed with GitHub Actions Pages (`actions/upload-pages-artifact` + `actions/deploy-pages`) to https://david-engelmann.github.io/atproto/. GitHub Pages is enabled (Settings → Pages → Source: GitHub Actions). `dune-project` `documentation` points at that live URL.
 
+## Quick start
+
+Pin the repo, then resolve a handle and search posts. Neither call needs `ATP_AUTH`:
+
+```shell
+opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+```
+
+```ocaml
+(* public AppView, no ATP_AUTH *)
+let did = (Identity.resolve_handle "jay.bsky.team").did
+let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
+```
+
+`examples/quickstart.ml` is that flow as a copy-paste executable (`dune exec -- examples/quickstart.exe`).
+
+## Docs
+
+Module HTML is at https://david-engelmann.github.io/atproto/. Build it locally with `dune build @doc` or `make doc`.
+
 ## Environment
 
 Create a `.env` (see `sample.env`) with at least:

--- a/examples/dune
+++ b/examples/dune
@@ -5,6 +5,13 @@
  (libraries atproto yojson)
  (modules offline))
 
+(executable
+ (name quickstart)
+ (flags
+  (:standard -w +33 -warn-error +33))
+ (libraries atproto)
+ (modules quickstart))
+
 (rule
  (alias runtest)
  (action

--- a/examples/quickstart.ml
+++ b/examples/quickstart.ml
@@ -1,0 +1,10 @@
+(* Copy-paste public AppView example. No ATP_AUTH. *)
+
+open Atproto.Identity
+open Atproto.Feed
+
+let () =
+  let did = (Identity.resolve_handle "jay.bsky.team").did in
+  Printf.printf "jay.bsky.team -> %s\n%!" did;
+  let posts = Feed.search_posts ~q:"atproto" ~limit:5 () in
+  Printf.printf "searchPosts %d\n%!" (List.length posts.posts)

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -971,25 +971,33 @@ module Ozone = struct
       "tools.ozone.communication.listTemplates" []
     |> parse_templates
 
-  let create_template_body ~name ~content_markdown ?subject ?lang () :
-      Yojson.Safe.t =
+  let create_template_body ~name ~content_markdown ?subject ?lang ?created_by ()
+      : Yojson.Safe.t =
     `Assoc
       ([ ("name", `String name); ("contentMarkdown", `String content_markdown) ]
       @ (match subject with Some s -> [ ("subject", `String s) ] | None -> [])
-      @ match lang with Some s -> [ ("lang", `String s) ] | None -> [])
+      @ (match lang with Some s -> [ ("lang", `String s) ] | None -> [])
+      @
+      match created_by with
+      | Some d -> [ ("createdBy", `String d) ]
+      | None -> [])
 
   let create_template (s : Session.session) ~proxy ~name ~content_markdown
-      ?subject ?lang () : template =
+      ?subject ?lang ?created_by () : template =
+    let created_by = Option.value created_by ~default:s.auth.did in
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.communication.createTemplate"
       (Yojson.Safe.to_string
-         (create_template_body ~name ~content_markdown ?subject ?lang ()))
+         (create_template_body ~name ~content_markdown ?subject ?lang
+            ~created_by ()))
     |> parse_template
 
   let update_template (s : Session.session) ~proxy ~id ?name ?content_markdown
-      ?subject ?disabled () : template =
+      ?subject ?disabled ?updated_by () : template =
+    let updated_by = Option.value updated_by ~default:s.auth.did in
     let fields =
       ("id", `String id)
+      :: ("updatedBy", `String updated_by)
       :: (match name with Some n -> [ ("name", `String n) ] | None -> [])
       @ (match content_markdown with
         | Some c -> [ ("contentMarkdown", `String c) ]

--- a/test/test_local_ozone.ml
+++ b/test/test_local_ozone.ml
@@ -555,7 +555,7 @@ let test_template_and_set_writes _ =
   (match
      ozone_post s p "tools.ozone.communication.createTemplate"
        (Ozone.create_template_body ~name:tmpl_name ~content_markdown:"hi"
-          ~subject:"welcome" ())
+          ~subject:"welcome" ~created_by:s.auth.did ())
    with
   | json when served json ->
       let created = Ozone.parse_template json in

--- a/test/test_local_ozone.ml
+++ b/test/test_local_ozone.ml
@@ -545,6 +545,86 @@ let test_privileged_writes _ =
             >= 0))
   | _ -> ()
 
+(* Template / set writes + cheap leftover reads. Skip if not served. *)
+let test_template_and_set_writes _ =
+  let s = admin_session () in
+  let p = proxy () in
+  let alice = Session.create_session "alice.test" "hunter2" in
+  let tag = leftover_tag () in
+  let tmpl_name = "ocaml-tmpl-" ^ tag in
+  (match
+     ozone_post s p "tools.ozone.communication.createTemplate"
+       (Ozone.create_template_body ~name:tmpl_name ~content_markdown:"hi"
+          ~subject:"welcome" ())
+   with
+  | json when served json ->
+      let created = Ozone.parse_template json in
+      OUnit2.assert_bool "createTemplate id" (String.length created.id > 0);
+      let updated =
+        Ozone.update_template s ~proxy:p ~id:created.id
+          ~content_markdown:("updated " ^ tag) ()
+      in
+      OUnit2.assert_equal created.id updated.id;
+      let typed =
+        Ozone.create_template s ~proxy:p ~name:(tmpl_name ^ "-b")
+          ~content_markdown:"typed" ~subject:"welcome" ()
+      in
+      OUnit2.assert_bool "create_template helper" (String.length typed.id > 0);
+      Ozone.delete_template s ~proxy:p ~id:created.id ();
+      Ozone.delete_template s ~proxy:p ~id:typed.id ()
+  | _ -> ());
+  let set_name = "ocaml-set-" ^ tag in
+  (match
+     ozone_post s p "tools.ozone.set.upsertSet"
+       (`Assoc
+         [ ("name", `String set_name); ("description", `String ("set " ^ tag)) ])
+   with
+  | json when served json ->
+      let created =
+        Ozone.upsert_set s ~proxy:p ~name:set_name ~description:("set " ^ tag)
+          ()
+      in
+      OUnit2.assert_equal ~printer:(fun x -> x) set_name created.name;
+      Ozone.add_set_values s ~proxy:p ~name:set_name ~values:[ tag ] ();
+      (match
+         ozone_json s p "tools.ozone.set.getValues" [ ("name", set_name) ]
+       with
+      | values when served values ->
+          let got = Ozone.get_set_values s ~proxy:p ~name:set_name () in
+          OUnit2.assert_bool "addValues" (List.mem tag got.values)
+      | _ -> ());
+      Ozone.delete_set s ~proxy:p ~name:set_name ()
+  | _ -> ());
+  (match
+     ozone_post s p "tools.ozone.safelink.queryEvents"
+       (Ozone.query_safelink_events_body ~limit:10 ())
+   with
+  | json when served json ->
+      let events = Ozone.query_safelink_events s ~proxy:p ~limit:10 () in
+      OUnit2.assert_bool "queryEvents" (List.length events.events >= 0)
+  | _ -> ());
+  match
+    ozone_post s p "tools.ozone.moderation.scheduleAction"
+      (Ozone.schedule_action_body
+         ~action:(Ozone.takedown_action ~comment:("sched " ^ tag) ())
+         ~subjects:[ alice.auth.did ] ~created_by:s.auth.did
+         ~scheduling:
+           {
+             execute_at = Some "2099-01-01T00:00:00.000Z";
+             execute_after = None;
+             execute_until = None;
+           }
+         ())
+  with
+  | json when served json ->
+      let scheduled = Ozone.parse_batch_result json in
+      OUnit2.assert_bool "scheduleAction parsed"
+        (List.length scheduled.succeeded + List.length scheduled.failed >= 0);
+      ignore
+        (Ozone.cancel_scheduled_actions s ~proxy:p ~subjects:[ alice.auth.did ]
+           ~comment:("cancel " ^ tag) ())
+  | _ -> ()
+
 let suite =
   "local_ozone"
   >::: [
@@ -555,6 +635,7 @@ let suite =
          "test_more_ozone" >:: test_more_ozone;
          "test_leftover_ozone" >:: test_leftover_ozone;
          "test_privileged_writes" >:: test_privileged_writes;
+         "test_template_and_set_writes" >:: test_template_and_set_writes;
        ]
 
 let () =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recreates the unique leftover from closed [#115](https://github.com/david-engelmann/atproto/pull/115) against current `main` (includes merged [#113](https://github.com/david-engelmann/atproto/pull/113) `68318876` — Pages docs URL + `Label.subscribe_url` `ws://`). Does **not** revive #115.

## What this does

- **Live ozone writes** in `test/test_local_ozone.ml`: `tools.ozone.communication.createTemplate` (+ `updateTemplate` / `deleteTemplate`) via `Ozone.create_template` / `update_template` / `delete_template`, and `tools.ozone.set.upsertSet` (+ `addValues`) via `Ozone.upsert_set` / `add_set_values`. Same `served` skip as the rest of the file (not-served / cannot-moderate). Cheap same-class extras: `tools.ozone.safelink.queryEvents` and `tools.ozone.moderation.scheduleAction` (far-future takedown + cancel). Does not call `hosting.getAccountHistory` or `signature.*` (not in ozone 0.3.1).
- **Ozone 0.3.1 `createdBy`**: TestNetwork rejects `createTemplate` without `createdBy`. `Ozone.create_template` / `create_template_body` now send it (session DID by default). `update_template` sends `updatedBy` the same way.
- **README Quick start** after Install: `opam pin` + public `Identity.resolve_handle` / `Feed.search_posts` (no `ATP_AUTH`). First-class **Docs** heading for https://david-engelmann.github.io/atproto/ plus `dune build @doc` / `make doc`. Coverage table and OAuth TestNetwork prose are unchanged.
- **`examples/quickstart.ml`**: short copy-paste executable in `examples/dune` (no runtest; public network). `examples/offline.ml` is unchanged.
- **Makefile `doc`**: `dune build @doc`. One line in `.github/CONTRIBUTING.md` that you build odoc locally with `make doc`.

## Out of scope / notes

- No CHANGELOG edit (mention here only). Version notes stay on #113 until the next changelog pass.
- No opam publish, no pin bump, no fake chat/video/Tap.
- Does not touch #114 (`doc/index.mld`, `doc/dune`, dependabot, lexicon-pin), #116 (local PDS/AppView tests), or #117 (identity/session/actor/feed/oauth/firehose/request).

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5122d56-ff51-4d4d-917e-7a5b60f8a21b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5122d56-ff51-4d4d-917e-7a5b60f8a21b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

