### PR TITLE
Odoc Graph, Ozone, Repo, Sync, MST, Jetstream entry points

### DIFF
--- a/src/bsky/bookmark.ml
+++ b/src/bsky/bookmark.ml
@@ -63,6 +63,8 @@ module Bookmark = struct
   let delete_bookmark_body ~uri : Yojson.Safe.t =
     `Assoc [ ("uri", `String uri) ]
 
+  (** Bookmark [uri] / [cid] via [app.bsky.bookmark.createBookmark] (auth
+      required). *)
   let create_bookmark (s : Session.session) ~uri ~cid () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.bookmark.createBookmark"
@@ -73,6 +75,7 @@ module Bookmark = struct
       (Client.post_json ~session:s "app.bsky.bookmark.deleteBookmark"
          (Yojson.Safe.to_string (delete_bookmark_body ~uri)))
 
+  (** The session's bookmarks via [app.bsky.bookmark.getBookmarks]. *)
   let get_bookmarks (s : Session.session) ?limit ?cursor () : bookmarks =
     Client.get_json ~session:s "app.bsky.bookmark.getBookmarks"
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -100,6 +100,7 @@ module Graph = struct
     in
     blocks |> convert_body_to_json |> parse_blocks
 
+  (** Followers of [actor] (handle or DID) via [app.bsky.graph.getFollowers]. *)
   let get_followers (s : Session.session) (actor : string) (limit : int) :
       followers =
     let bearer_token = Session.bearer_token_from_session s in
@@ -128,6 +129,7 @@ module Graph = struct
       (follow_page_pairs ~actor ?limit ?cursor ?sort ())
     |> parse_followers
 
+  (** Accounts [actor] follows via [app.bsky.graph.getFollows]. *)
   let get_follows (s : Session.session) (actor : string) (limit : int) : follows
       =
     let bearer_token = Session.bearer_token_from_session s in
@@ -191,6 +193,9 @@ module Graph = struct
     in
     `Assoc fields
 
+  (** Mute [actor] via [app.bsky.graph.muteActor]. Optional [only_reposts] /
+      [only_quoteposts] store a scoped mute; later calls replace the stored
+      scope. *)
   let mute_actor (s : Session.session) ?only_reposts ?only_quoteposts
       (actor : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -679,6 +684,8 @@ module Graph = struct
           | _ -> []);
     }
 
+  (** List view and items for [list] (AT URI) via [app.bsky.graph.getList].
+      Works without a session against public AppView. *)
   let get_list ?session ?host ~list ?limit ?cursor () : list_page =
     Client.Client.get_json ?session ?host "app.bsky.graph.getList"
       ((("list", list) :: Client.Client.opt_int "limit" limit)

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -337,6 +337,9 @@ module Notification = struct
     in
     unread_count |> convert_body_to_json |> parse_unread_count
 
+  (** Notifications for the session via
+      [app.bsky.notification.listNotifications]. Optional [reasons] /
+      [priority] / [cursor] / [seen_at] map to the lexicon query. *)
   let list_notifications (s : Session.session) ?reasons ?priority ?cursor
       ?seen_at (limit : int) : notification list =
     Client.Client.get_json ~session:s "app.bsky.notification.listNotifications"

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -60,6 +60,9 @@ module Chat = struct
     try chat_proxy_of_document (Did_plc.Did_plc.parse_document json)
     with _ -> None
 
+  (** [atproto-proxy] for chat XRPC: explicit [proxy], else the chat service
+      in [did_doc], else [ATP_CHAT_DID], else [did:web:api.bsky.chat]. This
+      is a client for the hosted chat service, not an OSS chat backend. *)
   let effective_proxy ?proxy ?did_doc () : Xrpc.proxy =
     match proxy with
     | Some p -> p
@@ -541,6 +544,8 @@ module Chat = struct
     in
     `Assoc fields
 
+  (** Conversations via [chat.bsky.convo.listConvos]. Always sends
+      [atproto-proxy] ([effective_proxy]). *)
   let list_convos (s : Session.session) ?proxy ?limit ?cursor ?read_state
       ?status ?kind () : convos =
     Client.get_json ~session:s

--- a/src/jetstream.ml
+++ b/src/jetstream.ml
@@ -128,6 +128,9 @@ module Jetstream = struct
     | V2, Some n when n > 0 -> [ ("maxMessageSizeBytes", string_of_int n) ]
     | _ -> []
 
+  (** WebSocket URL for [network.bsky.jetstream.subscribeEvents] (v2) or
+      [/subscribe] (v1). Optional [filter] and [compress] become query
+      params; v2 dict-zstd uses [zstdDictionary=<id>]. *)
   let subscribe_url ?(host = default_host) ?(version = V2)
       ?(filter = empty_filter) ?(compress = false) ?zstd_dictionary_id () =
     validate_filter filter;
@@ -573,6 +576,8 @@ module Jetstream = struct
     in
     attempt 0
 
+  (** Receive one Jetstream event. v2 offers
+      [Sec-WebSocket-Protocol: xrpc.v1.json] (the server must echo it). *)
   let subscribe_one ?host ?version ?filter ?(compress = false) () : event =
     let cell = ref None in
     subscribe ?host ?version ?filter ~compress ~max_messages:1 ~max_reconnects:0

--- a/src/mst.ml
+++ b/src/mst.ml
@@ -39,6 +39,8 @@ module Mst = struct
     in
     loop 0 0
 
+  (** MST layer (height) for [key]: leading zero bits of SHA-256([key])
+      divided by 2 (fanout 4). Official vector: [layer_for_key "blue" = 1]. *)
   let layer_for_key (key : string) : int = leading_zeros_on_hash key / 2
 
   let common_prefix_len (a : string) (b : string) : int =
@@ -179,6 +181,8 @@ module Mst = struct
         check_child node.left;
         List.iter (fun r -> check_child r.right) items
 
+  (** Look up [key] in the MST rooted at [root], loading nodes through
+      [get_block]. Returns the record CID, or [None] if missing. *)
   let rec lookup ~(get_block : Cid.t -> string option) (root : Cid.t)
       (key : string) : Cid.t option =
     match get_block root with
@@ -643,6 +647,8 @@ module Mst = struct
       in
       (create_tree t.store ~layer:key_layer entries, None)
 
+  (** Insert or replace [key] with [value]. Returns the updated tree and the
+      previous CID when the key already existed. Empty keys fail. *)
   let insert (t : tree) (key : string) (value : Cid.t) : tree * Cid.t option =
     if key = "" then fail "MST insert: empty key";
     insert_rec t key value (layer_for_key key)

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -604,6 +604,8 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_statuses
 
+  (** Moderation events via [tools.ozone.moderation.queryEvents]. Password
+      [at+jwt] sessions send [atproto-proxy] through the PDS. *)
   let query_events (s : Session.session) ~proxy ?host ?types ?created_by
       ?subject ?limit ?cursor () : events =
     Client.get_json ~session:s ?host ~extra:(proxy_headers proxy)
@@ -615,6 +617,8 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_events
 
+  (** Emit a moderation event via [tools.ozone.moderation.emitEvent]. Password
+      [at+jwt] sessions send [atproto-proxy] through the PDS. *)
   let emit_event (s : Session.session) ~proxy ?host ~event ~subject ~created_by
       ?subject_blob_cids ?external_id ?mod_tool ?report_action () : mod_event =
     Client.post_json ~session:s ?host ~extra:(proxy_headers proxy)
@@ -667,6 +671,8 @@ module Ozone = struct
       (("uri", uri) :: Client.opt_pair "cid" cid)
     |> parse_record
 
+  (** Ozone server config via [tools.ozone.server.getConfig] ([appview] /
+      [pds] / [chat] / [viewer.role]). *)
   let get_config (s : Session.session) ~proxy ?host () : server_config =
     Client.get_json ~session:s ?host ~extra:(proxy_headers proxy)
       "tools.ozone.server.getConfig" []

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -192,6 +192,8 @@ module Repo = struct
     in
     repo_description
 
+  (** Fetch a record via [com.atproto.repo.getRecord]. Returns the raw JSON
+      body. *)
   let get_record (s : Session.session) (repo : string) (collection : string)
       (rkey : string) (cid : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -246,6 +248,9 @@ module Repo = struct
     in
     records
 
+  (** Create a record via [com.atproto.repo.createRecord]. [record] is a JSON
+      object string; optional [rkey] and [swap_commit] map to the lexicon
+      inputs. *)
   let create_record (s : Session.session) (repo : string) (collection : string)
       ?rkey ?(validate = true) ?swap_commit (record : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -397,6 +402,8 @@ module Repo = struct
     in
     `Assoc fields
 
+  (** Apply a batch of create/update/delete ops via
+      [com.atproto.repo.applyWrites]. Returns the raw JSON body. *)
   let apply_writes (s : Session.session) ~repo ~writes ?validate ?swap_commit ()
       : string =
     let bearer_token = Session.bearer_token_from_session s in

--- a/src/sync.ml
+++ b/src/sync.ml
@@ -110,12 +110,17 @@ module Sync = struct
   let optional_pairs pairs =
     List.filter_map (fun (k, v) -> Option.map (fun x -> (k, x)) v) pairs
 
+  (** Latest commit CID and rev for [did] via
+      [com.atproto.sync.getLatestCommit]. Optional [host] / [session] select
+      the PDS; otherwise [ATP_HOST] or [bsky.social]. *)
   let get_latest_commit ?host ?session (did : string) : latest_commit =
     request_json ?host ?session
       (create_sync_endpoint "getLatestCommit")
       [ ("did", did) ]
     |> parse_latest_commit
 
+  (** Full repo CAR bytes for [did] via [com.atproto.sync.getRepo]. Optional
+      [since] is a rev to diff from. *)
   let get_repo ?host ?session ?since (did : string) : string =
     request_bytes ?host ?session
       (create_sync_endpoint "getRepo")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Function-level `(** *)` odoc on public entry points a new user actually calls in modules #117 did not cover. Module-level comments were already present; no behavior changes, no private helpers, no leftover fields.

## Documented

- `Graph.get_follows`, `get_followers`, `mute_actor`, `get_list`
- `Ozone.emit_event`, `query_events`, `get_config` (password `at+jwt` + `atproto-proxy`)
- `Repo.create_record`, `get_record`, `apply_writes`
- `Sync.get_latest_commit`, `get_repo`
- `Mst.layer_for_key`, `insert`, `lookup` (layer comment matches official vectors, e.g. `layer_for_key "blue" = 1`)
- `Jetstream.subscribe_url`, `subscribe_one`
- `Chat.list_convos`, `Chat.effective_proxy` (hosted chat client; no OSS backend claim)
- `Bookmark.get_bookmarks`, `create_bookmark`
- `Notification.list_notifications`

Comments are 1–3 sentences. Files owned by #117 (`identity.ml`, `session.ml`, `actor.ml`, `feed.ml`, `oauth.ml`, `firehose.ml`, `request.ml`) were not restyled.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing headers unchanged)
- [ ] User-facing change is noted in CHANGELOG.md

## CHANGELOG (not edited)

#121 owns `CHANGELOG.md`. After merge, a Docs bullet such as: function-level odoc on Graph, Ozone, Repo, Sync, MST, Jetstream, Chat, Bookmark, and Notification entry points (`get_follows`, `emit_event`, `create_record`, `get_latest_commit`, `layer_for_key`, `subscribe_url`, `list_convos`, `get_bookmarks`, `list_notifications`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d31790a-8477-4898-9d68-3c25f461c505?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d31790a-8477-4898-9d68-3c25f461c505&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

