### PR TITLE
Odoc Label, Video, CID/CAR, PLC, Records entry points

### DIFF
--- a/src/admin.ml
+++ b/src/admin.ml
@@ -181,6 +181,8 @@ module Admin = struct
     in
     `Assoc fields
 
+  (** Subject status (takedown / deactivated) via
+      [com.atproto.admin.getSubjectStatus]. Pass [did], [uri], or [blob]. *)
   let get_subject_status (s : Session.session) ?did ?uri ?blob () :
       subject_status =
     Client.get_json ~session:s "com.atproto.admin.getSubjectStatus"
@@ -188,6 +190,8 @@ module Admin = struct
       @ Client.opt_pair "blob" blob)
     |> parse_subject_status
 
+  (** Update takedown / deactivated flags via
+      [com.atproto.admin.updateSubjectStatus]. *)
   let update_subject_status (s : Session.session) ~subject ?takedown
       ?deactivated () : subject_status =
     Client.post_json ~session:s "com.atproto.admin.updateSubjectStatus"
@@ -195,6 +199,7 @@ module Admin = struct
          (update_subject_status_body ~subject ?takedown ?deactivated ()))
     |> parse_subject_status
 
+  (** Account view for [did] via [com.atproto.admin.getAccountInfo]. *)
   let get_account_info (s : Session.session) ~did () : account_info =
     Client.get_json ~session:s "com.atproto.admin.getAccountInfo"
       [ ("did", did) ]
@@ -209,6 +214,8 @@ module Admin = struct
       | [] -> Client.list_member json "accounts"
       | xs -> xs)
 
+  (** Search accounts via [com.atproto.admin.searchAccounts]. Optional
+      [email] / [cursor] map to the lexicon query. *)
   let search_accounts (s : Session.session) ?email ?cursor () : accounts =
     Client.get_json ~session:s "com.atproto.admin.searchAccounts"
       (Client.opt_pair "email" email @ Client.opt_pair "cursor" cursor)

--- a/src/at_uri.ml
+++ b/src/at_uri.ml
@@ -52,6 +52,8 @@ module Uri = struct
       in
       Some pairs
 
+  (** Parse an [at://] URI. Fails on a missing [at://] prefix, empty
+      authority, trailing slash, or more than two path segments. *)
   let of_string (raw : string) : t =
     let s =
       if String.length raw >= 5 && String.sub raw 0 5 = "at://" then

--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -693,6 +693,7 @@ module Embed = struct
       else `Record (parse_record_embed json)
     else `Unknown json
 
+  (** [chat.bsky.embed.joinLink] embed for invite [code]. *)
   let join_link ~code () : embed =
     `JoinLink { embed_type = "chat.bsky.embed.joinLink"; code }
 

--- a/src/bsky/facet.ml
+++ b/src/bsky/facet.ml
@@ -137,6 +137,8 @@ module Facet = struct
   let facets_to_json (fs : facet list) : Yojson.Safe.t =
     `List (List.map facet_to_json fs)
 
+  (** Mention facet for [did] covering UTF-8 bytes from [byte_start]
+      (inclusive) to [byte_end] (exclusive). *)
   let mention ~byte_start ~byte_end did : facet =
     `Mention
       {
@@ -145,6 +147,8 @@ module Facet = struct
         features = [ { did; mention_type = "app.bsky.richtext.facet#mention" } ];
       }
 
+  (** Link facet for [uri] covering UTF-8 bytes from [byte_start]
+      (inclusive) to [byte_end] (exclusive). *)
   let link ~byte_start ~byte_end uri : facet =
     `Link
       {
@@ -153,6 +157,8 @@ module Facet = struct
           [ { uri; cid = ""; link_type = "app.bsky.richtext.facet#link" } ];
       }
 
+  (** Tag facet for [tag] covering UTF-8 bytes from [byte_start]
+      (inclusive) to [byte_end] (exclusive). *)
   let tag ~byte_start ~byte_end tag : facet =
     `Tag
       {

--- a/src/bsky/records.ml
+++ b/src/bsky/records.ml
@@ -36,6 +36,9 @@ module Records = struct
   let parse_strong_ref json : Embed.strong_ref = Embed.parse_strong_ref json
   let via_fields via = match via with Some v -> [ ("via", v) ] | None -> []
 
+  (** Build an [app.bsky.feed.post] record. [text] and [created_at] are
+      required; optional [langs] / [facets] / [embed] / [reply] / [tags]
+      / [self_labels] map to the lexicon. *)
   let post ~text ~created_at ?langs ?facets ?embed ?reply ?tags ?self_labels ()
       : Yojson.Safe.t =
     let fields =
@@ -74,6 +77,7 @@ module Records = struct
     in
     `Assoc fields
 
+  (** Build an [app.bsky.feed.like] record for [uri] / [cid]. *)
   let like ~uri ~cid ~created_at ?via () : Yojson.Safe.t =
     `Assoc
       ([
@@ -92,6 +96,7 @@ module Records = struct
        ]
       @ via_fields via)
 
+  (** Build an [app.bsky.graph.follow] record for [subject] (DID). *)
   let follow ~subject ~created_at ?via () : Yojson.Safe.t =
     `Assoc
       ([

--- a/src/bsky/site.ml
+++ b/src/bsky/site.ml
@@ -197,6 +197,9 @@ module Site = struct
       Yojson.Safe.t =
     theme_to_json (theme ~background ~foreground ~accent ~accent_foreground)
 
+  (** Build a [site.standard.document] record. [site], [title], and
+      [published_at] are required; optional path, tags, contributors,
+      and content map to the lexicon. *)
   let document ~site ~title ~published_at ?path ?description ?text_content
       ?(tags = []) ?(contributors = []) ?updated_at ?bsky_post_ref ?self_labels
       ?cover_image ?content ?links () : Yojson.Safe.t =

--- a/src/bsky/video.ml
+++ b/src/bsky/video.ml
@@ -149,6 +149,9 @@ module Video = struct
     Client.get_json ~session:s "app.bsky.video.getUploadLimits" []
     |> parse_upload_limits
 
+  (** XRPC URL for [app.bsky.video.uploadVideo] on the hosted video
+      service (default [video.bsky.app]). Query params are [did] and
+      [name]. Client URL helper only — this is not a local transcoder. *)
   let upload_video_url ?host ~did ~name () =
     let base = Client.nsid_url ~host:(video_host ?host ()) upload_nsid in
     let qs =
@@ -338,6 +341,10 @@ module Video = struct
       failure_reason = Client.string_opt json "failureReason";
     }
 
+  (** JSON body for [app.bsky.video.startUpload] (multipart session).
+      [size_bytes] and [mime_type] are required; optional [name] /
+      [duration_ms] / [width] / [height] map to the lexicon. Client
+      request body only. *)
   let start_upload_body ~size_bytes ~mime_type ?name ?duration_ms ?width ?height
       () : Yojson.Safe.t =
     let fields =

--- a/src/car.ml
+++ b/src/car.ml
@@ -7,6 +7,8 @@ module Car = struct
   type block = { cid : Cid.t; data : string }
   type t = { roots : Cid.t list; blocks : block list }
 
+  (** Decode CARv1 bytes (header plus CID-prefixed blocks). Used by
+      [com.atproto.sync.getRepo] and firehose diffs. *)
   let parse (bytes : string) : t =
     if String.length bytes = 0 then failwith "Car.parse: empty";
     let header_len, i = Varint.decode_from bytes 0 in
@@ -41,6 +43,7 @@ module Car = struct
     in
     { roots; blocks = read_blocks i [] }
 
+  (** Encode a CARv1 (version 1 header with [roots], then blocks). *)
   let encode (car : t) : string =
     let header =
       Dag_cbor.encode

--- a/src/cid.ml
+++ b/src/cid.ml
@@ -41,8 +41,10 @@ module Cid = struct
     if consumed <> String.length s then failwith "Cid.of_bytes: trailing bytes";
     cid
 
+  (** Multibase base32 string ([b...]) for this CID. *)
   let to_string (c : t) : string = "b" ^ Base32.encode (to_bytes c)
 
+  (** Parse a multibase base32 CID ([b...]). Other bases fail. *)
   let of_string (s : string) : t =
     if String.length s < 2 then failwith "Cid.of_string: empty";
     match s.[0] with
@@ -69,10 +71,14 @@ module Cid = struct
   let sha256 (data : string) : string =
     Digestif.SHA256.(digest_string data |> to_raw_string)
 
+  (** CIDv1 from SHA-256 of [data]. Default codec is dag-cbor; use
+      [~codec:Raw] for blobs. *)
   let create ?(codec = Dag_cbor) (data : string) : t =
     of_digest ~codec (sha256 data)
 
   (* Blobs are raw + SHA-256; repo records / MST nodes are dag-cbor. *)
+
+  (** Blob CID: CIDv1 raw plus SHA-256 of [bytes]. *)
   let of_blob (bytes : string) : t = create ~codec:Raw bytes
 
   let verify_blob ?(expected : t option) (bytes : string) : t =

--- a/src/did_plc.ml
+++ b/src/did_plc.ml
@@ -347,6 +347,9 @@ module Did_plc = struct
          services)
 
   (* Field order matches @did-plc/lib formatAtprotoOp. DAG-CBOR sorts keys. *)
+
+  (** Unsigned genesis [plc_operation] ([prev] is null). Pass rotation
+      keys and optional alsoKnownAs / verificationMethods / services. *)
   let genesis_operation ?(also_known_as = [])
       ?(verification_methods : (string * string) list = [])
       ?(services : (string * plc_service) list = []) ~rotation_keys () :
@@ -361,6 +364,8 @@ module Did_plc = struct
         ("prev", `Null);
       ]
 
+  (** Unsigned update [plc_operation] chained from [prev] (CID of the
+      previous operation). *)
   let update_operation ?(also_known_as = [])
       ?(verification_methods : (string * string) list = [])
       ?(services : (string * plc_service) list = []) ~rotation_keys ~prev () :
@@ -383,6 +388,10 @@ module Did_plc = struct
 
   (* @did-plc/lib formatAtprotoOp: type plc_operation, verificationMethods.atproto,
      rotationKeys, alsoKnownAs [at://handle], services.atproto_pds, prev. *)
+
+  (** AT Protocol-shaped PLC op: [verificationMethods.atproto],
+      [alsoKnownAs] [at://handle], and [services.atproto_pds]. Omit
+      [prev] for genesis; pass it to update. *)
   let format_atproto_op ~signing_key ~rotation_keys ~handle ~pds ?prev () :
       Yojson.Safe.t =
     let also_known_as =

--- a/src/germnetwork.ml
+++ b/src/germnetwork.ml
@@ -45,6 +45,9 @@ module Germnetwork = struct
         | _ -> "");
     }
 
+  (** Build a [com.germnetwork.declaration] record. [current_key] is
+      encoded as lexicon bytes; optional [message_me] / [key_package] /
+      [continuity_proofs] map to the lexicon. *)
   let declaration ~version ~current_key ?message_me ?key_package
       ?(continuity_proofs = []) () : Yojson.Safe.t =
     let fields =

--- a/src/label.ml
+++ b/src/label.ml
@@ -207,9 +207,9 @@ module Label = struct
     in
     pairs
 
-  (* List of AT URI patterns to match (boolean 'OR'). Each may
-   * be a prefix (ending with '*'; will match inclusive of the string leading to
-   * '*'), or a full URI *)
+  (** Query labels matching [uri_patterns] via [com.atproto.label.queryLabels].
+      Each pattern may be a full AT URI or a prefix ending in [*]. Returns
+      the raw JSON body. *)
   let query_labels (s : Session.session) (uri_patterns : string list) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -385,6 +385,9 @@ module Label = struct
     let bare = String.lowercase_ascii bare in
     bare = "localhost" || bare = "127.0.0.1" || bare = "[::1]" || bare = "::1"
 
+  (** WebSocket URL for [com.atproto.label.subscribeLabels]. Default host
+      is [bsky.network]; localhost / 127.0.0.1 use [ws], otherwise [wss].
+      Optional [cursor] is a seq to resume from. *)
   let subscribe_url ?(host = "bsky.network") ?scheme ?cursor () =
     let scheme =
       match scheme with

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -181,6 +181,8 @@ module Lexicon = struct
     in
     { lexicon; id; description = string_opt json "description"; defs }
 
+  (** Parse a Lexicon 1 document from a JSON string. Fails when [id] is
+      missing. *)
   let of_string (body : string) : document =
     of_json (Yojson.Safe.from_string body)
 

--- a/src/oauth_scope.ml
+++ b/src/oauth_scope.ml
@@ -227,6 +227,9 @@ module Oauth_scope = struct
   let split_scopes (scope : string) : string list =
     String.split_on_char ' ' scope |> List.filter (fun t -> t <> "")
 
+  (** Parse a space-separated scope string into validated tokens.
+      Raises [Invalid] on empty tokens or illegal resource params.
+      Does not require [atproto] — use [parse_and_require] for that. *)
   let parse (scope : string) : t list = List.map parse_one (split_scopes scope)
 
   let to_string (s : t) : string =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -47,6 +47,8 @@ module Syntax = struct
     | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' -> true
     | _ -> false
 
+  (** True when [input] is a valid AT Protocol handle (DNS labels, max
+      253 chars). Does not check TLD policy. *)
   let is_valid_handle (input : string) : bool =
     let len = String.length input in
     if len = 0 || len > handle_max_len then false
@@ -106,6 +108,7 @@ module Syntax = struct
     in
     loop 0
 
+  (** True when [input] is a valid DID ([did:method:id], max 2048). *)
   let is_valid_did (input : string) : bool =
     let len = String.length input in
     if len < 7 || len > did_max_len then false
@@ -204,6 +207,7 @@ module Syntax = struct
     in
     loop 0
 
+  (** True when [input] is a valid NSID (at least three segments). *)
   let is_valid_nsid (input : string) : bool =
     let len = String.length input in
     if len = 0 || len > nsid_max_len then false
@@ -285,6 +289,8 @@ module Syntax = struct
     | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '~' | '.' | ':' | '-' -> true
     | _ -> false
 
+  (** True when [input] is a valid record key (1–512 chars, no [.] or
+      [..]). *)
   let is_valid_record_key (input : string) : bool =
     let len = String.length input in
     if len < 1 || len > record_key_max then false

--- a/src/temp.ml
+++ b/src/temp.ml
@@ -48,6 +48,9 @@ module Temp = struct
       original = json;
     }
 
+  (** Check whether [handle] is available via
+      [com.atproto.temp.checkHandleAvailability]. Optional [email] /
+      [birth_date] may yield suggestions when unavailable. *)
   let check_handle_availability ?session ?host ~handle ?email ?birth_date () :
       handle_check =
     Client.get_json ?session ?host "com.atproto.temp.checkHandleAvailability"

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -16,6 +16,7 @@ module Tid = struct
     in
     loop 0
 
+  (** True when [s] is a 13-character TID (base32, top bit zero). *)
   let is_valid (s : string) : bool =
     String.length s = 13
     &&

--- a/src/websocket.ml
+++ b/src/websocket.ml
@@ -279,6 +279,9 @@ module Websocket = struct
                       "Sec-WebSocket-Protocol %S was not in the client offer"
                       got)))
 
+  (** Open a WebSocket to [url] ([wss://] TLS or [ws://] cleartext).
+      Optional [extra_headers] are sent on the handshake. Default
+      [tls_verify] is [false]. *)
   let connect ?(tls_verify = false) ?(extra_headers = []) (url : string) : t =
     Random.self_init ();
     let p = parse_url url in

--- a/src/xrpc.ml
+++ b/src/xrpc.ml
@@ -52,6 +52,7 @@ module Xrpc = struct
 
   let proxy_to_string (p : proxy) : string = p.did ^ "#" ^ p.service
 
+  (** [atproto-proxy] header pair ([did#service]). *)
   let proxy_header (p : proxy) : string * string =
     ("atproto-proxy", proxy_to_string p)
 
@@ -100,9 +101,11 @@ module Xrpc = struct
          (fun (l : labeler) -> if l.redact then l.did ^ ";redact" else l.did)
          ls)
 
+  (** [atproto-accept-labelers] header from [ls] ([did] or [did;redact]). *)
   let accept_labelers_header (ls : labeler list) : string * string =
     ("atproto-accept-labelers", labelers_to_string ls)
 
+  (** [atproto-content-labelers] header from [ls]. *)
   let content_labelers_header (ls : labeler list) : string * string =
     ("atproto-content-labelers", labelers_to_string ls)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Function-level `(** *)` odoc on public entry points that #117 did not cover. Sibling of #122 (Graph, Ozone, Repo, Sync, MST, Jetstream, Bookmark, Notification, Chat).

Comments are 1–3 sentences. No behavior changes, no private helpers, no leftover fields, no pin bump, no opam publish.

## Documented

- `Admin.get_subject_status`, `update_subject_status`, `get_account_info`, `search_accounts`
- `Label.query_labels`, `Label.subscribe_url`
- `Facet.mention` / `link` / `tag`, `Embed.join_link`
- `Temp.check_handle_availability`
- `Video.upload_video_url`, `Video.start_upload_body` (hosted-service client URL/body helpers only — not a local transcoder)
- `Site.document`, `Germnetwork.declaration`
- `Did_plc.genesis_operation`, `update_operation`, `format_atproto_op`
- `Car.parse` / `encode`, `Cid.to_string` / `of_string` / `create` / `of_blob`
- `Websocket.connect`
- `Xrpc.proxy_header`, `accept_labelers_header`, `content_labelers_header`
- `Oauth_scope.parse`
- `Syntax.is_valid_handle` / `is_valid_did` / `is_valid_nsid` / `is_valid_record_key`
- `Tid.is_valid`, `Uri.of_string`
- `Records.post` / `like` / `follow`
- `Lexicon.of_string` (there is no public `Lexicon.parse`)

## Out of scope

Files owned by #122 (`src/bsky/bookmark.ml`, `graph.ml`, `notification.ml`, `src/chat.ml`, `src/jetstream.ml`, `src/mst.ml`, `src/ozone.ml`, `src/repo.ml`, `src/sync.ml`) were not touched. #123 owns `test/test_local_*.ml`. `CHANGELOG.md`, `README.md`, `sample.env`, `SECURITY.md`, `test/`, `doc/`, and `.github/` were not edited.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (a CHANGELOG PR may be in flight — not edited here)

## CHANGELOG (not edited)

After merge, a Docs bullet such as: function-level odoc on Label, Video, CID/CAR, PLC, Records, Admin, Embed/Facet, Temp, Site, Germnetwork, Websocket, Xrpc, Oauth_scope, Syntax/Tid/At_uri, and Lexicon entry points.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b1780d0-3be3-42a7-a6c0-f93c79bc63b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b1780d0-3be3-42a7-a6c0-f93c79bc63b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

