### PR TITLE
Odoc remaining public entry points (Firehose, Oauth, Session, Auth, Client, Server)

### DIFF
--- a/src/app.ml
+++ b/src/app.ml
@@ -3,16 +3,19 @@ open Auth
 
 (** XRPC base-URL helpers for a PDS session or a public host. *)
 module App = struct
+  (** Join a base XRPC URL and an NSID (or path) with a single slash. *)
   let create_endpoint_url (url : string) (endpoint : string) : string =
     let url =
       if String.get url (String.length url - 1) = '/' then url else url ^ "/"
     in
     url ^ endpoint
 
+  (** PDS XRPC base for [s] ([https://host/xrpc] or [ATP_SCHEME]). *)
   let create_base_url (s : Session.session) : string =
     let base_endpoint = Auth.get_base_endpoint in
     Auth.origin_of_host s.atp_host ^ "/" ^ base_endpoint
 
+  (** XRPC base for a public [host] (default [ATP_HOST]). *)
   let create_public_base_url ?(host = Session.atp_host_from_env) () : string =
     let base_endpoint = Auth.get_base_endpoint in
     Auth.origin_of_host host ^ "/" ^ base_endpoint

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -168,6 +168,7 @@ module Auth = struct
 
   (* com.atproto.server.refreshSession is POST with no input lexicon.
      Authorization is Bearer refreshJwt. Do not send a JSON body. *)
+
   (** POST [com.atproto.server.refreshSession] with Bearer [refreshJwt]
       (no JSON body). *)
   let refresh_auth_token_request (_access_jwt : string) (refresh_jwt : string)

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -36,6 +36,7 @@ module Auth = struct
         if s = "http" then "http" else "https"
     | None -> "https"
 
+  (** [ATP_SCHEME://host] ([https] unless [ATP_SCHEME=http]). *)
   let origin_of_host (host : string) : string = scheme_from_env ^ "://" ^ host
 
   let print_auth (a : auth) : unit =

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -74,6 +74,8 @@ module Auth = struct
     in
     aux 0
 
+  (** True when [ATP_AUTH] is [user:password] and not a placeholder
+      dummy pair. *)
   let has_live_credentials : bool =
     match Sys.getenv_opt "ATP_AUTH" with
     | None -> false
@@ -81,6 +83,7 @@ module Auth = struct
         String.contains auth ':'
         && not (List.exists (string_contains auth) dummy_auth_markers)
 
+  (** [username, password] from [ATP_AUTH] ([user:password]). *)
   let username_and_password_from_env : string * string =
     let atp_auth =
       match Sys.getenv_opt "ATP_AUTH" with
@@ -92,6 +95,8 @@ module Auth = struct
   let create_server_endpoint (query_name : string) : string =
     "com.atproto.server" ^ "." ^ query_name
 
+  (** Parse [createSession] / [refreshSession] JSON into [auth]
+      ([accessJwt] claims plus optional [refreshJwt]). *)
   let parse_auth json : auth =
     let open Yojson.Safe.Util in
     let token = json |> member "accessJwt" |> to_string in
@@ -141,6 +146,7 @@ module Auth = struct
     in
     `Assoc fields
 
+  (** POST [com.atproto.server.createSession] and return the raw body. *)
   let make_auth_token_request ?auth_factor_token ?allow_takendown
       (username : string) (password : string) (personal_data_server : string) :
       string =
@@ -161,6 +167,8 @@ module Auth = struct
 
   (* com.atproto.server.refreshSession is POST with no input lexicon.
      Authorization is Bearer refreshJwt. Do not send a JSON body. *)
+  (** POST [com.atproto.server.refreshSession] with Bearer [refreshJwt]
+      (no JSON body). *)
   let refresh_auth_token_request (_access_jwt : string) (refresh_jwt : string)
       (_handle : string) (_did : string) (personal_data_server : string) :
       string =
@@ -171,6 +179,7 @@ module Auth = struct
     in
     Lwt_main.run (Cohttp_client.post_request_with_headers url headers)
 
+  (** True when [a.exp] is within one minute of now. *)
   let is_token_expired (a : auth) : bool =
     let expired_at = Ptime.of_float_s (float_of_int a.exp) |> Option.get in
     let expired_at =

--- a/src/bsky/actor.ml
+++ b/src/bsky/actor.ml
@@ -539,6 +539,7 @@ module Actor = struct
     let profiles_json = profiles |> convert_body_to_json in
     profiles_json |> parse_profiles
 
+  (** Suggested accounts via [app.bsky.actor.getSuggestions]. *)
   let get_suggestions (s : Session.session) (limit : int) : short_profile list =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -559,6 +560,7 @@ module Actor = struct
     in
     suggestions |> convert_body_to_json |> parse_short_profiles
 
+  (** Actor search via [app.bsky.actor.searchActors] ([q] = [term]). *)
   let search_actors (s : Session.session) (term : string) (limit : int) :
       short_profile list =
     let bearer_token = Session.bearer_token_from_session s in
@@ -581,6 +583,7 @@ module Actor = struct
     in
     profiles |> convert_body_to_json |> parse_short_profiles
 
+  (** Typeahead via [app.bsky.actor.searchActorsTypeahead]. *)
   let search_actors_typeahead (s : Session.session) (term : string)
       (limit : int) : typeahead_profile list =
     let bearer_token = Session.bearer_token_from_session s in
@@ -896,6 +899,7 @@ module Actor = struct
     Client.Client.get_json ~session:s "app.bsky.actor.getPreferences" []
     |> parse_preferences
 
+  (** Replace stored preferences via [app.bsky.actor.putPreferences]. *)
   let put_preferences (s : Session.session) preferences : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.actor.putPreferences"

--- a/src/bsky/ageassurance.ml
+++ b/src/bsky/ageassurance.ml
@@ -149,6 +149,7 @@ module Ageassurance = struct
     Client.get_json ?session ?host "app.bsky.ageassurance.getConfig" []
     |> parse_config
 
+  (** Age-assurance state via [app.bsky.ageassurance.getState]. *)
   let get_state (s : Session.session) ~country_code ?region_code () :
       state_bundle =
     Client.get_json ~session:s "app.bsky.ageassurance.getState"
@@ -156,6 +157,7 @@ module Ageassurance = struct
       @ Client.opt_pair "regionCode" region_code)
     |> parse_state_bundle
 
+  (** Start age assurance via [app.bsky.ageassurance.begin]. *)
   let begin_assurance (s : Session.session) ~email ~language ~country_code
       ?region_code () : state =
     Client.post_json ~session:s "app.bsky.ageassurance.begin"

--- a/src/bsky/bookmark.ml
+++ b/src/bsky/bookmark.ml
@@ -70,6 +70,7 @@ module Bookmark = struct
       (Client.post_json ~session:s "app.bsky.bookmark.createBookmark"
          (Yojson.Safe.to_string (create_bookmark_body ~uri ~cid)))
 
+  (** Remove the bookmark for [uri] via [app.bsky.bookmark.deleteBookmark]. *)
   let delete_bookmark (s : Session.session) ~uri () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.bookmark.deleteBookmark"

--- a/src/bsky/contact.ml
+++ b/src/bsky/contact.ml
@@ -69,6 +69,7 @@ module Contact = struct
   let send_notification_body ~from ~to_ : Yojson.Safe.t =
     `Assoc [ ("from", `String from); ("to", `String to_) ]
 
+  (** Matched contacts via [app.bsky.contact.getMatches]. *)
   let get_matches (s : Session.session) ?limit ?cursor () : matches_page =
     Client.get_json ~session:s "app.bsky.contact.getMatches"
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
@@ -78,6 +79,8 @@ module Contact = struct
     Client.get_json ~session:s "app.bsky.contact.getSyncStatus" []
     |> parse_sync_status_opt
 
+  (** Import phone contacts via [app.bsky.contact.importContacts]
+      ([token] from [verify_phone]). *)
   let import_contacts (s : Session.session) ~token ~contacts () : import_result
       =
     Client.post_json ~session:s "app.bsky.contact.importContacts"

--- a/src/bsky/draft.ml
+++ b/src/bsky/draft.ml
@@ -313,11 +313,13 @@ module Draft = struct
 
   let delete_draft_body ~id : Yojson.Safe.t = `Assoc [ ("id", `String id) ]
 
+  (** Private stash drafts via [app.bsky.draft.getDrafts]. *)
   let get_drafts (s : Session.session) ?limit ?cursor () : drafts_page =
     Client.get_json ~session:s "app.bsky.draft.getDrafts"
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
     |> parse_drafts_page
 
+  (** Create a stash draft via [app.bsky.draft.createDraft]. *)
   let create_draft (s : Session.session) draft : create_result =
     Client.post_json ~session:s "app.bsky.draft.createDraft"
       (Yojson.Safe.to_string (create_draft_body draft))

--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -539,6 +539,8 @@ module Feed = struct
   let create_feed_endpoint (query_name : string) : string =
     "app.bsky.feed" ^ "." ^ query_name
 
+  (** Author feed via [app.bsky.feed.getAuthorFeed] (session required).
+      Prefer [get_author_feed_page] for public AppView + cursor. *)
   let get_author_feed ?filter ?include_pins (s : Session.session)
       (actor : string) (limit : int) : feed list =
     let open Yojson.Safe.Util in
@@ -568,6 +570,7 @@ module Feed = struct
     let feed = author_feed |> convert_body_to_json |> member "feed" in
     feed |> to_list |> List.map parse_feed
 
+  (** Likes on [uri] / [cid] via [app.bsky.feed.getLikes]. *)
   let get_likes (s : Session.session) (uri : string) (cid : string)
       (limit : int) : likes =
     let bearer_token = Session.bearer_token_from_session s in
@@ -590,6 +593,7 @@ module Feed = struct
     in
     likes |> convert_body_to_json |> parse_likes
 
+  (** Thread for [uri] via [app.bsky.feed.getPostThread]. *)
   let get_post_thread (s : Session.session) (uri : string) (depth : int) :
       thread_feed =
     let bearer_token = Session.bearer_token_from_session s in
@@ -612,6 +616,7 @@ module Feed = struct
     in
     post_thread |> convert_body_to_json |> parse_thread_feed
 
+  (** Hydrated posts for [uris] via [app.bsky.feed.getPosts]. *)
   let get_posts (s : Session.session) (uris : string list) : posts_feed =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -652,6 +657,7 @@ module Feed = struct
     in
     reposted_by |> convert_body_to_json |> parse_reposted_by_feed
 
+  (** Home timeline via [app.bsky.feed.getTimeline]. *)
   let get_timeline (s : Session.session) (algorithm : string) (limit : int) :
       timeline =
     let bearer_token = Session.bearer_token_from_session s in
@@ -1027,6 +1033,8 @@ module Feed = struct
     in
     `Assoc fields
 
+  (** Custom feed [feed] (AT URI) via [app.bsky.feed.getFeed]. Works
+      without a session against public AppView. *)
   let get_feed ?session ?host ~feed ?limit ?cursor () : timeline =
     Client.Client.get_json ?session ?host "app.bsky.feed.getFeed"
       ((("feed", feed) :: Client.Client.opt_int "limit" limit)
@@ -1068,6 +1076,7 @@ module Feed = struct
       @ Client.Client.opt_bool "includePins" include_pins)
     |> parse_timeline
 
+  (** Posts from list [list] (AT URI) via [app.bsky.feed.getListFeed]. *)
   let get_list_feed ?session ?host ~list ?limit ?cursor () : timeline =
     Client.Client.get_json ?session ?host "app.bsky.feed.getListFeed"
       ((("list", list) :: Client.Client.opt_int "limit" limit)

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -80,6 +80,7 @@ module Graph = struct
     in
     { mutes; cursor }
 
+  (** Accounts the session blocks via [app.bsky.graph.getBlocks]. *)
   let get_blocks (s : Session.session) (limit : int) : blocks =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -157,6 +158,7 @@ module Graph = struct
       (follow_page_pairs ~actor ?limit ?cursor ?sort ())
     |> parse_follows
 
+  (** Accounts the session mutes via [app.bsky.graph.getMutes]. *)
   let get_mutes (s : Session.session) (limit : int) : mutes =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -217,6 +219,7 @@ module Graph = struct
     in
     muted_actor
 
+  (** Unmute [actor] via [app.bsky.graph.unmuteActor]. *)
   let unmute_actor (s : Session.session) (actor : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -692,6 +695,7 @@ module Graph = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_list_page
 
+  (** Lists created by [actor] via [app.bsky.graph.getLists]. *)
   let get_lists ?session ?host ~actor ?limit ?cursor () : lists =
     Client.Client.get_json ?session ?host "app.bsky.graph.getLists"
       ((("actor", actor) :: Client.Client.opt_int "limit" limit)
@@ -780,6 +784,8 @@ module Graph = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_starter_packs_with_membership
 
+  (** Follow/block relationships for [actor] vs [others] via
+      [app.bsky.graph.getRelationships]. *)
   let get_relationships ?session ?host ~actor ?others () : relationships =
     Client.Client.get_json ?session ?host "app.bsky.graph.getRelationships"
       (("actor", actor)

--- a/src/bsky/labeler.ml
+++ b/src/bsky/labeler.ml
@@ -55,6 +55,7 @@ module Labeler = struct
   let parse_services json : services =
     { views = List.map parse_service (Client.list_member json "views") }
 
+  (** Labeler views for [dids] via [app.bsky.labeler.getServices]. *)
   let get_services ?session ?host ~dids ?(detailed = false) () : services =
     Client.get_json ?session ?host "app.bsky.labeler.getServices"
       (Client.repeat_param "dids" dids

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -320,6 +320,7 @@ module Notification = struct
     let json = Yojson.Safe.from_string body in
     json
 
+  (** Unread count via [app.bsky.notification.getUnreadCount]. *)
   let get_unread_count (s : Session.session) : unread_count =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -362,6 +363,8 @@ module Notification = struct
       @ Client.Client.opt_pair "seenAt" seen_at)
     |> parse_notification_page
 
+  (** Mark notifications seen at [seen_at] via
+      [app.bsky.notification.updateSeen]. *)
   let update_seen (s : Session.session) (seen_at : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -518,6 +521,7 @@ module Notification = struct
         ("verified", preference_to_json p.verified);
       ]
 
+  (** Notification preferences via [app.bsky.notification.getPreferences]. *)
   let get_preferences (s : Session.session) : preferences =
     Client.Client.get_json ~session:s "app.bsky.notification.getPreferences" []
     |> parse_preferences

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -145,6 +145,7 @@ module Unspecced = struct
       feeds = List.map parse_generator_view (Client.list_member json "feeds");
     }
 
+  (** Post search skeleton via [app.bsky.unspecced.searchPostsSkeleton]. *)
   let search_posts_skeleton ?session ?host ~q ?sort ?since ?until ?mentions
       ?author ?lang ?domain ?url ?viewer ?limit ?cursor () : skeleton_posts =
     Client.get_json ?session ?host "app.bsky.unspecced.searchPostsSkeleton"
@@ -182,6 +183,7 @@ module Unspecced = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_skeleton_starter_packs
 
+  (** Trending topics via [app.bsky.unspecced.getTrendingTopics]. *)
   let get_trending_topics ?session ?host ?viewer ?limit () : trending_topics =
     Client.get_json ?session ?host "app.bsky.unspecced.getTrendingTopics"
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)

--- a/src/chat.ml
+++ b/src/chat.ml
@@ -558,6 +558,8 @@ module Chat = struct
       @ Client.opt_pair "kind" kind)
     |> parse_convos
 
+  (** Conversation [convo_id] via [chat.bsky.convo.getConvo]. Hosted
+      chat service; always sends [atproto-proxy]. *)
   let get_convo (s : Session.session) ?proxy ~convo_id () : convo =
     Client.get_json ~session:s
       ~extra:(session_proxy_headers ?proxy s)
@@ -578,6 +580,8 @@ module Chat = struct
     | `Assoc _ as c -> parse_convo c
     | _ -> parse_convo json
 
+  (** Messages in [convo_id] via [chat.bsky.convo.getMessages]. Hosted
+      chat service; always sends [atproto-proxy]. *)
   let get_messages (s : Session.session) ?proxy ~convo_id ?limit ?cursor () :
       messages =
     Client.get_json ~session:s
@@ -588,6 +592,8 @@ module Chat = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_messages
 
+  (** Send [text] via [chat.bsky.convo.sendMessage]. Hosted chat
+      service; always sends [atproto-proxy]. *)
   let send_message (s : Session.session) ?proxy ~convo_id ~text ?facets ?embed
       ?reply_to () : message =
     Client.post_json ~session:s

--- a/src/client.ml
+++ b/src/client.ml
@@ -109,6 +109,8 @@ module Client = struct
     let body = String.trim body in
     if body = "" then `Assoc [] else Yojson.Safe.from_string body
 
+  (** XRPC GET [nsid] with query [pairs]. Auth from [session] or
+      [bearer]; optional [host] and extra headers. *)
   let get_json ?session ?host ?bearer ?(extra = []) nsid pairs =
     let headers = request_headers ?session ?bearer ~extra () in
     let url = nsid_url ?session ?host nsid in
@@ -126,6 +128,8 @@ module Client = struct
     Lwt_main.run
       (Cohttp_client.get_request_with_body_and_headers url body headers)
 
+  (** XRPC POST [nsid] with JSON [data]. Auth from [session] or
+      [bearer]; optional [host] and extra headers. *)
   let post_json ?session ?host ?bearer ?(extra = []) nsid data =
     let headers = request_headers ?session ?bearer ~extra () in
     let url = nsid_url ?session ?host nsid in
@@ -174,6 +178,9 @@ module Client = struct
      (com.atproto.server.getServiceAuth, aud=AppView DID, lxm=NSID).
      OAuth sessions mint the same JWT with Oauth.get_service_auth (DPoP)
      and pass it here as ~bearer — Client cannot depend on Oauth. *)
+  (** Mint [com.atproto.server.getServiceAuth] for [aud] / [lxm] using
+      the session [at+jwt]. AppView and Ozone want this JWT, not the
+      PDS access token. *)
   let get_service_auth (s : Session.session) ~aud ~lxm () : string =
     let json =
       get_json ~session:s "com.atproto.server.getServiceAuth"
@@ -183,6 +190,8 @@ module Client = struct
     | `String t when String.trim t <> "" -> t
     | _ -> failwith ("getServiceAuth failed: " ^ Yojson.Safe.to_string json)
 
+  (** XRPC GET against AppView ([ATP_APPVIEW_HOST]). With a session,
+      mints a service-auth JWT ([aud] = AppView DID, [lxm] = [nsid]). *)
   let get_json_appview ?session ?host ?aud ?(extra = []) nsid pairs =
     let host = match host with Some h -> h | None -> appview_host_from_env in
     match session with
@@ -192,6 +201,8 @@ module Client = struct
         let token = get_service_auth s ~aud ~lxm:nsid () in
         get_json ~host ~bearer:token ~extra nsid pairs
 
+  (** XRPC POST against AppView. With a session, mints a service-auth
+      JWT like [get_json_appview]. *)
   let post_json_appview ?session ?host ?aud ?(extra = []) nsid data =
     let host = match host with Some h -> h | None -> appview_host_from_env in
     match session with

--- a/src/client.ml
+++ b/src/client.ml
@@ -179,6 +179,7 @@ module Client = struct
      (com.atproto.server.getServiceAuth, aud=AppView DID, lxm=NSID).
      OAuth sessions mint the same JWT with Oauth.get_service_auth (DPoP)
      and pass it here as ~bearer — Client cannot depend on Oauth. *)
+
   (** Mint [com.atproto.server.getServiceAuth] for [aud] / [lxm] using
       the session [at+jwt]. AppView and Ozone want this JWT, not the
       PDS access token. *)

--- a/src/client.ml
+++ b/src/client.ml
@@ -121,6 +121,7 @@ module Client = struct
     in
     json_of_body resp
 
+  (** XRPC GET [nsid] returning the raw body string. *)
   let get_text ?session ?host ?bearer ?(extra = []) nsid pairs =
     let headers = request_headers ?session ?bearer ~extra () in
     let url = nsid_url ?session ?host nsid in

--- a/src/dag_cbor.ml
+++ b/src/dag_cbor.ml
@@ -258,6 +258,7 @@ module Dag_cbor = struct
   let get_map (v : value) : (string * value) list =
     match v with Map m -> m | _ -> fail "expected map"
 
+  (** Optional map field [key]. *)
   let find key fields =
     try Some (List.assoc key fields) with Not_found -> None
 
@@ -283,6 +284,7 @@ module Dag_cbor = struct
   let as_bytes = function Bytes b -> b | _ -> fail "expected bytes"
   let as_array = function Array a -> a | _ -> fail "expected array"
 
+  (** Unwrap a [Cid] (or a text CID string). *)
   let as_cid = function
     | Cid c -> c
     | Text t -> Cid.of_string t

--- a/src/dag_cbor.ml
+++ b/src/dag_cbor.ml
@@ -18,6 +18,7 @@ module Dag_cbor = struct
 
   let fail msg = raise (Decode_error msg)
 
+  (** Encode [v] as DAG-CBOR (map keys sorted by encoded CBOR bytes). *)
   let rec encode (v : value) : string =
     match v with
     | Null -> "\xF6"
@@ -237,11 +238,13 @@ module Dag_cbor = struct
     in
     (acc 0 0L, i + 8)
 
+  (** Decode a single DAG-CBOR value. Fails on trailing bytes. *)
   let decode (s : string) : value =
     let v, i = decode_from s 0 in
     if i <> String.length s then fail "trailing bytes";
     v
 
+  (** Decode concatenated DAG-CBOR values (firehose header + body). *)
   let decode_sequence (s : string) : value list =
     let rec loop i acc =
       if i >= String.length s then List.rev acc
@@ -251,12 +254,14 @@ module Dag_cbor = struct
     in
     loop 0 []
 
+  (** Unwrap a [Map]; raise [Decode_error] otherwise. *)
   let get_map (v : value) : (string * value) list =
     match v with Map m -> m | _ -> fail "expected map"
 
   let find key fields =
     try Some (List.assoc key fields) with Not_found -> None
 
+  (** Required map field [key]; raise [Decode_error] if missing. *)
   let require key fields =
     match find key fields with
     | Some v -> v
@@ -290,8 +295,8 @@ module Dag_cbor = struct
 
   let as_cid_opt = function Null -> None | v -> Some (as_cid v)
 
-  (* IPLD JSON → DAG-CBOR. `{ "$link": cid }` and `{ "$bytes": b64 }` are
-     the official JSON encodings for CID and bytes. *)
+  (** IPLD JSON to DAG-CBOR. Official [$link] / [$bytes] objects become
+      [Cid] and [Bytes]. *)
   let rec of_yojson (json : Yojson.Safe.t) : value =
     match json with
     | `Null -> Null

--- a/src/did_key.ml
+++ b/src/did_key.ml
@@ -47,6 +47,7 @@ module Did_key = struct
   (** Wrap secp256k1 public-key octets as a [did:key]. *)
   let of_k256_octets (public_key : string) : t = { curve = K256; public_key }
 
+  (** P-256 public key for [k], or [None] if the curve is not p256. *)
   let p256_pub (k : t) : Mirage_crypto_ec.P256.Dsa.pub option =
     if k.curve <> P256 then None
     else
@@ -54,6 +55,7 @@ module Did_key = struct
       | Ok pub -> Some pub
       | Error _ -> None
 
+  (** secp256k1 public key for [k], or [None] if the curve is not k256. *)
   let k256_pub (k : t) : K256.pub option =
     if k.curve <> K256 then None
     else

--- a/src/did_key.ml
+++ b/src/did_key.ml
@@ -18,6 +18,7 @@ module Did_key = struct
   let is_did_key (s : string) : bool =
     String.length s > 8 && String.sub s 0 8 = "did:key:"
 
+  (** Parse a [did:key:] (multibase base58btc, p256 or k256). *)
   let of_string (s : string) : t =
     if not (is_did_key s) then failwith "Did_key.of_string: not a did:key";
     let rest = String.sub s 8 (String.length s - 8) in
@@ -33,13 +34,17 @@ module Did_key = struct
     in
     { curve; public_key }
 
+  (** Encode [k] as [did:key:z…]. *)
   let to_string (k : t) : string =
     let code =
       match k.curve with P256 -> p256_code | K256 -> k256_code | Other n -> n
     in
     "did:key:z" ^ Base58.encode (Varint.encode code ^ k.public_key)
 
+  (** Wrap uncompressed P-256 public-key octets as a [did:key]. *)
   let of_p256_octets (public_key : string) : t = { curve = P256; public_key }
+
+  (** Wrap secp256k1 public-key octets as a [did:key]. *)
   let of_k256_octets (public_key : string) : t = { curve = K256; public_key }
 
   let p256_pub (k : t) : Mirage_crypto_ec.P256.Dsa.pub option =

--- a/src/did_web.ml
+++ b/src/did_web.ml
@@ -29,6 +29,7 @@ module Did_web = struct
 
   let parse_document = Did_plc.parse_document
 
+  (** Fetch the [did:web:] document as JSON. *)
   let resolve_json (did : string) : Yojson.Safe.t =
     let url = document_url did in
     let headers =

--- a/src/did_web.ml
+++ b/src/did_web.ml
@@ -12,6 +12,8 @@ module Did_web = struct
     if not (is_web_did did) then
       failwith ("Did_web: not a did:web identifier: " ^ did)
 
+  (** HTTPS URL for the [did:web:] document ([/.well-known/did.json] or
+      a path [did.json]). *)
   let document_url (did : string) : string =
     validate_web_did did;
     let rest = String.sub did 8 (String.length did - 8) in
@@ -40,5 +42,6 @@ module Did_web = struct
     | Some e -> failwith ("Did_web.resolve: " ^ Error.Error.to_string e)
     | None -> Yojson.Safe.from_string body
 
+  (** Fetch and parse the [did:web:] document. *)
   let resolve (did : string) : did_document = parse_document (resolve_json did)
 end

--- a/src/error.ml
+++ b/src/error.ml
@@ -75,6 +75,7 @@ module Error = struct
     | Some "MethodNotImplemented" | Some "MethodNotFound" -> true
     | _ -> false
 
+  (** [is_not_served] for an XRPC JSON body. *)
   let is_not_served_json json : bool =
     match check_for_error json with
     | None -> false

--- a/src/error.ml
+++ b/src/error.ml
@@ -14,8 +14,11 @@ module Error = struct
     in
     { error; message }
 
+  (** Parse an XRPC [error] / [message] JSON object. *)
   let of_json = parse_error_from_json
 
+  (** Parse [error] from an HTTP body, or [None] if it is not an XRPC
+      error object. *)
   let of_body (body : string) : t option =
     try
       let json = Yojson.Safe.from_string body in
@@ -24,19 +27,23 @@ module Error = struct
       | _ -> None
     with _ -> None
 
+  (** [Some error] when [json] has an [error] string field. *)
   let check_for_error json : string option =
     let open Yojson.Safe.Util in
     match json |> member "error" with `String s -> Some s | _ -> None
 
+  (** Classify [json] as [RateLimitExceeded] or a generic XRPC error. *)
   let parse_error json : error_type =
     let e = parse_error_from_json json in
     match e.error with
     | "RateLimitExceeded" -> `RateLimitExceeded e
     | _ -> `Xrpc e
 
+  (** [error] or [error: message]. *)
   let to_string (e : t) : string =
     if e.message = "" then e.error else e.error ^ ": " ^ e.message
 
+  (** True for [MethodNotImplemented] / [MethodNotFound]. *)
   let is_not_implemented (e : t) : bool =
     e.error = "MethodNotImplemented" || e.error = "MethodNotFound"
 
@@ -58,6 +65,8 @@ module Error = struct
        || contains_ci e.message "not available"
        || contains_ci e.message "unknown lexicon")
 
+  (** True when the host does not serve the NSID (not implemented or
+      flag-off). *)
   let is_not_served (e : t) : bool =
     is_not_implemented e || is_feature_disabled e
 
@@ -71,6 +80,7 @@ module Error = struct
     | None -> false
     | Some _ -> is_not_served (of_json json)
 
+  (** Raise [Failure] for a classified XRPC error. *)
   let handle_error error_type =
     match error_type with
     | `RateLimitExceeded e -> failwith ("RateLimitExceeded: " ^ e.message)

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -80,6 +80,8 @@ module Firehose = struct
     let bare = String.lowercase_ascii bare in
     bare = "localhost" || bare = "127.0.0.1" || bare = "[::1]" || bare = "::1"
 
+  (** WebSocket URL for [com.atproto.sync.subscribeRepos]. Defaults to
+      [wss://bsky.network]; localhost uses [ws]. Optional [cursor]. *)
   let subscribe_url ?(host = default_relay_host) ?scheme ?cursor () =
     let scheme =
       match scheme with
@@ -218,6 +220,8 @@ module Firehose = struct
         | _ -> None);
     }
 
+  (** Decode a binary subscribeRepos frame into a header and [message]
+      ([#commit], [#sync], [#identity], [#account], [#info], or error). *)
   let decode_frame (bytes : string) : header * message =
     match Dag_cbor.decode_sequence bytes with
     | header_v :: body :: _ ->
@@ -257,6 +261,8 @@ module Firehose = struct
     in
     Dag_cbor.encode (Dag_cbor.Map fields)
 
+  (** Stream [com.atproto.sync.subscribeRepos] frames to [f]. Optional
+      [host], [cursor], and [max_messages]. *)
   let subscribe ?(host = default_relay_host) ?cursor ?max_messages f =
     let url = subscribe_url ~host ?cursor () in
     Websocket.with_connection url (fun ws ->
@@ -318,6 +324,8 @@ module Firehose = struct
           failwith "Firehose.validate_limits: block exceeds 1,000,000 bytes")
       c.blocks.blocks
 
+  (** Check commit limits and invert MST ops against [prev_data] when
+      the CAR is complete (not [too_big] / rebase). *)
   let verify_commit (c : commit) : unit =
     validate_limits c;
     match (c.too_big, c.rebase, c.ops) with
@@ -382,6 +390,8 @@ module Firehose = struct
         (Printf.sprintf "Firehose.verify_sync: rev %s != %s" signed.rev s.rev);
     signed
 
+  (** Verify [c] and apply its ops to [prev_tree]. The resulting MST
+      root must match the signed commit [data] CID. *)
   let apply_commit ~(prev_tree : Mst.Mst.tree) (c : commit) : Mst.Mst.tree =
     let signed = verify_commit_object c in
     verify_commit c;

--- a/src/firehose.ml
+++ b/src/firehose.ml
@@ -295,6 +295,8 @@ module Firehose = struct
     | None -> failwith "Firehose: commit block missing from CAR"
     | Some block -> Mst.Mst.parse_repo_commit (Dag_cbor.decode block.data)
 
+  (** Invert [c]'s MST ops and return the previous-root CID. Fails on
+      [too_big] or rebase. *)
   let invert_commit (c : commit) : Cid.t =
     if c.too_big then
       failwith "Firehose.invert_commit: tooBig (CAR is incomplete)";
@@ -344,6 +346,8 @@ module Firehose = struct
                    (Cid.to_string inverted) (Cid.to_string expected))
         | None -> ())
 
+  (** Check the signed commit object against [c.repo] / [c.rev] and the
+      CAR root. *)
   let verify_commit_object (c : commit) : Mst.Mst.repo_commit =
     (match Car.root c.blocks with
     | Some root when not (Cid.equal root c.commit) ->
@@ -364,9 +368,12 @@ module Firehose = struct
        ^ signed.rev);
     signed
 
+  (** Verify the commit signature with [keys] (PLC / did:key). *)
   let verify_commit_sig ~keys (c : commit) : Mst.Mst.sig_status =
     Mst.Mst.verify_commit_sig ~keys (repo_commit_of c)
 
+  (** Verify a [#sync] frame: CAR root, DID, and rev match the signed
+      commit. *)
   let verify_sync (s : sync) : Mst.Mst.repo_commit =
     let root =
       match Car.root s.blocks with

--- a/src/hash.ml
+++ b/src/hash.ml
@@ -1,20 +1,25 @@
 (** Hash helpers used by CID, MST, PLC, DPoP, and WebSocket. *)
 module Hash = struct
+  (** SHA-256 digest of [data] (raw 32 bytes). *)
   let sha256 (data : string) : string =
     Digestif.SHA256.(digest_string data |> to_raw_string)
 
+  (** SHA-1 digest of [data] (raw 20 bytes). *)
   let sha1 (data : string) : string =
     Digestif.SHA1.(digest_string data |> to_raw_string)
 
+  (** SHA-256 digest of [data] as lowercase hex. *)
   let sha256_hex (data : string) : string =
     Digestif.SHA256.(digest_string data |> to_hex)
 
+  (** Decode lowercase/uppercase hex to raw bytes. *)
   let hex_decode (hex : string) : string =
     let len = String.length hex in
     if len mod 2 <> 0 then failwith "Hash.hex_decode: odd length";
     String.init (len / 2) (fun i ->
         Char.chr (int_of_string ("0x" ^ String.sub hex (i * 2) 2)))
 
+  (** Encode raw bytes as lowercase hex. *)
   let hex_encode (data : string) : string =
     let buf = Buffer.create (String.length data * 2) in
     String.iter

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -181,6 +181,7 @@ module Http_client = struct
             exchange ~host:parsed.host ~port:parsed.port req parsed socket)
           (fun () -> close_socket socket)
 
+  (** Send [req] over HTTP/2 TLS (HTTPS + ALPN [h2]). *)
   let request ?(timeout = default_timeout) (req : Request.request) :
       Response.response Lwt.t =
     Lwt.catch
@@ -189,9 +190,11 @@ module Http_client = struct
         | Lwt_unix.Timeout -> Lwt.fail (Error "HTTP/2 request timed out")
         | exn -> Lwt.fail exn)
 
+  (** HTTP/2 GET [url]. *)
   let get url ?(headers = []) ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.get url ~headers ())
 
+  (** HTTP/2 POST [url] with optional [body]. *)
   let post url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.post url ~headers ?body ())
 
@@ -217,6 +220,7 @@ module Http_client = struct
     ^ "="
     ^ Uri.pct_encode ~component:`Query_value v
 
+  (** [https://host/xrpc/nsid] with optional query pairs. *)
   let xrpc_url ~host ?(port = 443) nsid ?(query = []) () : string =
     let base =
       if port = 443 then Printf.sprintf "https://%s/xrpc/%s" host nsid
@@ -226,10 +230,12 @@ module Http_client = struct
     | [] -> base
     | qs -> base ^ "?" ^ String.concat "&" (List.map encode_query_pair qs)
 
+  (** HTTP/2 GET for XRPC [nsid] on [host]. *)
   let xrpc_get ~host ?port ~nsid ?(query = []) ?(headers = []) ?timeout () :
       Response.response Lwt.t =
     get (xrpc_url ~host ?port nsid ~query ()) ~headers ?timeout ()
 
+  (** HTTP/2 POST for XRPC [nsid] on [host] (JSON content-type default). *)
   let xrpc_post ~host ?port ~nsid ?(headers = []) ?body ?timeout () :
       Response.response Lwt.t =
     let hdrs =
@@ -266,5 +272,6 @@ module Http_client = struct
       (xrpc_url ~host ?port nsid ())
       ~headers:(json_headers headers) ?body ?timeout ()
 
+  (** [Lwt_main.run t] — block on an HTTP/2 request. *)
   let run (t : 'a Lwt.t) : 'a = Lwt_main.run t
 end

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -198,9 +198,11 @@ module Http_client = struct
   let post url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.post url ~headers ?body ())
 
+  (** HTTP/2 PUT [url] with optional [body]. *)
   let put url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.put url ~headers ?body ())
 
+  (** HTTP/2 DELETE [url]. *)
   let delete url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.delete url ~headers ?body ())
 

--- a/src/http_method.ml
+++ b/src/http_method.ml
@@ -2,6 +2,7 @@
 module Http_method = struct
   type http_method = Get | Post | Put | Delete | Patch
 
+  (** Parse ["GET"] / ["POST"] / ["PUT"] / ["DELETE"] / ["PATCH"]. *)
   let lookup_http_method meth : http_method =
     match String.lowercase_ascii meth with
     | "get" -> Get
@@ -11,6 +12,7 @@ module Http_method = struct
     | "patch" -> Patch
     | _ -> failwith "Not Recognized Method"
 
+  (** Uppercase method name. *)
   let to_string = function
     | Get -> "GET"
     | Post -> "POST"

--- a/src/k256.ml
+++ b/src/k256.ml
@@ -110,12 +110,14 @@ module K256 = struct
           let q = mul (Z.shift_right k 1) (double p) in
           if Z.testbit k 0 then add q p else q
 
+  (** Parse a 32-byte secp256k1 private scalar. *)
   let priv_of_octets (s : string) : (priv, error) result =
     if String.length s <> 32 then Error `Invalid_key
     else
       let d = z_of_be s in
       if in_scalar d then Ok { d } else Error `Invalid_key
 
+  (** Public point [d·G] for private key [k]. *)
   let pub_of_priv (k : priv) : pub =
     match mul k.d (Pt g) with
     | Pt q -> q
@@ -130,6 +132,7 @@ module K256 = struct
     let q = { x; y } in
     if on_curve q then Ok q else Error `Invalid_key
 
+  (** Parse a compressed (33-byte) or uncompressed (65-byte) public key. *)
   let pub_of_octets (s : string) : (pub, error) result =
     if String.length s = 33 && (s.[0] = '\x02' || s.[0] = '\x03') then
       decompress (z_of_be (String.sub s 1 32)) (s.[0] = '\x03')
@@ -140,6 +143,7 @@ module K256 = struct
       if on_curve q then Ok q else Error `Invalid_key
     else Error `Invalid_key
 
+  (** Encode [q] as compressed ([02]/[03]+x) or uncompressed ([04]+x+y). *)
   let pub_to_octets ?(compress = true) (q : pub) : string =
     if compress then
       let prefix = if Z.testbit q.y 0 then "\x03" else "\x02" in
@@ -157,11 +161,13 @@ module K256 = struct
     in
     loop ()
 
+  (** Fresh secp256k1 key pair. *)
   let generate () : priv * pub =
     Random.self_init ();
     let priv = { d = random_scalar () } in
     (priv, pub_of_priv priv)
 
+  (** ECDSA sign [digest] (32 bytes) as IEEE P1363 [r, s] (low-S). *)
   let sign ~(key : priv) (digest : string) : string * string =
     if String.length digest <> 32 then
       failwith "K256.sign: digest must be 32 bytes";
@@ -183,6 +189,7 @@ module K256 = struct
     Random.self_init ();
     attempt ()
 
+  (** Verify IEEE P1363 [r, s] over 32-byte [digest]. *)
   let verify ~(key : pub) (r, s) (digest : string) : bool =
     try
       if

--- a/src/moderation.ml
+++ b/src/moderation.ml
@@ -117,6 +117,8 @@ module Moderation = struct
     Yojson.Safe.to_string
       (`Assoc (report_fields reason_type ?reason ?mod_tool subject))
 
+  (** User report via [com.atproto.moderation.createReport] on a record
+      ([com.atproto.repo.strongRef]). Not an Ozone operator tool. *)
   let create_report_with_strong_ref (s : Session.session) (reason_type : string)
       ?reason ?mod_tool (subject : strong_ref) : report_response =
     let bearer_token = Session.bearer_token_from_session s in
@@ -138,6 +140,8 @@ module Moderation = struct
     in
     created_report |> convert_body_to_json |> parse_report_response
 
+  (** User report via [com.atproto.moderation.createReport] on an
+      account ([com.atproto.admin.defs#repoRef]). *)
   let create_report_with_repo_ref (s : Session.session) (reason_type : string)
       ?reason ?mod_tool (subject : repo_ref) : report_response =
     let bearer_token = Session.bearer_token_from_session s in

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -45,6 +45,8 @@ module Oauth = struct
       failwith "Oauth.pkce_challenge: verifier must be 43-128 chars";
     Base64url.encode (Hash.sha256 verifier)
 
+  (** S256 PKCE pair: random [verifier] (43-128 chars) and its SHA-256
+      challenge. *)
   let pkce_s256 ?(verifier = random_verifier ()) () : pkce =
     { verifier; challenge = pkce_challenge verifier; method_ = "S256" }
 
@@ -118,6 +120,9 @@ module Oauth = struct
     done;
     Base64url.encode (Bytes.to_string bytes)
 
+  (** RFC 9449 DPoP proof (ES256, low-S). [htu] is the HTTP URI without
+      query or fragment; optional [ath] / [nonce] for resource and
+      [use_dpop_nonce] retries. *)
   let dpop_proof ~(priv : Mirage_crypto_ec.P256.Dsa.priv)
       ~(pub : Mirage_crypto_ec.P256.Dsa.pub) ~htm ~htu ?ath ?jti ?iat ?nonce ()
       : string =
@@ -222,6 +227,7 @@ module Oauth = struct
   let token_url_of_origin origin = url_on origin "/oauth/token"
   let revocation_url_of_origin origin = url_on origin "/oauth/revoke"
 
+  (** Fresh P-256 key pair for DPoP proofs. *)
   let generate_dpop_pair () :
       Mirage_crypto_ec.P256.Dsa.priv * Mirage_crypto_ec.P256.Dsa.pub =
     Lazy.force ensure_rng;
@@ -388,6 +394,8 @@ module Oauth = struct
   let assoc_opt key pairs =
     match List.assoc_opt key pairs with Some "" -> None | other -> other
 
+  (** Parse an OAuth redirect URI into [Authorized] ([code]+[state]) or
+      [Denied]. *)
   let parse_redirect (uri : string) : callback =
     let q =
       match String.index_opt uri '?' with
@@ -494,6 +502,8 @@ module Oauth = struct
       policy_uri;
     }
 
+  (** Confidential client metadata ([private_key_jwt] / ES256) with
+      public [jwks]. *)
   let confidential_metadata ~client_id ~redirect_uris ~jwks
       ?(scope = default_scope) ?(application_type = "web") ?client_name
       ?client_uri ?logo_uri ?tos_uri ?policy_uri () : client_metadata =
@@ -1280,6 +1290,8 @@ module Oauth = struct
         (Printf.sprintf "Oauth: GET %s HTTP %d: %s" url resp.status resp.body);
     (resp, decode_json_body ("GET " ^ url) resp.body)
 
+  (** Fetch protected-resource and authorization-server metadata for
+      [pds_origin], then [validate_as_metadata]. *)
   let discover_authorization_server ~(http : http_get) ~pds_origin () :
       resource_metadata * as_metadata =
     let origin = trim_slash pds_origin in
@@ -1318,6 +1330,8 @@ module Oauth = struct
     validate_as_metadata as_;
     (resource, as_)
 
+  (** Pushed Authorization Request (PAR) with DPoP. Returns
+      [request_uri] and the next DPoP nonce. *)
   let push_authorization ~(http : http_post) ~priv ~pub ~par_url ~form ?nonce ()
       : par_response * string option =
     let body = form_encode form in
@@ -1326,6 +1340,8 @@ module Oauth = struct
     in
     (parse_par_response (ensure_ok "PAR" resp), nonce)
 
+  (** Authorization-code token exchange with DPoP. [token_type] must be
+      [DPoP]; [sub] is the account DID. *)
   let exchange_code ~(http : http_post) ~priv ~pub ~token_url ~form ?nonce () :
       token * string option =
     let body = form_encode form in
@@ -1334,11 +1350,14 @@ module Oauth = struct
     in
     (parse_token_response (ensure_ok "token" resp), nonce)
 
+  (** Refresh-token grant with DPoP (same response shape as
+      [exchange_code]). *)
   let refresh ~(http : http_post) ~priv ~pub ~token_url ~form ?nonce () :
       token * string option =
     exchange_code ~http ~priv ~pub ~token_url ~form ?nonce ()
 
-  (* RFC 7009 token revocation. 200 with an empty body is success. *)
+  (** RFC 7009 token revocation with DPoP. HTTP 200 with an empty body
+      is success. *)
   let revoke ~(http : http_post) ~priv ~pub ~revoke_url ~form ?nonce () :
       unit * string option =
     let body = form_encode form in
@@ -1429,9 +1448,10 @@ module Oauth = struct
     let url = xrpc_url ~origin nsid [] in
     post_json_dpop ~http ~priv ~pub ~url ~access_token ~body ?nonce ~extra ()
 
-  (* Mint com.atproto.server.getServiceAuth with the DPoP access token.
-     AppView and Ozone want this JWT ([aud] = service DID, [lxm] = NSID),
-     not the OAuth token and not a createSession at+jwt. *)
+  (** Mint [com.atproto.server.getServiceAuth] with the DPoP access
+      token. AppView and Ozone want this JWT ([aud] = service DID,
+      [lxm] = NSID), not the OAuth token and not a [createSession]
+      at+jwt. *)
   let get_service_auth ~(http : http_request) ~priv ~pub ~pds_origin
       ~access_token ~aud ?lxm ?exp ?nonce () : string * string option =
     let pairs =

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -1392,6 +1392,7 @@ module Oauth = struct
   (* DPoP-bound resource request with one use_dpop_nonce retry.
      [extra] is for headers such as [atproto-proxy]; DPoP still cannot be
      proxied — the PDS rejects that combination. *)
+
   (** DPoP-bound resource request with one [use_dpop_nonce] retry. *)
   let request_with_dpop ~(http : http_request) ~priv ~pub ~url ~htm
       ~access_token ?body ?ath ?nonce ?(extra = []) () :

--- a/src/oauth.ml
+++ b/src/oauth.ml
@@ -183,6 +183,7 @@ module Oauth = struct
         (match payload |> member "nonce" with `String s -> Some s | _ -> None);
     }
 
+  (** Verify a DPoP JWT against [pub] (ES256, low-S). *)
   let verify_dpop ~(pub : Mirage_crypto_ec.P256.Dsa.pub) (jwt : string) : bool =
     try
       let h, p, s = split_jwt jwt in
@@ -210,6 +211,7 @@ module Oauth = struct
     else if path.[0] = '/' then origin ^ path
     else origin ^ "/" ^ path
 
+  (** [scheme://host/oauth/par] (default [https://bsky.social]). *)
   let par_url ?(scheme = "https") ?(host = "bsky.social") () =
     Printf.sprintf "%s://%s/oauth/par" scheme host
 
@@ -1390,6 +1392,7 @@ module Oauth = struct
   (* DPoP-bound resource request with one use_dpop_nonce retry.
      [extra] is for headers such as [atproto-proxy]; DPoP still cannot be
      proxied — the PDS rejects that combination. *)
+  (** DPoP-bound resource request with one [use_dpop_nonce] retry. *)
   let request_with_dpop ~(http : http_request) ~priv ~pub ~url ~htm
       ~access_token ?body ?ath ?nonce ?(extra = []) () :
       http_response * string option =

--- a/src/request.ml
+++ b/src/request.ml
@@ -11,12 +11,16 @@ module Request = struct
 
   let user_agent = "david-engelmann/atproto (OCaml SDK)"
 
+  (** Build a request record ([method_], [url], optional [headers] /
+      [body]). *)
   let create ~method_ ~url ?(headers = []) ?body () : request =
     { method_; url; headers; body }
 
+  (** GET [url]. *)
   let get url ?(headers = []) () : request =
     create ~method_:Http_method.Get ~url ~headers ()
 
+  (** POST [url] with optional [body]. *)
   let post url ?(headers = []) ?body () : request =
     create ~method_:Http_method.Post ~url ~headers ?body ()
 

--- a/src/response.ml
+++ b/src/response.ml
@@ -7,6 +7,7 @@ module Response = struct
     headers : (string * string) list;
   }
 
+  (** Build a response; [success] is true for HTTP 2xx. *)
   let make ~status_code ~content ?(headers = []) () : response =
     {
       success = status_code >= 200 && status_code < 300;
@@ -15,9 +16,11 @@ module Response = struct
       headers;
     }
 
+  (** [make] with [body] as bytes. *)
   let of_string ~status_code ?(headers = []) body : response =
     make ~status_code ~content:(Bytes.of_string body) ~headers ()
 
+  (** Response body as a UTF-8 string. *)
   let body_string (r : response) : string = Bytes.to_string r.content
 
   let header (r : response) name : string option =

--- a/src/server.ml
+++ b/src/server.ml
@@ -7,6 +7,7 @@ module Server = struct
   let create_server_endpoint (query_name : string) : string =
     "com.atproto.server" ^ "." ^ query_name
 
+  (** Raw JSON from [com.atproto.server.describeServer] for [s]. *)
   let describe_server (s : Session.session) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -71,7 +72,9 @@ module Server = struct
     in
     created_account
 
-  (* Public signup — createAccount is unauthenticated on an open PDS. *)
+  (** Public signup via [com.atproto.server.createAccount] on [host]
+      (or the session / [ATP_HOST] PDS). Unauthenticated on an open
+      PDS. *)
   let create_account_at ?session ?host ~handle ~email ~password ?invite_code
       ?recovery_key ?did ?verification_code ?verification_phone ?plc_op () :
       Yojson.Safe.t =
@@ -125,6 +128,8 @@ module Server = struct
     | `List xs -> List.map parse_app_password xs
     | _ -> []
 
+  (** Create an app password via [com.atproto.server.createAppPassword].
+      The secret is only present on create. *)
   let create_app_password (s : Session.session) ?privileged (name : string) :
       string =
     Client.Client.post_json ~session:s "com.atproto.server.createAppPassword"
@@ -188,6 +193,8 @@ module Server = struct
       (Yojson.Safe.to_string (`Assoc fields))
     |> Yojson.Safe.to_string
 
+  (** App passwords via [com.atproto.server.listAppPasswords] (secrets
+      omitted). *)
   let list_app_passwords (s : Session.session) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -269,6 +276,8 @@ module Server = struct
     let qs = Cohttp_client.create_body_from_pairs pairs in
     if qs = "" then base else base ^ "?" ^ qs
 
+  (** Service-auth JWT via [com.atproto.server.getServiceAuth] for
+      [aud] (optional [lxm] / [exp]). *)
   let get_service_auth (s : Session.session) ~aud ?lxm ?exp () : service_auth =
     let _ = Xrpc.Xrpc.service_auth_body ~aud ?lxm ?exp () in
     let bearer_token = Session.bearer_token_from_session s in
@@ -398,6 +407,8 @@ module Server = struct
         | _ -> None);
     }
 
+  (** Parsed [com.atproto.server.describeServer] (DID, invite/phone
+      flags, links). Works without a session. *)
   let describe_server_parsed ?session ?host () : server_description =
     Client.Client.get_json ?session ?host "com.atproto.server.describeServer" []
     |> parse_describe_server
@@ -437,6 +448,7 @@ module Server = struct
 
   let request_email_update_body () : Yojson.Safe.t = `Assoc []
 
+  (** Confirm [email] with [token] via [com.atproto.server.confirmEmail]. *)
   let confirm_email (s : Session.session) ~email ~token () : unit =
     ignore
       (Client.Client.post_json ~session:s "com.atproto.server.confirmEmail"
@@ -474,16 +486,20 @@ module Server = struct
     | Some t -> `Assoc [ ("deleteAfter", `String t) ]
     | None -> `Assoc []
 
+  (** Deactivate the account via [com.atproto.server.deactivateAccount].
+      Optional [delete_after] is an ISO datetime. *)
   let deactivate_account (s : Session.session) ?delete_after () : unit =
     ignore
       (Client.Client.post_json ~session:s "com.atproto.server.deactivateAccount"
          (Yojson.Safe.to_string (deactivate_account_body ?delete_after ())))
 
+  (** Reactivate via [com.atproto.server.activateAccount]. *)
   let activate_account (s : Session.session) : unit =
     ignore
       (Client.Client.post_json ~session:s "com.atproto.server.activateAccount"
          "")
 
+  (** Import / activation status via [com.atproto.server.checkAccountStatus]. *)
   let check_account_status (s : Session.session) : account_status =
     Client.Client.get_json ~session:s "com.atproto.server.checkAccountStatus" []
     |> parse_account_status

--- a/src/server.ml
+++ b/src/server.ml
@@ -236,6 +236,7 @@ module Server = struct
       (Yojson.Safe.to_string (request_account_delete_body ()))
     |> Yojson.Safe.to_string
 
+  (** Request a reset email via [com.atproto.server.requestPasswordReset]. *)
   let request_password_reset (s : Session.session) (email : string) : string =
     Client.Client.post_json ~session:s "com.atproto.server.requestPasswordReset"
       (Yojson.Safe.to_string (request_password_reset_body ~email))
@@ -426,6 +427,7 @@ module Server = struct
         | _ -> "");
     }
 
+  (** Reserve a signing key via [com.atproto.server.reserveSigningKey]. *)
   let reserve_signing_key ?session ?host ?did () : reserved_signing_key =
     Client.Client.post_json ?session ?host
       "com.atproto.server.reserveSigningKey"
@@ -474,6 +476,7 @@ module Server = struct
       (Yojson.Safe.to_string (request_email_update_body ()))
     |> parse_email_update
 
+  (** Update account email via [com.atproto.server.updateEmail]. *)
   let update_email (s : Session.session) ~email ?token ?email_auth_factor () :
       unit =
     ignore

--- a/src/session.ml
+++ b/src/session.ml
@@ -62,6 +62,7 @@ module Session = struct
       did_doc;
     }
 
+  (** PDS host from [ATP_HOST] (default [bsky.social]). *)
   let atp_host_from_env : string =
     let atp_host =
       try Sys.getenv "ATP_HOST" with Not_found -> "bsky.social"

--- a/src/session.ml
+++ b/src/session.ml
@@ -87,6 +87,7 @@ module Session = struct
     in
     { username; password; atp_host; auth = session_auth; did_doc }
 
+  (** [Authorization: Bearer] header pair from the session access JWT. *)
   let bearer_token_from_session (s : session) : string * string =
     let bearer_header = "Bearer " ^ s.auth.token in
     ("Authorization", bearer_header)
@@ -119,6 +120,8 @@ module Session = struct
   let get_session (s : session) : session_request =
     Yojson.Safe.from_string (get_session_request s) |> parse_session_request
 
+  (** Rotate JWTs via [com.atproto.server.refreshSession] using
+      [refreshJwt]. Fails if the session has no refresh token. *)
   let refresh_session (s : session) : session =
     match s.auth.refresh_token with
     | None -> failwith "Session.refresh_session: missing refreshJwt"
@@ -142,9 +145,12 @@ module Session = struct
         in
         { s with auth = session_auth; did_doc }
 
+  (** Refresh [s] when [Auth.is_token_expired]; otherwise return [s]. *)
   let refresh_session_auth (s : session) : session =
     if Auth.is_token_expired s.auth then refresh_session s else s
 
+  (** End the session via [com.atproto.server.deleteSession] (Bearer
+      [refreshJwt]). *)
   let delete_session (s : session) : string =
     let bearer_token = refresh_token_from_session s in
     let headers = Cohttp_client.create_headers_from_pairs [ bearer_token ] in

--- a/src/varint.ml
+++ b/src/varint.ml
@@ -1,5 +1,6 @@
 (** Unsigned LEB128 / multiformat varints used by CID, CAR, and DAG-CBOR. *)
 module Varint = struct
+  (** Unsigned LEB128 encode of non-negative [n]. *)
   let encode (n : int) : string =
     if n < 0 then invalid_arg "Varint.encode: negative";
     let buf = Buffer.create 4 in
@@ -14,6 +15,7 @@ module Varint = struct
     loop n;
     Buffer.contents buf
 
+  (** Decode a varint starting at [off]. Returns [value, next_offset]. *)
   let decode_from (s : string) (off : int) : int * int =
     let rec loop acc shift i =
       if i >= String.length s then failwith "Varint.decode: truncated";
@@ -25,5 +27,6 @@ module Varint = struct
     in
     loop 0 0 off
 
+  (** [decode_from s 0]. *)
   let decode (s : string) : int * int = decode_from s 0
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Function-level `(** *)` odoc on remaining public entry points that #117 and merged #122 did not cover. Sibling of merged #125 (Label, Video, CID/CAR, PLC, Records). Files owned by #125 and #123 were not touched. Merges cleanly onto `origin/main` (`cdb46382`).

Comments are 1–3 sentences. No behavior changes, no private helpers, no leftover fields, no pin bump, no opam publish. Chat comments name the hosted service only.

## Documented

- `Firehose.subscribe_url`, `subscribe`, `decode_frame`, `invert_commit`, `verify_commit`, `verify_commit_object`, `verify_commit_sig`, `verify_sync`, `apply_commit` (`subscribe_one` already in #117)
- `Oauth.pkce_s256`, `dpop_proof`, `verify_dpop`, `generate_dpop_pair`, `par_url`, `parse_redirect`, `confidential_metadata`, `discover_authorization_server`, `push_authorization`, `exchange_code`, `refresh`, `revoke`, `request_with_dpop`, `get_service_auth`
- `Session.atp_host_from_env`, `bearer_token_from_session`, `refresh_session`, `refresh_session_auth`, `delete_session`
- `Auth.origin_of_host`, `has_live_credentials`, `username_and_password_from_env`, `parse_auth`, `make_auth_token_request`, `refresh_auth_token_request`, `is_token_expired`
- `Client.get_json`, `get_text`, `post_json`, `get_service_auth`, `get_json_appview`, `post_json_appview`
- `Server.describe_server`, `create_account_at`, `create_app_password`, `list_app_passwords`, `request_password_reset`, `get_service_auth`, `describe_server_parsed`, `reserve_signing_key`, `confirm_email`, `update_email`, `deactivate_account`, `activate_account`, `check_account_status`
- `Did_key.of_string`, `to_string`, `of_p256_octets`, `of_k256_octets`, `p256_pub`, `k256_pub`
- `Did_web.document_url`, `resolve_json`, `resolve`
- `K256.priv_of_octets`, `pub_of_priv`, `pub_of_octets`, `pub_to_octets`, `generate`, `sign`, `verify`
- `Dag_cbor.encode`, `decode`, `decode_sequence`, `get_map`, `find`, `require`, `as_cid`, `of_yojson`
- `Hash.sha256`, `sha1`, `sha256_hex`, `hex_decode`, `hex_encode`
- `Varint.encode`, `decode_from`, `decode`
- `Error.of_json`, `of_body`, `check_for_error`, `parse_error`, `to_string`, `is_not_implemented`, `is_not_served`, `is_not_served_json`, `handle_error`
- `Http_client.request`, `get`, `post`, `put`, `delete`, `xrpc_url`, `xrpc_get`, `xrpc_post`, `run`
- `Http_method.lookup_http_method`, `to_string`
- Plus earlier-on-this-PR App, Actor, Feed, Graph, Notification, Chat, Request/Response, and other app.bsky.* wrappers

## Out of scope

Files landed in #125 (`src/admin.ml`, `at_uri.ml`, `bsky/embed.ml`, `facet.ml`, `records.ml`, `site.ml`, `video.ml`, `car.ml`, `cid.ml`, `did_plc.ml`, `germnetwork.ml`, `label.ml`, `lexicon.ml`, `oauth_scope.ml`, `syntax.ml`, `temp.ml`, `tid.ml`, `websocket.ml`, `xrpc.ml`) were not restyled. #123 owns `identity.ml`, `test/test_local_*.ml`, `CHANGELOG.md`, and `README.md`. #122 Graph/Ozone/Repo/Sync/MST/Jetstream files were only given comments on functions that still lacked `(** *)`.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing headers unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (#123 owns CHANGELOG)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19026190-3790-498a-ad4f-e8de79379ce6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19026190-3790-498a-ad4f-e8de79379ce6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

