### PR TITLE
Add function-level odoc on remaining Ozone and Repo_sync entry points

### DIFF
--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -7,7 +7,10 @@ open Xrpc
     OAuth DPoP cannot be proxied: mint [getServiceAuth] ([aud] = Ozone DID)
     and call the Ozone host with that JWT ([emit_event_service] / …). *)
 module Ozone = struct
+  (** [atproto-proxy] for Ozone ([did#atproto_labeler]). *)
   let labeler_proxy (did : string) : Xrpc.proxy = Xrpc.labeler_proxy did
+
+  (** [atproto-proxy] header list for [proxy]. *)
   let proxy_headers proxy = [ Xrpc.proxy_header proxy ]
 
   type repo_ref = { did : string }
@@ -593,6 +596,7 @@ module Ozone = struct
     in
     `Assoc fields
 
+  (** Subject statuses via [tools.ozone.moderation.queryStatuses]. *)
   let query_statuses (s : Session.session) ~proxy ?host ?subject ?comment
       ?review_state ?limit ?cursor () : statuses =
     Client.get_json ~session:s ?host ~extra:(proxy_headers proxy)
@@ -628,9 +632,10 @@ module Ozone = struct
             ?external_id ?mod_tool ?report_action ()))
     |> parse_mod_event
 
-  (* Ozone host + PDS-minted service-auth JWT (OAuth DPoP getServiceAuth).
-     No [atproto-proxy] and no createSession at+jwt — DPoP cannot be
-     proxied, and Ozone rejects the PDS access token. *)
+  (** Emit a moderation event via [tools.ozone.moderation.emitEvent] on the
+      Ozone host with a PDS-minted service-auth JWT (OAuth DPoP
+      [getServiceAuth]). No [atproto-proxy] — DPoP cannot be proxied, and
+      Ozone rejects the PDS access token. *)
   let emit_event_service ~bearer ~host ~event ~subject ~created_by
       ?subject_blob_cids ?external_id ?mod_tool ?report_action () : mod_event =
     Client.post_json ~bearer ~host "tools.ozone.moderation.emitEvent"
@@ -639,6 +644,8 @@ module Ozone = struct
             ?external_id ?mod_tool ?report_action ()))
     |> parse_mod_event
 
+  (** Moderation events via [tools.ozone.moderation.queryEvents] on the Ozone
+      host with a service-auth JWT (no [atproto-proxy]). *)
   let query_events_service ~bearer ~host ?types ?created_by ?subject ?limit
       ?cursor () : events =
     Client.get_json ~bearer ~host "tools.ozone.moderation.queryEvents"
@@ -649,22 +656,27 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_events
 
+  (** Ozone config via [tools.ozone.server.getConfig] on the Ozone host with
+      a service-auth JWT. *)
   let get_config_service ~bearer ~host () : server_config =
     Client.get_json ~bearer ~host "tools.ozone.server.getConfig" []
     |> parse_server_config
 
+  (** One event by [id] via [tools.ozone.moderation.getEvent]. *)
   let get_event (s : Session.session) ~proxy ~id () : mod_event =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getEvent"
       [ ("id", string_of_int id) ]
     |> parse_mod_event
 
+  (** Repo view for [did] via [tools.ozone.moderation.getRepo]. *)
   let get_repo (s : Session.session) ~proxy ~did () : repo_view =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getRepo"
       [ ("did", did) ]
     |> parse_repo
 
+  (** Record view for [uri] via [tools.ozone.moderation.getRecord]. *)
   let get_record (s : Session.session) ~proxy ~uri ?cid () : record_view =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getRecord"
@@ -810,24 +822,28 @@ module Ozone = struct
       failed = List.map parse_failed_item (Client.list_member json "failed");
     }
 
+  (** Record views for [uris] via [tools.ozone.moderation.getRecords]. *)
   let get_records (s : Session.session) ~proxy ~uris () : record_view list =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getRecords"
       (Client.repeat_param "uris" uris)
     |> fun json -> List.map parse_record (Client.list_member json "records")
 
+  (** Repo views for [dids] via [tools.ozone.moderation.getRepos]. *)
   let get_repos (s : Session.session) ~proxy ~dids () : repo_view list =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getRepos"
       (Client.repeat_param "dids" dids)
     |> fun json -> List.map parse_repo (Client.list_member json "repos")
 
+  (** Subject views via [tools.ozone.moderation.getSubjects]. *)
   let get_subjects (s : Session.session) ~proxy ~subjects () : subjects =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.moderation.getSubjects"
       (Client.repeat_param "subjects" subjects)
     |> parse_subjects
 
+  (** Search repos via [tools.ozone.moderation.searchRepos] ([q] or [term]). *)
   let search_repos (s : Session.session) ~proxy ?q ?term ?limit ?cursor () :
       repo_view list * string option =
     let json =
@@ -841,6 +857,8 @@ module Ozone = struct
     ( List.map parse_repo (Client.list_member json "repos"),
       Client.string_opt json "cursor" )
 
+  (** Event timeline for [did] via
+      [tools.ozone.moderation.getAccountTimeline]. *)
   let get_account_timeline (s : Session.session) ~proxy ~did () :
       account_timeline =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -848,6 +866,8 @@ module Ozone = struct
       [ ("did", did) ]
     |> parse_account_timeline
 
+  (** Reporter stats for [dids] via
+      [tools.ozone.moderation.getReporterStats]. *)
   let get_reporter_stats (s : Session.session) ~proxy ~dids () : reporter_stats
       =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -896,6 +916,7 @@ module Ozone = struct
     in
     `Assoc fields
 
+  (** Schedule a future action via [tools.ozone.moderation.scheduleAction]. *)
   let schedule_action (s : Session.session) ~proxy ~action ~subjects ~created_by
       ~scheduling ?mod_tool () : batch_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -905,6 +926,7 @@ module Ozone = struct
             ?mod_tool ()))
     |> parse_batch_result
 
+  (** Scheduled actions via [tools.ozone.moderation.listScheduledActions]. *)
   let list_scheduled_actions (s : Session.session) ~proxy ~statuses
       ?starts_after ?ends_before ?subjects ?limit ?cursor () : scheduled_actions
       =
@@ -929,6 +951,8 @@ module Ozone = struct
       (Yojson.Safe.to_string body)
     |> parse_scheduled_actions
 
+  (** Cancel scheduled actions via
+      [tools.ozone.moderation.cancelScheduledActions]. *)
   let cancel_scheduled_actions (s : Session.session) ~proxy ~subjects ?comment
       () : batch_result =
     let fields =
@@ -972,6 +996,7 @@ module Ozone = struct
           | xs -> xs);
     }
 
+  (** Communication templates via [tools.ozone.communication.listTemplates]. *)
   let list_templates (s : Session.session) ~proxy () : templates =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.communication.listTemplates" []
@@ -988,6 +1013,7 @@ module Ozone = struct
       | Some d -> [ ("createdBy", `String d) ]
       | None -> [])
 
+  (** Create a template via [tools.ozone.communication.createTemplate]. *)
   let create_template (s : Session.session) ~proxy ~name ~content_markdown
       ?subject ?lang ?created_by () : template =
     let created_by = Option.value created_by ~default:s.auth.did in
@@ -998,6 +1024,7 @@ module Ozone = struct
             ~created_by ()))
     |> parse_template
 
+  (** Update template [id] via [tools.ozone.communication.updateTemplate]. *)
   let update_template (s : Session.session) ~proxy ~id ?name ?content_markdown
       ?subject ?disabled ?updated_by () : template =
     let updated_by = Option.value updated_by ~default:s.auth.did in
@@ -1016,6 +1043,7 @@ module Ozone = struct
       (Yojson.Safe.to_string (`Assoc fields))
     |> parse_template
 
+  (** Delete template [id] via [tools.ozone.communication.deleteTemplate]. *)
   let delete_template (s : Session.session) ~proxy ~id () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1061,6 +1089,7 @@ module Ozone = struct
       cursor = Client.string_opt json "cursor";
     }
 
+  (** Sets via [tools.ozone.set.querySets]. *)
   let query_sets (s : Session.session) ~proxy ?limit ?cursor ?name_prefix
       ?sort_by ?sort_direction () : sets =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1072,6 +1101,7 @@ module Ozone = struct
       @ Client.opt_pair "sortDirection" sort_direction)
     |> parse_sets
 
+  (** Create or update set [name] via [tools.ozone.set.upsertSet]. *)
   let upsert_set (s : Session.session) ~proxy ~name ?description () : set_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.set.upsertSet"
@@ -1084,6 +1114,7 @@ module Ozone = struct
            | None -> []))))
     |> parse_set_view
 
+  (** Values in set [name] via [tools.ozone.set.getValues]. *)
   let get_set_values (s : Session.session) ~proxy ~name ?limit ?cursor () :
       set_values =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1092,6 +1123,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_set_values
 
+  (** Add [values] to set [name] via [tools.ozone.set.addValues]. *)
   let add_set_values (s : Session.session) ~proxy ~name ~values () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1103,6 +1135,7 @@ module Ozone = struct
                 ("values", `List (List.map (fun v -> `String v) values));
               ])))
 
+  (** Remove [values] from set [name] via [tools.ozone.set.deleteValues]. *)
   let delete_set_values (s : Session.session) ~proxy ~name ~values () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1114,6 +1147,7 @@ module Ozone = struct
                 ("values", `List (List.map (fun v -> `String v) values));
               ])))
 
+  (** Delete set [name] via [tools.ozone.set.deleteSet]. *)
   let delete_set (s : Session.session) ~proxy ~name () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1148,6 +1182,7 @@ module Ozone = struct
           | xs -> xs);
     }
 
+  (** Settings via [tools.ozone.setting.listOptions]. *)
   let list_options (s : Session.session) ~proxy ?prefix ?scope ?limit ?cursor ()
       : setting_options =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1158,6 +1193,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_setting_options
 
+  (** Create or update setting [key] via [tools.ozone.setting.upsertOption]. *)
   let upsert_option (s : Session.session) ~proxy ~key ~scope ~value ?description
       () : setting_option =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1171,6 +1207,7 @@ module Ozone = struct
            | None -> [])))
     |> parse_setting_option
 
+  (** Remove setting [keys] via [tools.ozone.setting.removeOptions]. *)
   let remove_options (s : Session.session) ~proxy ~keys ~scope () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1205,6 +1242,7 @@ module Ozone = struct
       members = List.map parse_team_member (Client.list_member json "members");
     }
 
+  (** Team members via [tools.ozone.team.listMembers]. *)
   let list_members (s : Session.session) ~proxy ?q ?disabled ?(roles = [])
       ?limit ?cursor () : team_members =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1216,6 +1254,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_team_members
 
+  (** Add team member [did] via [tools.ozone.team.addMember]. *)
   let add_member (s : Session.session) ~proxy ~did ~role () : team_member =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.team.addMember"
@@ -1223,6 +1262,7 @@ module Ozone = struct
          (`Assoc [ ("did", `String did); ("role", `String role) ]))
     |> parse_team_member
 
+  (** Update team member [did] via [tools.ozone.team.updateMember]. *)
   let update_member (s : Session.session) ~proxy ~did ?role ?disabled () :
       team_member =
     let fields =
@@ -1235,6 +1275,7 @@ module Ozone = struct
       (Yojson.Safe.to_string (`Assoc fields))
     |> parse_team_member
 
+  (** Remove team member [did] via [tools.ozone.team.deleteMember]. *)
   let delete_member (s : Session.session) ~proxy ~did () : unit =
     ignore
       (Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1276,6 +1317,7 @@ module Ozone = struct
           | xs -> xs);
     }
 
+  (** URL rules via [tools.ozone.safelink.queryRules]. *)
   let query_safelink_rules (s : Session.session) ~proxy ?cursor ?limit
       ?(urls = []) ?pattern_type ?(actions = []) ?reason ?created_by
       ?sort_direction () : url_rules =
@@ -1379,6 +1421,7 @@ module Ozone = struct
       events = List.map parse_safelink_event (Client.list_member json "events");
     }
 
+  (** Add a URL rule via [tools.ozone.safelink.addRule]. *)
   let add_safelink_rule (s : Session.session) ~proxy ~url ~pattern ~action
       ~reason ?comment ?created_by () : safelink_event =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1388,6 +1431,7 @@ module Ozone = struct
             ?created_by ()))
     |> parse_safelink_event
 
+  (** Update a URL rule via [tools.ozone.safelink.updateRule]. *)
   let update_safelink_rule (s : Session.session) ~proxy ~url ~pattern ~action
       ~reason ?comment ?created_by () : safelink_event =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1397,6 +1441,7 @@ module Ozone = struct
             ?created_by ()))
     |> parse_safelink_event
 
+  (** Remove a URL rule via [tools.ozone.safelink.removeRule]. *)
   let remove_safelink_rule (s : Session.session) ~proxy ~url ~pattern ?comment
       ?created_by () : safelink_event =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1421,6 +1466,7 @@ module Ozone = struct
       | Some d -> [ ("sortDirection", `String d) ]
       | None -> [])
 
+  (** Safelink events via [tools.ozone.safelink.queryEvents]. *)
   let query_safelink_events (s : Session.session) ~proxy ?cursor ?limit
       ?(urls = []) ?pattern_type ?sort_direction () : safelink_events =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1456,11 +1502,15 @@ module Ozone = struct
           | xs -> xs);
     }
 
+  (** Signature correlation for [dids] via
+      [tools.ozone.signature.findCorrelation]. *)
   let find_correlation (s : Session.session) ~proxy ~dids () : Yojson.Safe.t =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.signature.findCorrelation"
       (Client.repeat_param "dids" dids)
 
+  (** Related accounts for [did] via
+      [tools.ozone.signature.findRelatedAccounts]. *)
   let find_related_accounts (s : Session.session) ~proxy ~did ?limit ?cursor ()
       : related_accounts =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1469,6 +1519,8 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_related_accounts
 
+  (** Accounts matching signature [values] via
+      [tools.ozone.signature.searchAccounts]. *)
   let search_accounts_by_signature (s : Session.session) ~proxy ?(values = [])
       ?limit ?cursor () : related_accounts =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1586,6 +1638,7 @@ module Ozone = struct
       | Some r -> [ ("revokeReason", `String r) ]
       | None -> []))
 
+  (** Verifications via [tools.ozone.verification.listVerifications]. *)
   let list_verifications (s : Session.session) ~proxy ?cursor ?limit
       ?(issuers = []) ?(subjects = []) () : verifications =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1596,6 +1649,7 @@ module Ozone = struct
       @ Client.repeat_param "subjects" subjects)
     |> parse_verifications
 
+  (** Grant verifications via [tools.ozone.verification.grantVerifications]. *)
   let grant_verifications (s : Session.session) ~proxy ~verifications () :
       grant_verifications_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1603,6 +1657,8 @@ module Ozone = struct
       (Yojson.Safe.to_string (grant_verifications_body ~verifications ()))
     |> parse_grant_verifications
 
+  (** Revoke verification [uris] via
+      [tools.ozone.verification.revokeVerifications]. *)
   let revoke_verifications (s : Session.session) ~proxy ~uris ?revoke_reason ()
       : revoke_verifications_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1637,6 +1693,7 @@ module Ozone = struct
         List.map parse_account_history_event (Client.list_member json "events");
     }
 
+  (** Hosting history for [did] via [tools.ozone.hosting.getAccountHistory]. *)
   let get_account_history (s : Session.session) ~proxy ~did ?events ?cursor
       ?limit () : account_history =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1829,6 +1886,7 @@ module Ozone = struct
       (("queueId", `Int queue_id)
       :: opt_json_int "migrateToQueueId" migrate_to_queue_id)
 
+  (** Moderation queues via [tools.ozone.queue.listQueues]. *)
   let list_queues (s : Session.session) ~proxy ?enabled ?subject_type
       ?collection ?(report_types = []) ?limit ?cursor () : queues =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1841,6 +1899,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_queues
 
+  (** Create a queue via [tools.ozone.queue.createQueue]. *)
   let create_queue (s : Session.session) ~proxy ~name ?subject_types ?collection
       ?report_types ?description ?recommended_policies () : queue_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1850,6 +1909,7 @@ module Ozone = struct
             ?description ?recommended_policies ()))
     |> parse_queue_result
 
+  (** Update queue [queue_id] via [tools.ozone.queue.updateQueue]. *)
   let update_queue (s : Session.session) ~proxy ~queue_id ?name ?enabled
       ?description ?recommended_policies () : queue_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1859,6 +1919,7 @@ module Ozone = struct
             ?recommended_policies ()))
     |> parse_queue_result
 
+  (** Delete queue [queue_id] via [tools.ozone.queue.deleteQueue]. *)
   let delete_queue (s : Session.session) ~proxy ~queue_id ?migrate_to_queue_id
       () : delete_queue_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1867,6 +1928,7 @@ module Ozone = struct
          (delete_queue_body ~queue_id ?migrate_to_queue_id ()))
     |> parse_delete_queue_result
 
+  (** Assign [did] to [queue_id] via [tools.ozone.queue.assignModerator]. *)
   let assign_queue_moderator (s : Session.session) ~proxy ~queue_id ~did () :
       assignment_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -1875,6 +1937,8 @@ module Ozone = struct
          (`Assoc [ ("queueId", `Int queue_id); ("did", `String did) ]))
     |> parse_assignment_view
 
+  (** Unassign [did] from [queue_id] via
+      [tools.ozone.queue.unassignModerator]. *)
   let unassign_queue_moderator (s : Session.session) ~proxy ~queue_id ~did () :
       unit =
     ignore
@@ -1883,6 +1947,7 @@ module Ozone = struct
          (Yojson.Safe.to_string
             (`Assoc [ ("queueId", `Int queue_id); ("did", `String did) ])))
 
+  (** Queue assignments via [tools.ozone.queue.getAssignments]. *)
   let get_queue_assignments (s : Session.session) ~proxy ?only_active
       ?(queue_ids = []) ?(dids = []) ?limit ?cursor () : assignments =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -1894,6 +1959,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_assignments
 
+  (** Route a report-id range via [tools.ozone.queue.routeReports]. *)
   let route_reports (s : Session.session) ~proxy ~start_report_id ~end_report_id
       () : route_reports_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -2136,6 +2202,7 @@ module Ozone = struct
       @ opt_json_str "publicNote" public_note
       @ opt_json_bool "isAutomated" is_automated)
 
+  (** Reports via [tools.ozone.report.queryReports] ([status] required). *)
   let query_reports (s : Session.session) ~proxy ~status ?queue_id
       ?(report_types = []) ?subject ?did ?subject_type ?(collections = [])
       ?reported_after ?reported_before ?is_muted ?assigned_to ?sort_field
@@ -2158,17 +2225,20 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_reports
 
+  (** Report [id] via [tools.ozone.report.getReport]. *)
   let get_report (s : Session.session) ~proxy ~id () : report_view =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.report.getReport"
       [ ("id", string_of_int id) ]
     |> parse_report_result
 
+  (** Latest report via [tools.ozone.report.getLatestReport]. *)
   let get_latest_report (s : Session.session) ~proxy () : report_view =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
       "tools.ozone.report.getLatestReport" []
     |> parse_report_result
 
+  (** Assign a moderator via [tools.ozone.report.assignModerator]. *)
   let assign_report_moderator (s : Session.session) ~proxy ~report_id ?queue_id
       ?did ?is_permanent () : assignment_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -2180,6 +2250,7 @@ module Ozone = struct
            @ opt_json_bool "isPermanent" is_permanent)))
     |> parse_assignment_view
 
+  (** Unassign the moderator via [tools.ozone.report.unassignModerator]. *)
   let unassign_report_moderator (s : Session.session) ~proxy ~report_id () :
       assignment_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -2187,6 +2258,7 @@ module Ozone = struct
       (Yojson.Safe.to_string (`Assoc [ ("reportId", `Int report_id) ]))
     |> parse_assignment_view
 
+  (** Report assignments via [tools.ozone.report.getAssignments]. *)
   let get_report_assignments (s : Session.session) ~proxy ?only_active
       ?(report_ids = []) ?(dids = []) ?limit ?cursor () : assignments =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -2198,6 +2270,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_assignments
 
+  (** Record activity via [tools.ozone.report.createActivity]. *)
   let create_activity (s : Session.session) ~proxy ~activity ?report_id
       ?event_id ?internal_note ?public_note ?is_automated () :
       report_activity_view =
@@ -2208,6 +2281,7 @@ module Ozone = struct
             ?public_note ?is_automated ()))
     |> parse_activity_result
 
+  (** Activities for [report_id] via [tools.ozone.report.listActivities]. *)
   let list_activities (s : Session.session) ~proxy ~report_id ?limit ?cursor ()
       : report_activities =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -2216,6 +2290,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_report_activities
 
+  (** Activities via [tools.ozone.report.queryActivities]. *)
   let query_activities (s : Session.session) ~proxy ?(activity_types = [])
       ?created_after ?created_before ?sort_direction ?limit ?cursor () :
       report_activities =
@@ -2229,6 +2304,7 @@ module Ozone = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_report_activities
 
+  (** Move [report_id] to [queue_id] via [tools.ozone.report.reassignQueue]. *)
   let reassign_queue (s : Session.session) ~proxy ~report_id ~queue_id ?comment
       () : report_view =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -2240,6 +2316,7 @@ module Ozone = struct
            :: opt_json_str "comment" comment)))
     |> parse_report_result
 
+  (** Recompute stats via [tools.ozone.report.refreshStats]. *)
   let refresh_stats (s : Session.session) ~proxy ~start_date ~end_date
       ?queue_ids () : unit =
     ignore
@@ -2254,6 +2331,7 @@ module Ozone = struct
               | Some xs -> [ ("queueIds", json_ints xs) ]
               | None -> [])))))
 
+  (** Close reports for [subject] via [tools.ozone.report.closeReports]. *)
   let close_reports (s : Session.session) ~proxy ~subject ?(report_types = [])
       ?internal_note ?is_automated () : close_reports_result =
     Client.post_json ~session:s ~extra:(proxy_headers proxy)
@@ -2269,6 +2347,7 @@ module Ozone = struct
            @ opt_json_bool "isAutomated" is_automated)))
     |> parse_close_reports_result
 
+  (** Live report stats via [tools.ozone.report.getLiveStats]. *)
   let get_live_stats (s : Session.session) ~proxy ?queue_id ?moderator_did
       ?(report_types = []) () : report_stats =
     Client.get_json ~session:s ~extra:(proxy_headers proxy)
@@ -2278,6 +2357,7 @@ module Ozone = struct
       @ Client.repeat_param "reportTypes" report_types)
     |> parse_live_stats
 
+  (** Historical report stats via [tools.ozone.report.getHistoricalStats]. *)
   let get_historical_stats (s : Session.session) ~proxy ?queue_id ?moderator_did
       ?(report_types = []) ?start_date ?end_date ?limit ?cursor () :
       historical_stats =

--- a/src/repo_sync.ml
+++ b/src/repo_sync.ml
@@ -53,6 +53,8 @@ module Repo_sync = struct
     collections = []
     || List.exists (fun c -> path = c || starts_with path (c ^ "/")) collections
 
+  (** Split [collection/rkey] on the first [/]; no slash yields [path] and
+      [""]. *)
   let split_path path =
     match String.index_opt path '/' with
     | None -> (path, "")
@@ -60,6 +62,8 @@ module Repo_sync = struct
         ( String.sub path 0 i,
           String.sub path (i + 1) (String.length path - i - 1) )
 
+  (** Open a repo CAR: verify commit CID, rev TID, and MST (full tree when
+      [complete]). *)
   let open_car ?(complete = true) (car : Car.t) : snapshot =
     let commit_cid =
       match Car.root car with Some c -> c | None -> fail "CAR has no root"
@@ -98,9 +102,11 @@ module Repo_sync = struct
       tree;
     }
 
+  (** [open_car] on CARv1 [bytes]. *)
   let open_car_bytes ?complete (bytes : string) : snapshot =
     open_car ?complete (Car.parse bytes)
 
+  (** Re-verify the MST; optional [keys] check the commit signature. *)
   let verify_snapshot ?(keys : string list option) (snap : snapshot) : unit =
     Mst.verify_tree
       ~get_block:(Mst.store_get (Mst.store_of_car snap.car))
@@ -114,8 +120,10 @@ module Repo_sync = struct
         | `Invalid -> fail "commit signature is invalid"
         | `Unsupported_curve c -> fail ("commit uses unsupported curve " ^ c))
 
+  (** All record paths and CIDs in [snap]'s MST. *)
   let walk (snap : snapshot) : (string * Cid.t) list = Mst.walk snap.tree
 
+  (** Record bytes for [cid] in [car]; verifies the CID. *)
   let record_block (car : Car.t) (cid : Cid.t) : string =
     match Car.find_block car cid with
     | None -> fail ("record block missing " ^ Cid.to_string cid)
@@ -123,6 +131,7 @@ module Repo_sync = struct
         ignore (Cid.verify_block ~expected:cid ~codec:cid.codec b.data);
         b.data
 
+  (** Partial getRecord proof CAR: return path CID and record bytes. *)
   let verify_record_proof ~(car : Car.t) ~(path : string) : Cid.t * string =
     if not (Syntax.Syntax.is_valid_repo_path path) then
       fail ("invalid repo path " ^ path);
@@ -133,6 +142,7 @@ module Repo_sync = struct
     | None -> fail ("record path not in MST: " ^ path)
     | Some cid -> (cid, record_block car cid)
 
+  (** Commit block plus MST blocks in streamable pre-order. *)
   let preorder_blocks (snap : snapshot) : Car.block list =
     let commit_block =
       match Car.find_block snap.car snap.commit_cid with
@@ -147,11 +157,13 @@ module Repo_sync = struct
     in
     commit_block :: Mst.preorder_blocks snap.tree
 
+  (** True when [snap.car] blocks follow MST pre-order. *)
   let is_preorder (snap : snapshot) : bool =
     Car.follows_order
       ~expected:(List.map (fun (b : Car.block) -> b.cid) (preorder_blocks snap))
       (Car.block_cids snap.car)
 
+  (** Full repo CAR (commit root, pre-order blocks, first-occurrence only). *)
   let export_car (snap : snapshot) : Car.t =
     let seen = Hashtbl.create 16 in
     let blocks =
@@ -166,8 +178,10 @@ module Repo_sync = struct
     in
     { Car.roots = [ snap.commit_cid ]; blocks }
 
+  (** CARv1 bytes of [export_car snap]. *)
   let export_car_bytes (snap : snapshot) : string = Car.encode (export_car snap)
 
+  (** Partial CAR for [collections] (commit plus MST range proofs). *)
   let export_subset (snap : snapshot) ~(collections : string list) : Car.t =
     if collections = [] then export_car snap
     else
@@ -197,13 +211,14 @@ module Repo_sync = struct
             expected;
       }
 
+  (** CARv1 bytes of [export_subset]. *)
   let export_subset_bytes snap ~collections =
     Car.encode (export_subset snap ~collections)
 
   exception Not_preorder of string
 
-  (* Walk records by consuming blocks in streamable pre-order. Omitted child
-     CIDs (subset proofs) are skipped; an out-of-order present block fails. *)
+  (** Walk records by consuming blocks in streamable pre-order. Omitted child
+      CIDs (subset proofs) are skipped; an out-of-order present block fails. *)
   let stream_walk (car : Car.t) : (string * Cid.t) list =
     let by_cid = Hashtbl.create (List.length car.blocks) in
     List.iter
@@ -269,12 +284,15 @@ module Repo_sync = struct
     in
     walk_node commit.data
 
+  (** Walk records: streamable pre-order, or [Mst.walk_available] if
+      shuffled. *)
   let walk_car (car : Car.t) : (string * Cid.t) list =
     try stream_walk car
     with Not_preorder _ ->
       let snap = open_car ~complete:false car in
       Mst.walk_available snap.tree
 
+  (** Check collection range proofs and record blocks in a subset CAR. *)
   let verify_subset ~(collections : string list) (car : Car.t) : snapshot =
     let snap = open_car ~complete:false car in
     let store = Mst.store_of_car car in
@@ -295,6 +313,7 @@ module Repo_sync = struct
       collections;
     snap
 
+  (** In-memory TAP account for [did] (starts [Desynchronized]). *)
   let create_account ?(collections = []) ~did () : account =
     if not (Syntax.Syntax.is_valid_did did) then fail ("invalid did " ^ did);
     {
@@ -372,6 +391,7 @@ module Repo_sync = struct
       !deletes;
     List.rev !events
 
+  (** Check firehose commit DID/rev against the signed object. *)
   let verify_commit_object (c : Firehose.commit) : Mst.repo_commit =
     let signed = Firehose.repo_commit_of c in
     if c.repo <> signed.did then
@@ -380,6 +400,7 @@ module Repo_sync = struct
       fail (Printf.sprintf "commit.rev %s != rev %s" signed.rev c.rev);
     signed
 
+  (** Verify the firehose commit signature with PLC / did:key [keys]. *)
   let verify_commit_sig ~keys (c : Firehose.commit) : unit =
     let signed = Firehose.repo_commit_of c in
     match Mst.verify_commit_sig ~keys signed with
@@ -389,6 +410,7 @@ module Repo_sync = struct
     | `Unsupported_curve curve ->
         fail ("firehose commit uses unsupported curve " ^ curve)
 
+  (** Apply [c]'s ops to [prev] and check the resulting MST root. *)
   let apply_commit_tree (prev : snapshot) (c : Firehose.commit) : snapshot =
     if prev.did <> c.repo then
       fail
@@ -417,6 +439,7 @@ module Repo_sync = struct
       tree;
     }
 
+  (** Apply a live [#commit] to [acct], or queue / desync as needed. *)
   let process_commit ?keys ?(live = true) (acct : account) (c : Firehose.commit)
       : record_change list =
     if c.repo <> acct.did then
@@ -447,6 +470,7 @@ module Repo_sync = struct
               acct.commit <- Some c.commit;
               events)
 
+  (** Handle a [#sync] frame: desync unless [acct] already matches [s.rev]. *)
   let process_sync (acct : account) (s : Firehose.sync) : record_change list =
     if s.did <> acct.did then
       fail (Printf.sprintf "sync did %s != account %s" s.did acct.did);
@@ -456,6 +480,7 @@ module Repo_sync = struct
     | _ -> acct.status <- Desynchronized);
     []
 
+  (** Dispatch a firehose [msg] ([#commit] / [#sync]; others ignored). *)
   let process_message ?keys (acct : account) (msg : Firehose.message) :
       record_change list =
     match msg with
@@ -463,6 +488,7 @@ module Repo_sync = struct
     | `Sync s -> process_sync acct s
     | `Identity _ | `Account _ | `Info _ | `Error _ | `Unknown _ -> []
 
+  (** Backfill [acct] from a full repo CAR, then replay queued commits. *)
   let resync_from_car ?keys ?(live = false) (acct : account) (car : Car.t) :
       record_change list =
     acct.status <- In_progress;
@@ -484,18 +510,22 @@ module Repo_sync = struct
     in
     events @ rest
 
+  (** Full repo snapshot via [com.atproto.sync.getRepo]. *)
   let fetch_repo ?host ?session (did : string) : snapshot =
     open_car_bytes (Sync.get_repo ?host ?session did)
 
+  (** Subset CAR for [collections] from a fetched repo. *)
   let fetch_repo_subset ?host ?session ~did ~collections () : Car.t =
     let snap = fetch_repo ?host ?session did in
     export_subset snap ~collections
 
+  (** getRecord proof via [com.atproto.sync.getRecord]; verify path. *)
   let fetch_record_proof ?host ?session ?commit ~did ~collection ~rkey () :
       Cid.t * string =
     let car = Sync.get_record_car ?host ?session ?commit did collection rkey in
     verify_record_proof ~car ~path:(Sync.record_path ~collection ~rkey)
 
+  (** Fetch the repo and [resync_from_car] into [acct]. *)
   let backfill ?host ?session ?keys (acct : account) : record_change list =
     let snap = fetch_repo ?host ?session acct.did in
     resync_from_car ?keys ~live:false acct snap.car
@@ -503,7 +533,7 @@ module Repo_sync = struct
   type commit_signer =
     did:string -> data:Cid.t -> rev:string -> ?prev:Cid.t -> unit -> string
 
-  (* Offline signed repo: JSON records → DAG-CBOR → MST → commit → CAR. *)
+  (** Offline signed repo: JSON records → DAG-CBOR → MST → commit → CAR. *)
   let write_signed_repo ~did ~rev ?prev ~(sign : commit_signer)
       ~(records : (string * Yojson.Safe.t) list) () : snapshot =
     List.iter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds function-level `(** *)` odoc on remaining public **Ozone** XRPC wrappers and **Repo_sync** TAP helpers that #122 left module-level only (`emit_event` / `query_events` / `get_config` already documented). Short comments with NSID names. No behavior changes.

Skipped functions that already have `(** *)`. Did not touch test files, CHANGELOG, README, `identity.ml`, or #126 files.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md (docs-only odoc, same as #122/#125/#126)

## Functions documented

**Ozone** (`src/ozone.ml`) — wrappers still missing after #122:

- `labeler_proxy`, `proxy_headers`
- `query_statuses`
- `emit_event_service`, `query_events_service`, `get_config_service`
- `get_event`, `get_repo`, `get_record`, `get_records`, `get_repos`, `get_subjects`, `search_repos`
- `get_account_timeline`, `get_reporter_stats`
- `schedule_action`, `list_scheduled_actions`, `cancel_scheduled_actions`
- `list_templates`, `create_template`, `update_template`, `delete_template`
- `query_sets`, `upsert_set`, `get_set_values`, `add_set_values`, `delete_set_values`, `delete_set`
- `list_options`, `upsert_option`, `remove_options`
- `list_members`, `add_member`, `update_member`, `delete_member`
- `query_safelink_rules`, `add_safelink_rule`, `update_safelink_rule`, `remove_safelink_rule`, `query_safelink_events`
- `find_correlation`, `find_related_accounts`, `search_accounts_by_signature`
- `list_verifications`, `grant_verifications`, `revoke_verifications`
- `get_account_history`
- `list_queues`, `create_queue`, `update_queue`, `delete_queue`, `assign_queue_moderator`, `unassign_queue_moderator`, `get_queue_assignments`, `route_reports`
- `query_reports`, `get_report`, `get_latest_report`, `assign_report_moderator`, `unassign_report_moderator`, `get_report_assignments`, `create_activity`, `list_activities`, `query_activities`, `reassign_queue`, `refresh_stats`, `close_reports`, `get_live_stats`, `get_historical_stats`

Already had odoc (unchanged): `query_events`, `emit_event`, `get_config`.

**Repo_sync** (`src/repo_sync.ml`):

- `split_path`, `open_car`, `open_car_bytes`, `verify_snapshot`, `walk`, `record_block`, `verify_record_proof`
- `preorder_blocks`, `is_preorder`, `export_car`, `export_car_bytes`, `export_subset`, `export_subset_bytes`
- `stream_walk`, `walk_car`, `verify_subset`, `create_account`
- `verify_commit_object`, `verify_commit_sig`, `apply_commit_tree`
- `process_commit`, `process_sync`, `process_message`, `resync_from_car`
- `fetch_repo`, `fetch_repo_subset`, `fetch_record_proof`, `backfill`, `write_signed_repo`

Internal helpers (`fail`, `starts_with`, `path_in_scope`, `apply_record_op`, `apply_record_ops`, `diff_walk`) left undocumented.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb003da-cb03-409b-ae2c-0fe5820fef0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb003da-cb03-409b-ae2c-0fe5820fef0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

