### PR TITLE
Add function-level odoc on remaining Identity entry points

### DIFF
--- a/src/identity.ml
+++ b/src/identity.ml
@@ -36,7 +36,8 @@ module Identity = struct
     let bare = String.lowercase_ascii bare in
     bare = "localhost" || bare = "127.0.0.1" || bare = "[::1]" || bare = "::1"
 
-  (* PLC_ORIGIN, or local @atproto/dev-env :2582 when talking to a local PDS. *)
+  (** PLC directory origin: [PLC_ORIGIN], or [http://localhost:2582] on a
+      local PDS. *)
   let plc_directory ?host ?session () : string option =
     match Sys.getenv_opt "PLC_ORIGIN" with
     | Some o when String.trim o <> "" -> Some (String.trim o)
@@ -77,6 +78,7 @@ module Identity = struct
   let raise_xrpc json =
     failwith ("Identity: " ^ Error.Error.to_string (Error.Error.of_json json))
 
+  (** Host of a service endpoint URL (scheme and path stripped). *)
   let host_of_service_endpoint (url : string) : string =
     let strip prefix =
       let plen = String.length prefix in
@@ -106,6 +108,8 @@ module Identity = struct
     document : Did_plc.Did_plc.did_document option;
   }
 
+  (** Parse [resolveDid] JSON into [didDoc] and optional
+      [Did_plc.did_document]. *)
   let parse_did_resolution json : did_resolution =
     let open Yojson.Safe.Util in
     let did_doc =
@@ -146,9 +150,13 @@ module Identity = struct
       | Some _ -> raise_xrpc json
       | None -> json
 
+  (** Parsed {!resolve_did}: raw [didDoc] plus optional
+      [Did_plc.did_document]. *)
   let resolve_did_parsed ?host ?session (did : string) : did_resolution =
     resolve_did ?host ?session did |> parse_did_resolution
 
+  (** Resolve a handle or DID to [did], optional [handle], and [pds].
+      Supports did:plc, did:web, and did:key. *)
   let resolve ?host ?session (actor : string) : resolved_identity =
     let directory = plc_directory ?host ?session () in
     if String.length actor >= 4 && String.sub actor 0 4 = "did:" then
@@ -199,6 +207,7 @@ module Identity = struct
     did_doc : Yojson.Safe.t option;
   }
 
+  (** Parse [com.atproto.identity.defs#identityInfo] JSON. *)
   let parse_identity_info json : identity_info =
     let open Yojson.Safe.Util in
     {
@@ -247,6 +256,7 @@ module Identity = struct
       | Some _ -> raise_xrpc json
       | None -> parse_identity_info json
 
+  (** JSON body for [com.atproto.identity.updateHandle]. *)
   let update_handle_body (handle : string) : Yojson.Safe.t =
     `Assoc [ ("handle", `String handle) ]
 
@@ -257,6 +267,7 @@ module Identity = struct
     services : Yojson.Safe.t;
   }
 
+  (** Parse [com.atproto.identity.getRecommendedDidCredentials] output. *)
   let parse_recommended_did_credentials json : recommended_did_credentials =
     let open Yojson.Safe.Util in
     let strings field =
@@ -272,6 +283,7 @@ module Identity = struct
       services = json |> member "services";
     }
 
+  (** JSON body for [com.atproto.identity.signPlcOperation]. *)
   let sign_plc_operation_body ?token ?rotation_keys ?also_known_as
       ?verification_methods ?services () : Yojson.Safe.t =
     let str_list xs = `List (List.map (fun s -> `String s) xs) in
@@ -290,25 +302,39 @@ module Identity = struct
     in
     `Assoc fields
 
+  (** JSON body for [com.atproto.identity.submitPlcOperation]
+      ([operation] wrapper). *)
   let submit_plc_operation_body (operation : Yojson.Safe.t) : Yojson.Safe.t =
     `Assoc [ ("operation", operation) ]
 
+  (** DNS TXT name for handle verification ([_atproto.handle]). *)
   let handle_txt_name = Syntax.Syntax.handle_txt_name
+
+  (** DID from an [_atproto] TXT value ([did=did:...]). *)
   let parse_txt_did = Syntax.Syntax.parse_txt_did
+
+  (** HTTPS URL for handle verification ([/.well-known/atproto-did]). *)
   let handle_well_known_url = Syntax.Syntax.handle_well_known_url
+
+  (** DID from a [/.well-known/atproto-did] body. *)
   let parse_well_known_did = Syntax.Syntax.parse_well_known_did
 
+  (** Update the account handle via [com.atproto.identity.updateHandle]. *)
   let update_handle (s : Session.session) ~handle () : unit =
     ignore
       (Client.Client.post_json ~session:s "com.atproto.identity.updateHandle"
          (Yojson.Safe.to_string (update_handle_body handle)))
 
+  (** Recommended rotation keys and DID fields via
+      [com.atproto.identity.getRecommendedDidCredentials]. *)
   let get_recommended_did_credentials (s : Session.session) :
       recommended_did_credentials =
     Client.Client.get_json ~session:s
       "com.atproto.identity.getRecommendedDidCredentials" []
     |> parse_recommended_did_credentials
 
+  (** Sign a PLC operation via [com.atproto.identity.signPlcOperation].
+      Optional [token] comes from {!request_plc_operation_signature}. *)
   let sign_plc_operation (s : Session.session) ?token ?rotation_keys
       ?also_known_as ?verification_methods ?services () : Yojson.Safe.t =
     Client.Client.post_json ~session:s "com.atproto.identity.signPlcOperation"
@@ -316,20 +342,26 @@ module Identity = struct
          (sign_plc_operation_body ?token ?rotation_keys ?also_known_as
             ?verification_methods ?services ()))
 
+  (** Submit a signed PLC operation via
+      [com.atproto.identity.submitPlcOperation]. *)
   let submit_plc_operation (s : Session.session) ~operation () : unit =
     ignore
       (Client.Client.post_json ~session:s
          "com.atproto.identity.submitPlcOperation"
          (Yojson.Safe.to_string (submit_plc_operation_body operation)))
 
+  (** Email a PLC-operation signature token via
+      [com.atproto.identity.requestPlcOperationSignature]. *)
   let request_plc_operation_signature (s : Session.session) : unit =
     ignore
       (Client.Client.post_json ~session:s
          "com.atproto.identity.requestPlcOperationSignature" "")
 
+  (** JSON body for [com.atproto.identity.refreshIdentity]. *)
   let refresh_identity_body ~identifier : Yojson.Safe.t =
     `Assoc [ ("identifier", `String identifier) ]
 
+  (** Re-resolve [identifier] via [com.atproto.identity.refreshIdentity]. *)
   let refresh_identity ?session ?host ~identifier () : identity_info =
     Client.Client.post_json ?session ?host
       "com.atproto.identity.refreshIdentity"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only odoc on remaining public `Identity` entry points in `src/identity.ml` that still lacked `(** *)`. Covers the PLC helpers landed in #123 (`f8070515`) plus other public Identity helpers.

Already documented (skipped): `resolve_handle`, `resolve_did`, `resolve_identity`.

Documented in this PR:

- `get_recommended_did_credentials`
- `sign_plc_operation` / `sign_plc_operation_body`
- `submit_plc_operation` / `submit_plc_operation_body`
- `request_plc_operation_signature`
- `update_handle` / `update_handle_body`
- `refresh_identity` / `refresh_identity_body`
- `resolve` / `resolve_did_parsed`
- `plc_directory` / `host_of_service_endpoint`
- `parse_did_resolution` / `parse_identity_info` / `parse_recommended_did_credentials`
- `handle_txt_name` / `parse_txt_did` / `handle_well_known_url` / `parse_well_known_did`

Short comments, NSID names where relevant. HTTP plumbing and directory-fallback internals left uncommented (same as #126). No leftover-field restyles, no OCaml 5, no pin bump, no CHANGELOG/README (just landed in #127).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (comment-only; #127 just landed)

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f267c8d-ff38-4438-aaaf-a0dd4f3b6879?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f267c8d-ff38-4438-aaaf-a0dd4f3b6879&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

