### PR TITLE
Add function-level odoc on User, Cohttp_client, and Base32/58/64url helpers

### DIFF
--- a/src/base32.ml
+++ b/src/base32.ml
@@ -2,6 +2,7 @@
 module Base32 = struct
   let alphabet = "abcdefghijklmnopqrstuvwxyz234567"
 
+  (** RFC 4648 base32 encode (lowercase, no padding). *)
   let encode (data : string) : string =
     let len = String.length data in
     if len = 0 then ""
@@ -39,6 +40,7 @@ module Base32 = struct
     | '=' -> -1
     | _ -> failwith ("Base32.decode: invalid character " ^ String.make 1 c)
 
+  (** RFC 4648 base32 decode (case-insensitive; skips [=] padding). *)
   let decode (s : string) : string =
     let len = String.length s in
     let buf = Buffer.create (len * 5 / 8) in

--- a/src/base58.ml
+++ b/src/base58.ml
@@ -2,6 +2,7 @@
 module Base58 = struct
   let alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
+  (** Encode raw bytes as base58btc (Bitcoin alphabet, no checksum). *)
   let encode (data : string) : string =
     let len = String.length data in
     if len = 0 then ""
@@ -39,6 +40,7 @@ module Base58 = struct
     | Some i -> i
     | None -> failwith ("Base58.decode: invalid character " ^ String.make 1 c)
 
+  (** Decode a base58btc string to raw bytes. *)
   let decode (s : string) : string =
     let len = String.length s in
     if len = 0 then ""

--- a/src/base64url.ml
+++ b/src/base64url.ml
@@ -38,7 +38,10 @@ module Base64url = struct
       in
       loop 0 0 0 ""
 
+  (** Encode [data] as unpadded base64url. [~pad:true] adds [=]. *)
   let encode ?(pad = false) data = encode_with url_alphabet ~pad data
+
+  (** Encode [data] as standard base64. Pads by default. *)
   let encode_std ?(pad = true) data = encode_with std_alphabet ~pad data
 
   let value_of alphabet c =
@@ -76,9 +79,11 @@ module Base64url = struct
     loop 0 0 0;
     Buffer.contents buf
 
+  (** Decode unpadded or padded base64url; falls back to standard base64. *)
   let decode s =
     try decode_with url_alphabet s
     with Failure _ -> decode_with std_alphabet s
 
+  (** Decode standard base64, ignoring padding. *)
   let decode_std s = decode_with std_alphabet s
 end

--- a/src/cohttp_client.ml
+++ b/src/cohttp_client.ml
@@ -3,6 +3,7 @@ open Cohttp_lwt_unix
 
 (** Cohttp Lwt helpers shared by session, identity, and XRPC clients. *)
 module Cohttp_client = struct
+  (** GET [url] and return the response body (prints status/headers). *)
   let get_body url =
     let open Lwt.Infix in
     Cohttp_lwt_unix.Client.get (Uri.of_string url) >>= fun (resp, body) ->
@@ -13,6 +14,7 @@ module Cohttp_client = struct
     Printf.printf "Body of length: %d\n" (String.length body);
     body
 
+  (** GET [http://host:port] via [get_body]. *)
   let get_host (host : string) (port : int) : string Lwt.t =
     let url = Printf.sprintf "http://%s:%d" host port in
     get_body url
@@ -27,6 +29,7 @@ module Cohttp_client = struct
         let h = add_pair_to_header h hd in
         add_pairs_to_header h res
 
+  (** Percent-encode [k=v] pairs as a query string. *)
   let pairs_to_query_string params =
     let kv_to_string (k, v) = Uri.pct_encode k ^ "=" ^ Uri.pct_encode v in
     String.concat "&" (List.map kv_to_string params)
@@ -40,6 +43,7 @@ module Cohttp_client = struct
     String.concat "&" (List.map kv_to_string params)
   *)
 
+  (** JSON object whose values are string arrays (for POST bodies). *)
   let create_body_from_pairs_with_array_value pairs =
     `Assoc
       (List.map
@@ -48,6 +52,7 @@ module Cohttp_client = struct
          pairs)
     |> Yojson.to_string
 
+  (** Cohttp [Header.t] from [setting, value] pairs. *)
   let create_headers_from_pairs (header_settings : (string * string) list) =
     match header_settings with
     | [] -> Header.init ()
@@ -56,14 +61,17 @@ module Cohttp_client = struct
         let headers = add_pair_to_header headers hd in
         add_pairs_to_header headers res
 
+  (** Query string from [k, v] pairs; empty list is [""]. *)
   let create_body_from_pairs (data : (string * string) list) =
     match data with [] -> "" | _ -> pairs_to_query_string data
 
+  (** Add each [key=value] query parameter to [url]. *)
   let add_query_params_to_url url key values =
     List.fold_left
       (fun url value -> Uri.add_query_param' url (key, value))
       url values
 
+  (** [key=v1&key=v2&...] without percent-encoding. *)
   let add_query_params key values =
     List.map (fun value -> key ^ "=" ^ value) values |> String.concat "&"
 
@@ -74,9 +82,11 @@ module Cohttp_client = struct
     | _ -> pairs_with_array_value_to_query_string data
   *)
 
+  (** [Content-Type: application/json] header pair. *)
   let application_json_setting_tuple : string * string =
     ("Content-Type", "application/json")
 
+  (** POST JSON [data] to [url]. *)
   let post_data (url : string) data =
     let open Lwt.Infix in
     let headers =
@@ -92,6 +102,7 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  (** POST [data] to [url] with [headers]. *)
   let post_data_with_headers (url : string) data headers =
     let open Lwt.Infix in
     let body = Cohttp_lwt.Body.of_string data in
@@ -104,6 +115,7 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  (** GET [url?body] with [headers]; return the body string. *)
   let get_request_with_body_and_headers (url : string) body headers =
     let open Lwt.Infix in
     let url_with_body = url ^ "?" ^ body in
@@ -116,6 +128,7 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  (** GET [url?body] with [headers]; concatenate the body as bytes. *)
   let get_bytes_request_with_body_and_headers (url : string) body headers =
     let open Lwt.Infix in
     let url_with_body = url ^ "?" ^ body in
@@ -124,6 +137,7 @@ module Cohttp_client = struct
     body |> Cohttp_lwt.Body.to_stream |> Lwt_stream.to_list >|= fun blob_list ->
     String.concat "" blob_list
 
+  (** GET [url] with [headers]; return the body string. *)
   let get_request_with_headers (url : string) headers =
     let open Lwt.Infix in
     Cohttp_lwt_unix.Client.get ~headers (Uri.of_string url) >>= fun (_, body) ->
@@ -134,6 +148,7 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  (** GET [url] with [headers]; return [(status, body)]. *)
   let get_with_status (url : string) headers : (int * string) Lwt.t =
     let open Lwt.Infix in
     Cohttp_lwt_unix.Client.get ~headers (Uri.of_string url)
@@ -141,6 +156,7 @@ module Cohttp_client = struct
     let code = resp |> Response.status |> Code.code_of_status in
     body |> Cohttp_lwt.Body.to_string >|= fun body -> (code, body)
 
+  (** POST [data] to [url] with [headers]; return [(status, body)]. *)
   let post_with_status (url : string) data headers : (int * string) Lwt.t =
     let open Lwt.Infix in
     let body = Cohttp_lwt.Body.of_string data in
@@ -149,6 +165,7 @@ module Cohttp_client = struct
     let code = resp |> Response.status |> Code.code_of_status in
     body |> Cohttp_lwt.Body.to_string >|= fun body -> (code, body)
 
+  (** POST to [url] with [headers] and no body; return the body string. *)
   let post_request_with_headers (url : string) headers =
     let open Lwt.Infix in
     Cohttp_lwt_unix.Client.post ~headers (Uri.of_string url)
@@ -160,6 +177,7 @@ module Cohttp_client = struct
     (*Printf.printf "Body of length: %d\n" (String.length body);*)
     body
 
+  (** GET [url?body] and return the [Content-Type] header. *)
   let get_content_type_with_body_headers (url : string) body headers =
     let open Lwt.Infix in
     let url_with_body = url ^ "?" ^ body in
@@ -169,9 +187,9 @@ module Cohttp_client = struct
     | Some ct -> Lwt.return ct
     | None -> Lwt.return "No content-type found"
 
-  (* Status + all response headers (including repeated Set-Cookie) + body.
-     Used by live OAuth (DPoP-Nonce, CSRF cookies) where XRPC helpers drop
-     headers. Does not follow redirects. *)
+  (** Status, all response headers (including repeated [Set-Cookie]), and
+      body. Used by live OAuth ([DPoP-Nonce], CSRF cookies) where XRPC
+      helpers drop headers. Does not follow redirects. *)
   let request_full (meth : Code.meth) (url : string) ?(body = "")
       (header_settings : (string * string) list) :
       (int * (string * string) list * string) Lwt.t =

--- a/src/user.ml
+++ b/src/user.ml
@@ -1,4 +1,5 @@
 (** Minimal username/password pair (used by tests; prefer [Auth] + [Session]). *)
 module User = struct
+  (** Username/password pair used by tests. Prefer [Auth] + [Session]. *)
   type user = { username : string; password : string }
 end

--- a/src/user.ml
+++ b/src/user.ml
@@ -1,5 +1,5 @@
 (** Minimal username/password pair (used by tests; prefer [Auth] + [Session]). *)
 module User = struct
-  (** Username/password pair used by tests. Prefer [Auth] + [Session]. *)
   type user = { username : string; password : string }
+  (** Username/password pair used by tests. Prefer [Auth] + [Session]. *)
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds function-level `(** *)` odoc on remaining public helpers in low-level modules that still had only a module-level comment (`User`, `Cohttp_client`, `Base32`, `Base58`, `Base64url`). Short comments. No behavior changes.

Skipped functions that already have `(** *)`. Did not touch `identity.ml` (#130), `test/test_local_*.ml` / CHANGELOG / README (#129), or `ozone.ml` / `repo_sync.ml` (#128).

`lint-fmt` wanted the `User.user` type comment after the declaration (`doc-comments = after-when-possible`); wrapped on this branch.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (docs-only odoc; CHANGELOG owned by #129)

## Functions documented

**User** (`src/user.ml`):

- `user` (type; only public item; comment after the declaration for lint-fmt)

**Cohttp_client** (`src/cohttp_client.ml`):

- `get_body`, `get_host`
- `pairs_to_query_string`, `create_body_from_pairs_with_array_value`
- `create_headers_from_pairs`, `create_body_from_pairs`
- `add_query_params_to_url`, `add_query_params`
- `application_json_setting_tuple`
- `post_data`, `post_data_with_headers`
- `get_request_with_body_and_headers`, `get_bytes_request_with_body_and_headers`
- `get_request_with_headers`, `get_with_status`
- `post_with_status`, `post_request_with_headers`
- `get_content_type_with_body_headers`, `request_full` (existing `(* *)` converted to odoc)

Internal helpers (`add_pair_to_header`, `add_pairs_to_header`) left undocumented.

**Base32** (`src/base32.ml`):

- `encode`, `decode`

**Base58** (`src/base58.ml`):

- `encode`, `decode`

**Base64url** (`src/base64url.ml`):

- `encode`, `encode_std`, `decode`, `decode_std`

Internal helpers (`alphabet`, `value_of_char`, `value_of`, `encode_with`, `decode_with`, `std_alphabet`, `url_alphabet`) left undocumented.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29a0cdcd-8135-4fb2-92d9-b4042844dd0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29a0cdcd-8135-4fb2-92d9-b4042844dd0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

