### PR TITLE
Bump official lexicon pin and add Ozone.get_account_preferences

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,8 +38,8 @@ opam lint atproto.opam
 ## Lexicon coverage
 
 Official lexicons are pinned at bluesky-social/atproto
-[`60c4395951`](https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf)
-(APP-2933). `scripts/gen-official-nsids.py` rebuilds
+[`5c154f9c51`](https://github.com/bluesky-social/atproto/commit/5c154f9c5173e7823a5353eab92207508a7dea99).
+`scripts/gen-official-nsids.py` rebuilds
 `lexicons/official-nsids.json` against a SHA. TestSuite
 `test_lexicon_coverage` fails if a public client NSID is missing a helper,
 record builder, bundled permission-set, or an explicit one-line skip.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -4,7 +4,7 @@
 {{:https://atproto.com}AT Protocol}: XRPC, identity, repo sync,
 AppView, Ozone, and a chat client. Official lexicons are pinned at
 bluesky-social/atproto
-{{:https://github.com/bluesky-social/atproto/commit/60c439595101fbcbe612463e6f23200590c5daaf}[60c4395951]}.
+{{:https://github.com/bluesky-social/atproto/commit/5c154f9c5173e7823a5353eab92207508a7dea99}[5c154f9c51]}.
 Leftovers are hosted-only (no PDS, OSS chat backend, video transcoder,
 or Tap in this package).
 

--- a/lexicons/official-nsids.json
+++ b/lexicons/official-nsids.json
@@ -1,6 +1,6 @@
 {
   "source": "https://github.com/bluesky-social/atproto",
-  "sha": "60c439595101fbcbe612463e6f23200590c5daaf",
+  "sha": "5c154f9c5173e7823a5353eab92207508a7dea99",
   "main_types": [
     "query",
     "procedure",
@@ -8,10 +8,10 @@
     "record",
     "permission-set"
   ],
-  "lexicon_json_count": 403,
-  "nsid_count": 359,
+  "lexicon_json_count": 404,
+  "nsid_count": 360,
   "counts": {
-    "query": 177,
+    "query": 178,
     "procedure": 142,
     "subscription": 3,
     "record": 27,
@@ -1213,6 +1213,10 @@
     {
       "id": "tools.ozone.moderation.emitEvent",
       "type": "procedure"
+    },
+    {
+      "id": "tools.ozone.moderation.getAccountPreferences",
+      "type": "query"
     },
     {
       "id": "tools.ozone.moderation.getAccountTimeline",

--- a/scripts/gen-official-nsids.py
+++ b/scripts/gen-official-nsids.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Generate lexicons/official-nsids.json from bluesky-social/atproto.
 
-Re-run against a SHA (default: the APP-2933 pin) after official lexicon JSON
-changes. This writes a compact NSID + main-def-type snapshot, not the 403
+Re-run against a SHA (default: the current official pin) after official lexicon
+JSON changes. This writes a compact NSID + main-def-type snapshot, not the 404
 lexicon JSON bodies.
 
 Usage:
   scripts/gen-official-nsids.py
-  scripts/gen-official-nsids.py 60c4395951
-  scripts/gen-official-nsids.py 60c4395951 /path/to/atproto/lexicons
+  scripts/gen-official-nsids.py 5c154f9c51
+  scripts/gen-official-nsids.py 5c154f9c51 /path/to/atproto/lexicons
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
-DEFAULT_SHA = "60c439595101fbcbe612463e6f23200590c5daaf"
+DEFAULT_SHA = "5c154f9c5173e7823a5353eab92207508a7dea99"
 MAIN_TYPES = ("query", "procedure", "subscription", "record", "permission-set")
 TARBALL_URL = "https://codeload.github.com/bluesky-social/atproto/tar.gz/{sha}"
 

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -712,6 +712,8 @@ module Ozone = struct
   type timeline_item = { day : string; summary : timeline_summary list }
   type account_timeline = { timeline : timeline_item list }
 
+  type account_preferences = { preferences : Yojson.Safe.t list }
+
   type scheduled_action = {
     id : string option;
     subject : string option;
@@ -784,6 +786,9 @@ module Ozone = struct
       timeline =
         List.map parse_timeline_item (Client.list_member json "timeline");
     }
+
+  let parse_account_preferences json : account_preferences =
+    { preferences = Client.list_member json "preferences" }
 
   let parse_scheduled_action json : scheduled_action =
     {
@@ -865,6 +870,16 @@ module Ozone = struct
       "tools.ozone.moderation.getAccountTimeline"
       [ ("did", did) ]
     |> parse_account_timeline
+
+  (** Private preferences for [did] via
+      [tools.ozone.moderation.getAccountPreferences]
+      (moderator or admin auth; [app.bsky.actor.defs#preferences]). *)
+  let get_account_preferences (s : Session.session) ~proxy ~did () :
+      account_preferences =
+    Client.get_json ~session:s ~extra:(proxy_headers proxy)
+      "tools.ozone.moderation.getAccountPreferences"
+      [ ("did", did) ]
+    |> parse_account_preferences
 
   (** Reporter stats for [dids] via
       [tools.ozone.moderation.getReporterStats]. *)

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -711,7 +711,6 @@ module Ozone = struct
 
   type timeline_item = { day : string; summary : timeline_summary list }
   type account_timeline = { timeline : timeline_item list }
-
   type account_preferences = { preferences : Yojson.Safe.t list }
 
   type scheduled_action = {

--- a/test/test_lexicon_coverage.ml
+++ b/test/test_lexicon_coverage.ml
@@ -1,13 +1,13 @@
 open OUnit2
 
 (* Drift gate for official lexicon NSIDs pinned at bluesky-social/atproto
-   60c4395951 (APP-2933). Re-run scripts/gen-official-nsids.py against a newer
+   5c154f9c51. Re-run scripts/gen-official-nsids.py against a newer
    SHA to refresh lexicons/official-nsids.json; this test then fails until each
    new NSID has a client helper, record builder, bundled permission-set, or an
    explicit skip with a one-line reason. Hosted-only *servers* are not a reason
    to skip a public client NSID. *)
 
-let expected_pin = "60c439595101fbcbe612463e6f23200590c5daaf"
+let expected_pin = "5c154f9c5173e7823a5353eab92207508a7dea99"
 
 let covered_types =
   [ "query"; "procedure"; "subscription"; "record"; "permission-set" ]

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -101,8 +101,7 @@ let test_parse_timeline_and_schedule _ =
               [
                 `Assoc
                   [
-                    ( "$type",
-                      `String "app.bsky.actor.defs#adultContentPref" );
+                    ("$type", `String "app.bsky.actor.defs#adultContentPref");
                     ("enabled", `Bool true);
                   ];
               ] );

--- a/test/test_ozone.ml
+++ b/test/test_ozone.ml
@@ -92,6 +92,28 @@ let test_parse_timeline_and_schedule _ =
   in
   OUnit2.assert_equal 1 (List.length timeline.timeline);
   OUnit2.assert_equal 2 (List.hd (List.hd timeline.timeline).summary).count;
+  let prefs =
+    Ozone.parse_account_preferences
+      (`Assoc
+        [
+          ( "preferences",
+            `List
+              [
+                `Assoc
+                  [
+                    ( "$type",
+                      `String "app.bsky.actor.defs#adultContentPref" );
+                    ("enabled", `Bool true);
+                  ];
+              ] );
+        ])
+  in
+  OUnit2.assert_equal 1 (List.length prefs.preferences);
+  let open Yojson.Safe.Util in
+  OUnit2.assert_equal
+    ~printer:(fun x -> x)
+    "app.bsky.actor.defs#adultContentPref"
+    (List.hd prefs.preferences |> member "$type" |> to_string);
   let result =
     Ozone.parse_batch_result
       (`Assoc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Official `lexicons/` drifted past pin `60c4395951` because bluesky-social/atproto main added `tools.ozone.moderation.getAccountPreferences`. That file is the only lexicon-path change since the old pin, and it landed in official main at `5c154f9c5173e7823a5353eab92207508a7dea99` (#5421).

- Pin `lexicons/official-nsids.json` to that SHA (360 NSIDs / 404 lexicon JSON files; +1 query).
- Re-ran `scripts/gen-official-nsids.py` and updated `DEFAULT_SHA` / `test_lexicon_coverage` `expected_pin`.
- Added `Ozone.get_account_preferences` (required `did`, `app.bsky.actor.defs#preferences` output, moderator/admin auth) with a short odoc. Coverage gate sees the helper; no skip.
- Offline parser coverage in `test/test_ozone.ml` only. Did not edit `test/test_local_*.ml`, `CHANGELOG.md`, or `README.md`.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] Lexicon pin bump: `scripts/gen-official-nsids.py` re-run; helper bound (no skip)
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public entry point has a function-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (left untouched per request)

Fixes lexicon-pin drift CI on every PR until this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3d63107-ea52-48ff-8851-16d3b88d197e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3d63107-ea52-48ff-8851-16d3b88d197e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

