### PR TITLE
Add function-level odoc on remaining encoding / DID / crypto helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ records what actually shipped through
 (remaining function-level odoc on Server XRPC wrappers), including
 [#134](https://github.com/david-engelmann/atproto/pull/134)
 (function-level odoc on remaining Error / Xrpc / Request / Response /
-Http_client / Http_method / Websocket helpers), including
+Http_client / Http_method / Websocket helpers) and this PR
+(function-level odoc on Tid / At_uri / Dag_cbor / K256 / Did_key /
+Did_web), including
 [#127](https://github.com/david-engelmann/atproto/pull/127)
 (CHANGELOG through #126), including
 [#126](https://github.com/david-engelmann/atproto/pull/126)
@@ -258,6 +260,9 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `update_account_email` / `update_account_handle` /
   `update_account_password` / `update_account_signing_key`).
   Comment-only
+- This PR: function-level odoc on remaining Tid / At_uri / Dag_cbor /
+  K256 / Did_key / Did_web helpers (`of_int64`, `to_string`, `as_text`,
+  `low_s`, `is_did_key`, `is_web_did`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/at_uri.ml
+++ b/src/at_uri.ml
@@ -16,6 +16,8 @@ module Uri = struct
     search_params : (string * string) list option;
   }
 
+  (** Convert an AT URI to the legacy [uri] record ([host] / [path_name] /
+      [hash]). *)
   let to_legacy (u : t) : uri =
     {
       host = u.authority;
@@ -24,6 +26,7 @@ module Uri = struct
       search_params = u.query;
     }
 
+  (** Convert a legacy [uri] record to an AT URI ([fragment] is [None]). *)
   let of_legacy (u : uri) : t =
     {
       authority = u.host;
@@ -104,6 +107,8 @@ module Uri = struct
     in
     { authority; collection; rkey; query; fragment }
 
+  (** Serialize [u] as
+      [at://authority[/collection[/rkey]][?query][#fragment]]. *)
   let to_string (u : t) : string =
     let buf = Buffer.create 64 in
     Buffer.add_string buf "at://";
@@ -131,6 +136,8 @@ module Uri = struct
     | None -> ());
     Buffer.contents buf
 
+  (** Build an AT URI for [authority] (DID or handle), optional
+      [collection] NSID, and optional record key [rkey]. *)
   let record ?(collection = "") ?(rkey = "") (authority : string) : t =
     {
       authority;

--- a/src/dag_cbor.ml
+++ b/src/dag_cbor.ml
@@ -123,6 +123,8 @@ module Dag_cbor = struct
       put 1 56;
       Bytes.to_string b
 
+  (** Decode one DAG-CBOR value starting at [off]. Returns
+      [value, next_offset]. *)
   let rec decode_from (s : string) (off : int) : value * int =
     if off >= String.length s then fail "truncated";
     let b = Char.code s.[off] in
@@ -268,20 +270,30 @@ module Dag_cbor = struct
     | Some v -> v
     | None -> fail ("missing field " ^ key)
 
+  (** Unwrap a [Text]; raise [Decode_error] otherwise. *)
   let as_text = function Text t -> t | _ -> fail "expected text"
 
+  (** Unwrap an [Int] or [Int64] as [int]; raise [Decode_error]
+      otherwise. *)
   let as_int = function
     | Int n -> n
     | Int64 n -> Int64.to_int n
     | _ -> fail "expected int"
 
+  (** Unwrap an [Int] or [Int64] as [int64]; raise [Decode_error]
+      otherwise. *)
   let as_int64 = function
     | Int n -> Int64.of_int n
     | Int64 n -> n
     | _ -> fail "expected int64"
 
+  (** Unwrap a [Bool]; raise [Decode_error] otherwise. *)
   let as_bool = function Bool b -> b | _ -> fail "expected bool"
+
+  (** Unwrap [Bytes]; raise [Decode_error] otherwise. *)
   let as_bytes = function Bytes b -> b | _ -> fail "expected bytes"
+
+  (** Unwrap an [Array]; raise [Decode_error] otherwise. *)
   let as_array = function Array a -> a | _ -> fail "expected array"
 
   (** Unwrap a [Cid] (or a text CID string). *)
@@ -290,11 +302,14 @@ module Dag_cbor = struct
     | Text t -> Cid.of_string t
     | _ -> fail "expected CID"
 
+  (** [None] for [Null], [Some] for [Text]; raise [Decode_error]
+      otherwise. *)
   let as_text_opt = function
     | Null -> None
     | Text t -> Some t
     | _ -> fail "expected text or null"
 
+  (** [None] for [Null], otherwise {!as_cid}. *)
   let as_cid_opt = function Null -> None | v -> Some (as_cid v)
 
   (** IPLD JSON to DAG-CBOR. Official [$link] / [$bytes] objects become

--- a/src/did_key.ml
+++ b/src/did_key.ml
@@ -7,14 +7,19 @@ module Did_key = struct
   type curve = P256 | K256 | Other of int
   type t = { curve : curve; public_key : string }
 
+  (** Multicodec code for P-256 public keys ([0x1200]). *)
   let p256_code = 0x1200
+
+  (** Multicodec code for secp256k1 public keys ([0xe7]). *)
   let k256_code = 0xe7
 
+  (** Short curve name ([p256], [k256], or [0x...]). *)
   let curve_name = function
     | P256 -> "p256"
     | K256 -> "k256"
     | Other n -> Printf.sprintf "0x%x" n
 
+  (** True when [s] starts with [did:key:]. *)
   let is_did_key (s : string) : bool =
     String.length s > 8 && String.sub s 0 8 = "did:key:"
 

--- a/src/did_web.ml
+++ b/src/did_web.ml
@@ -5,6 +5,7 @@ open Did_plc
 module Did_web = struct
   type did_document = Did_plc.did_document
 
+  (** True when [did] starts with [did:web:]. *)
   let is_web_did (did : string) : bool =
     String.length did > 8 && String.sub did 0 8 = "did:web:"
 
@@ -27,6 +28,7 @@ module Did_web = struct
         Printf.sprintf "https://%s/%s/did.json" (Uri.pct_decode host)
           (String.concat "/" (List.map Uri.pct_decode path))
 
+  (** Parse a DID document JSON object (same shape as [did:plc]). *)
   let parse_document = Did_plc.parse_document
 
   (** Fetch the [did:web:] document as JSON. *)

--- a/src/k256.ml
+++ b/src/k256.ml
@@ -44,7 +44,10 @@ module K256 = struct
     done;
     Z.of_bits (Bytes.to_string buf)
 
+  (** 32-byte big-endian secp256k1 curve order [n]. *)
   let n_octets = be_of_z n
+
+  (** 32-byte big-endian [n/2], the low-S threshold. *)
   let n_half_octets = be_of_z n_half
 
   let sub_be a b =
@@ -61,9 +64,11 @@ module K256 = struct
     done;
     Bytes.to_string out
 
+  (** Force IEEE P1363 [s] into the low-S range ([s] or [n-s]). *)
   let low_s (s : string) : string =
     if String.compare s n_half_octets > 0 then sub_be n_octets s else s
 
+  (** True when IEEE P1363 [s] is already low-S ([s <= n/2]). *)
   let is_low_s (s : string) : bool = String.compare s n_half_octets <= 0
   let in_scalar z = Z.gt z z0 && Z.lt z n
   let ( %: ) a m = Z.(erem a m)

--- a/src/k256.ml
+++ b/src/k256.ml
@@ -70,6 +70,7 @@ module K256 = struct
 
   (** True when IEEE P1363 [s] is already low-S ([s <= n/2]). *)
   let is_low_s (s : string) : bool = String.compare s n_half_octets <= 0
+
   let in_scalar z = Z.gt z z0 && Z.lt z n
   let ( %: ) a m = Z.(erem a m)
   let ( +: ) a b = Z.(a + b) %: p

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -1,7 +1,12 @@
 (** Timestamp Identifiers (TIDs) — https://atproto.com/specs/tid *)
 module Tid = struct
+  (** Crockford-style base32 alphabet used by TIDs (no [0], [1], or [l]). *)
   let alphabet = "234567abcdefghijklmnopqrstuvwxyz"
+
+  (** First-character alphabet: keeps the TID's high bit zero. *)
   let first_ok = "234567abcdefghij"
+
+  (** The all-zero TID ([2222222222222]). *)
   let zero = "2222222222222"
 
   exception Invalid of string
@@ -32,6 +37,7 @@ module Tid = struct
         in
         loop 1
 
+  (** Encode the low 63 bits of [v] as a 13-character TID. *)
   let of_int64 (v : int64) : string =
     let v = Int64.logand v 0x7FFF_FFFF_FFFF_FFFFL in
     let buf = Bytes.create 13 in
@@ -44,6 +50,8 @@ module Tid = struct
     loop 12 v;
     Bytes.to_string buf
 
+  (** Decode a 13-character TID to its 64-bit value. Fails if [s] is not
+      a valid TID or the high bit is set. *)
   let to_int64 (s : string) : int64 =
     if String.length s <> 13 then fail "TID must be 13 characters";
     let rec loop i acc =
@@ -59,29 +67,40 @@ module Tid = struct
       fail "TID top bit must be 0";
     v
 
+  (** Validate [s] as a TID and return it. Raises [Invalid] otherwise. *)
   let of_string (s : string) : string =
     if not (is_valid s) then fail ("invalid TID " ^ s);
     s
 
+  (** Microseconds since the Unix epoch encoded in [s] (high 53 bits). *)
   let timestamp_us (s : string) : int64 =
     Int64.shift_right_logical (to_int64 s) 10
 
+  (** 10-bit clock identifier encoded in [s] (low 10 bits). *)
   let clock_id (s : string) : int =
     Int64.to_int (Int64.logand (to_int64 s) 0x3FFL)
 
+  (** Build a TID from [timestamp_us] and optional [clock_id] (0-1023).
+      Used as record keys ([rkey]) and repo commit [rev]s. *)
   let create ?(clock_id = 0) (timestamp_us : int64) : string =
     let ts = Int64.logand timestamp_us 0x1F_FFFF_FFFF_FFFFL in
     let clk = Int64.logand (Int64.of_int clock_id) 0x3FFL in
     of_int64 (Int64.logor (Int64.shift_left ts 10) clk)
 
+  (** TID for the current wall-clock time. [clock_id] defaults to a
+      random 10-bit value. *)
   let now ?(clock_id = Random.int 1024) () : string =
     let us = Int64.of_float (Unix.gettimeofday () *. 1_000_000.) in
     create ~clock_id us
 
   (* Sync spec: reject commit revs corresponding to a future timestamp
      beyond a short clock-drift window (default 5 minutes). *)
+  (** Default clock-skew window for {!is_future} (5 minutes, in microseconds). *)
   let default_clock_skew_us = 300_000_000L
 
+  (** True when [s] is a valid TID whose timestamp is more than [skew_us]
+      ahead of [now_us] (or wall-clock now). Sync rejects future commit
+      [rev]s beyond this drift window. *)
   let is_future ?(now_us : int64 option) ?(skew_us = default_clock_skew_us)
       (s : string) : bool =
     if not (is_valid s) then false

--- a/src/tid.ml
+++ b/src/tid.ml
@@ -95,6 +95,7 @@ module Tid = struct
 
   (* Sync spec: reject commit revs corresponding to a future timestamp
      beyond a short clock-drift window (default 5 minutes). *)
+
   (** Default clock-skew window for {!is_future} (5 minutes, in microseconds). *)
   let default_clock_skew_us = 300_000_000L
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only function-level odoc on remaining public helpers in `Tid`, `At_uri`, `Dag_cbor`, `Hash`, `Varint`, `K256`, `Did_key`, and `Did_web`. Style matches `src/identity.ml` / `src/error.ml`: a `(** ... *)` immediately above each public `let`. Hash and Varint already had complete function-level odoc and are unchanged.

Documents AT Protocol meaning (TID rkeys / commit revs, `at://` URIs, DAG-CBOR accessors, secp256k1 low-S, `did:key` / `did:web`).

Rebased onto current `main` after [#135](https://github.com/david-engelmann/atproto/pull/135) (`22f2af34`). CHANGELOG keeps notes already on `main` (#129, #134, #136, #135) plus this PR's Tid / At_uri / Dag_cbor / K256 / Did_key / Did_web bullet.

No logic restyle, no test edits, no lexicon pin bump, no hosted chat / video / Tap, not an opam-repository publish.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6a84ffc-2ff2-46fa-bb48-1976ec6c3e98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6a84ffc-2ff2-46fa-bb48-1976ec6c3e98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

