### PR TITLE
Add function-level odoc on remaining XRPC / HTTP plumbing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 Notes for the packaged **0.1.0** library. This file records what actually
-shipped through this PR (function-level odoc on remaining Error / Xrpc /
-Request / Response / Http_client / Http_method / Websocket helpers),
-including [#127](https://github.com/david-engelmann/atproto/pull/127)
+shipped through [#134](https://github.com/david-engelmann/atproto/pull/134)
+(function-level odoc on remaining Error / Xrpc / Request / Response /
+Http_client / Http_method / Websocket helpers), including
+[#127](https://github.com/david-engelmann/atproto/pull/127)
 (CHANGELOG through #126), including
 [#126](https://github.com/david-engelmann/atproto/pull/126)
 (function-level odoc on remaining Firehose / Oauth / Session / Auth /
@@ -214,8 +215,9 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   Hash / Varint / Error / Http_client entry points (`subscribe_url`,
   `pkce_s256`, `refresh_session`, `get_json`, `describe_server`).
   Comment-only
-- This PR: function-level odoc on remaining Error / Xrpc / Request /
-  Response / Http_client / Http_method / Websocket helpers
+- [#134](https://github.com/david-engelmann/atproto/pull/134):
+  function-level odoc on remaining Error / Xrpc / Request / Response /
+  Http_client / Http_method / Websocket helpers
   (`parse_error_from_json`, `parse_proxy`, `parse_service_auth`,
   `xrpc_put`, `recv_message`). Comment-only
 - `examples/offline.ml` typechecks against the public API under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 Notes for the packaged **0.1.0** library. This file records what actually
-shipped through [#127](https://github.com/david-engelmann/atproto/pull/127)
+shipped through this PR (function-level odoc on remaining Error / Xrpc /
+Request / Response / Http_client / Http_method / Websocket helpers),
+including [#127](https://github.com/david-engelmann/atproto/pull/127)
 (CHANGELOG through #126), including
 [#126](https://github.com/david-engelmann/atproto/pull/126)
 (function-level odoc on remaining Firehose / Oauth / Session / Auth /
@@ -212,6 +214,10 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   Hash / Varint / Error / Http_client entry points (`subscribe_url`,
   `pkce_s256`, `refresh_session`, `get_json`, `describe_server`).
   Comment-only
+- This PR: function-level odoc on remaining Error / Xrpc / Request /
+  Response / Http_client / Http_method / Websocket helpers
+  (`parse_error_from_json`, `parse_proxy`, `parse_service_auth`,
+  `xrpc_put`, `recv_message`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/error.ml
+++ b/src/error.ml
@@ -62,6 +62,7 @@ module Error = struct
   (* Local AppView implements some NSIDs but keeps them flag-off
      (e.g. InvalidRequest: Search v2 is not enabled). A local PDS can
      also reject a record $type it has not bundled yet. *)
+
   (** True when [InvalidRequest] means the NSID is flag-off ([not
       enabled] / [not available] / [unknown lexicon]). *)
   let is_feature_disabled (e : t) : bool =

--- a/src/error.ml
+++ b/src/error.ml
@@ -4,6 +4,8 @@ module Error = struct
   type error = t
   type error_type = [ `RateLimitExceeded of t | `Xrpc of t ]
 
+  (** Parse XRPC [error] / [message] fields from [json]. Missing [error]
+      is ["Unknown"]; missing [message] is empty. *)
   let parse_error_from_json json : t =
     let open Yojson.Safe.Util in
     let error =
@@ -47,6 +49,7 @@ module Error = struct
   let is_not_implemented (e : t) : bool =
     e.error = "MethodNotImplemented" || e.error = "MethodNotFound"
 
+  (** Case-insensitive substring match (feature-disabled XRPC messages). *)
   let contains_ci hay needle =
     let h = String.lowercase_ascii hay and n = String.lowercase_ascii needle in
     let rec aux i =
@@ -59,6 +62,8 @@ module Error = struct
   (* Local AppView implements some NSIDs but keeps them flag-off
      (e.g. InvalidRequest: Search v2 is not enabled). A local PDS can
      also reject a record $type it has not bundled yet. *)
+  (** True when [InvalidRequest] means the NSID is flag-off ([not
+      enabled] / [not available] / [unknown lexicon]). *)
   let is_feature_disabled (e : t) : bool =
     e.error = "InvalidRequest"
     && (contains_ci e.message "not enabled"
@@ -70,6 +75,7 @@ module Error = struct
   let is_not_served (e : t) : bool =
     is_not_implemented e || is_feature_disabled e
 
+  (** True when [json] is [MethodNotImplemented] or [MethodNotFound]. *)
   let is_not_implemented_json json : bool =
     match check_for_error json with
     | Some "MethodNotImplemented" | Some "MethodNotFound" -> true

--- a/src/http_client.ml
+++ b/src/http_client.ml
@@ -9,7 +9,10 @@ open Lwt.Infix
 module Http_client = struct
   exception Error of string
 
+  (** Default request timeout (15s). *)
   let default_timeout = 15.0
+
+  (** Same User-Agent as [Request.user_agent]. *)
   let user_agent = Request.user_agent
 
   type parsed_url = {
@@ -21,6 +24,7 @@ module Http_client = struct
 
   let fail msg = raise (Error msg)
 
+  (** Parse an [https://] URL for the HTTP/2 transport. *)
   let parse_url (url : string) : parsed_url =
     let uri = Uri.of_string url in
     let scheme =
@@ -68,6 +72,7 @@ module Http_client = struct
     | Unix.ADDR_UNIX _ -> None
     | ADDR_INET (addr, port) -> Some (addr, port)
 
+  (** DNS lookup for [host]:[port] (HTTP/2 connect). *)
   let get_addr_info (host : string) (port : int) : Unix.addr_info list Lwt.t =
     Lwt_unix.getaddrinfo host (string_of_int port)
       [ Unix.AI_SOCKTYPE Unix.SOCK_STREAM ]
@@ -206,10 +211,12 @@ module Http_client = struct
   let delete url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout (Request.delete url ~headers ?body ())
 
+  (** HTTP/2 PATCH [url] with optional [body]. *)
   let patch url ?(headers = []) ?body ?timeout () : Response.response Lwt.t =
     request ?timeout
       (Request.create ~method_:Http_method.Patch ~url ~headers ?body ())
 
+  (** HTTP/2 GET [https://host[:port]/]. *)
   let get_host (host : string) (port : int) : Response.response Lwt.t =
     let url =
       if port = 443 then Printf.sprintf "https://%s/" host
@@ -258,16 +265,19 @@ module Http_client = struct
     then headers
     else ("content-type", "application/json") :: headers
 
+  (** HTTP/2 PUT for XRPC [nsid] on [host] (JSON content-type default). *)
   let xrpc_put ~host ?port ~nsid ?(headers = []) ?body ?timeout () :
       Response.response Lwt.t =
     put
       (xrpc_url ~host ?port nsid ())
       ~headers:(json_headers headers) ?body ?timeout ()
 
+  (** HTTP/2 DELETE for XRPC [nsid] on [host]. *)
   let xrpc_delete ~host ?port ~nsid ?(headers = []) ?body ?timeout () :
       Response.response Lwt.t =
     delete (xrpc_url ~host ?port nsid ()) ~headers ?body ?timeout ()
 
+  (** HTTP/2 PATCH for XRPC [nsid] on [host] (JSON content-type default). *)
   let xrpc_patch ~host ?port ~nsid ?(headers = []) ?body ?timeout () :
       Response.response Lwt.t =
     patch

--- a/src/request.ml
+++ b/src/request.ml
@@ -9,6 +9,7 @@ module Request = struct
     body : string option;
   }
 
+  (** User-Agent sent by [Http_client] ([david-engelmann/atproto]). *)
   let user_agent = "david-engelmann/atproto (OCaml SDK)"
 
   (** Build a request record ([method_], [url], optional [headers] /
@@ -24,9 +25,11 @@ module Request = struct
   let post url ?(headers = []) ?body () : request =
     create ~method_:Http_method.Post ~url ~headers ?body ()
 
+  (** PUT [url] with optional [body]. *)
   let put url ?(headers = []) ?body () : request =
     create ~method_:Http_method.Put ~url ~headers ?body ()
 
+  (** DELETE [url]. *)
   let delete url ?(headers = []) ?body () : request =
     create ~method_:Http_method.Delete ~url ~headers ?body ()
 

--- a/src/response.ml
+++ b/src/response.ml
@@ -23,11 +23,14 @@ module Response = struct
   (** Response body as a UTF-8 string. *)
   let body_string (r : response) : string = Bytes.to_string r.content
 
+  (** Case-insensitive header lookup ([RateLimit-*],
+      [atproto-repo-rev]). *)
   let header (r : response) name : string option =
     let lower = String.lowercase_ascii name in
     List.find_map
       (fun (k, v) -> if String.lowercase_ascii k = lower then Some v else None)
       r.headers
 
+  (** [Content-Type] header, if present. *)
   let content_type (r : response) : string option = header r "content-type"
 end

--- a/src/websocket.ml
+++ b/src/websocket.ml
@@ -20,8 +20,10 @@ module Websocket = struct
   (** RFC 6455 §4.1: the client offered [Sec-WebSocket-Protocol] but the
       101 response omitted it or named a protocol that was not offered. *)
 
+  (** RFC 6455 magic GUID for [Sec-WebSocket-Accept]. *)
   let guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
+  (** [Sec-WebSocket-Accept] from the client key (SHA-1 + GUID). *)
   let accept_key (sec_websocket_key : string) : string =
     Base64url.encode_std ~pad:true (Hash.sha1 (sec_websocket_key ^ guid))
 
@@ -40,6 +42,7 @@ module Websocket = struct
     done;
     Bytes.to_string out
 
+  (** Encode one RFC 6455 frame. Clients mask by default. *)
   let encode_frame ?(fin = true) ?(mask = true) ~(opcode : int)
       (payload : string) : string =
     let buf = Buffer.create (String.length payload + 14) in
@@ -69,6 +72,7 @@ module Websocket = struct
 
   type decoded_frame = { fin : bool; opcode : int; payload : string }
 
+  (** Decode one frame by reading from [read_exact]. *)
   let decode_frame_header (read_exact : int -> string) : decoded_frame =
     let h = read_exact 2 in
     let b0 = Char.code h.[0] in
@@ -94,6 +98,7 @@ module Websocket = struct
     let payload = if masked then mask_payload mask_key payload else payload in
     { fin; opcode; payload }
 
+  (** Decode one frame from [bytes]; returns the frame and bytes consumed. *)
   let decode_frame_bytes (bytes : string) : decoded_frame * int =
     if String.length bytes < 2 then failwith "Websocket.decode_frame: truncated";
     let off = ref 2 in
@@ -157,15 +162,22 @@ module Websocket = struct
     in
     loop 0
 
+  (** Send [payload] as a frame (default opcode 2 / binary). *)
   let send (ws : t) ?(opcode = 2) (payload : string) : unit =
     write_all ws.transport (encode_frame ~opcode payload)
 
+  (** Send a close frame (opcode 8). *)
   let send_close (ws : t) : unit = send ws ~opcode:8 ""
+
+  (** Send a pong frame (opcode 10). *)
   let send_pong (ws : t) payload = send ws ~opcode:10 payload
 
+  (** Read one raw frame. *)
   let recv_frame (ws : t) : decoded_frame =
     decode_frame_header (fun n -> read_exact ws.transport n)
 
+  (** Read a complete message (continuation frames). Auto-replies to
+      ping. Used by firehose / Jetstream / [subscribeLabels]. *)
   let recv_message (ws : t) : message =
     let rec collect opcode acc =
       let frame = recv_frame ws in
@@ -185,6 +197,7 @@ module Websocket = struct
     in
     collect 0 ""
 
+  (** Parse [ws://] or [wss://] into host, port, and path. *)
   let parse_url (url : string) : parsed_url =
     let secure, rest =
       if String.length url >= 6 && String.sub url 0 6 = "wss://" then
@@ -208,10 +221,12 @@ module Websocket = struct
     in
     { secure; host; port; path }
 
+  (** [(host, port, path)] from a [ws://] or [wss://] URL. *)
   let parse_wss_url (url : string) : string * int * string =
     let p = parse_url url in
     (p.host, p.port, p.path)
 
+  (** Host header authority ([host] or [host:port]). *)
   let authority (p : parsed_url) : string =
     if (p.secure && p.port = 443) || ((not p.secure) && p.port = 80) then p.host
     else Printf.sprintf "%s:%d" p.host p.port
@@ -249,6 +264,8 @@ module Websocket = struct
     String.concat ""
       (List.map (fun (k, v) -> Printf.sprintf "%s: %s\r\n" k v) extra)
 
+  (** [Sec-WebSocket-Protocol] values offered in [extra] handshake
+      headers (Jetstream v2 [xrpc.v1.json]). *)
   let offered_subprotocols (extra : (string * string) list) : string list =
     List.flatten
       (List.map
@@ -260,6 +277,8 @@ module Websocket = struct
                (List.map String.trim (String.split_on_char ',' v)))
          extra)
 
+  (** RFC 6455 §4.1: if the client offered a subprotocol, the 101 must
+      echo one of them. *)
   let check_subprotocol_echo ~(offered : string list) (echoed : string option) :
       unit =
     match offered with
@@ -363,6 +382,7 @@ module Websocket = struct
        raise exn);
     { transport }
 
+  (** Send close and shut down the transport. *)
   let close (ws : t) =
     (try send_close ws with _ -> ());
     match ws.transport with
@@ -371,6 +391,7 @@ module Websocket = struct
         (try Unix.shutdown fd Unix.SHUTDOWN_ALL with _ -> ());
         try Unix.close fd with _ -> ())
 
+  (** {!connect}, run [f], then {!close}. *)
   let with_connection ?tls_verify ?(extra_headers = []) url f =
     let ws = connect ?tls_verify ~extra_headers url in
     Fun.protect ~finally:(fun () -> close ws) (fun () -> f ws)

--- a/src/xrpc.ml
+++ b/src/xrpc.ml
@@ -38,6 +38,7 @@ module Xrpc = struct
 
   type proxy = { did : string; service : string }
 
+  (** Parse [atproto-proxy] ([did#service]). *)
   let parse_proxy (value : string) : proxy =
     let v = trim value in
     match String.index_opt v '#' with
@@ -50,18 +51,22 @@ module Xrpc = struct
         if service = "" then fail "atproto-proxy service id is empty";
         { did; service }
 
+  (** Format [p] as [did#service]. *)
   let proxy_to_string (p : proxy) : string = p.did ^ "#" ^ p.service
 
   (** [atproto-proxy] header pair ([did#service]). *)
   let proxy_header (p : proxy) : string * string =
     ("atproto-proxy", proxy_to_string p)
 
+  (** Labeler proxy ([did#atproto_labeler]). *)
   let labeler_proxy (did : string) : proxy =
     { did; service = "atproto_labeler" }
 
+  (** Official chat service ([did:web:api.bsky.chat#bsky_chat]). *)
   let chat_proxy : proxy =
     { did = "did:web:api.bsky.chat"; service = "bsky_chat" }
 
+  (** Official AppView ([did:web:api.bsky.app#bsky_appview]). *)
   let appview_proxy : proxy =
     { did = "did:web:api.bsky.app"; service = "bsky_appview" }
 
@@ -79,6 +84,8 @@ module Xrpc = struct
         let redact = List.exists (fun p -> ascii_lower p = "redact") params in
         { did; redact }
 
+  (** Parse [atproto-accept-labelers] / [atproto-content-labelers]
+      ([did] or [did;redact], comma-separated; redact flags unioned). *)
   let parse_labelers (value : string) : labeler list =
     let items = split_commas value in
     let parsed = List.map parse_labeler_item items in
@@ -95,6 +102,7 @@ module Xrpc = struct
       parsed;
     List.rev_map (fun did -> { did; redact = Hashtbl.find acc did }) !order
 
+  (** Format [ls] as [did] / [did;redact] for labeler headers. *)
   let labelers_to_string (ls : labeler list) : string =
     String.concat ", "
       (List.map
@@ -127,6 +135,7 @@ module Xrpc = struct
   let int_opt s = try Some (int_of_string s) with _ -> None
   let int64_opt s = try Some (Int64.of_string s) with _ -> None
 
+  (** Parse [RateLimit-Limit] / [Remaining] / [Reset] / [Policy]. *)
   let parse_rate_limit (headers : (string * string) list) : rate_limit =
     {
       limit =
@@ -144,6 +153,7 @@ module Xrpc = struct
       policy = header_value headers "RateLimit-Policy";
     }
 
+  (** [atproto-repo-rev] header pair. *)
   let repo_rev_header (rev : string) : string * string =
     ("atproto-repo-rev", rev)
 
@@ -165,8 +175,13 @@ module Xrpc = struct
     raw : string;
   }
 
+  (** Default service-auth [kid] (["#atproto"]). *)
   let default_kid = "#atproto"
+
+  (** Default JWT [typ] (["JWT"]). *)
   let default_typ = "JWT"
+
+  (** Recommended service-auth lifetime (60s). *)
   let recommended_lifetime = 60L
 
   let split_jwt jwt =
@@ -188,6 +203,7 @@ module Xrpc = struct
   let normalize_kid kid =
     if kid = "" then default_kid else if kid.[0] = '#' then kid else "#" ^ kid
 
+  (** Parse inter-service JWT claims ([iss] / [aud] / [lxm] / [jti]). *)
   let parse_service_auth (jwt : string) : service_auth =
     let header_b64, payload_b64, _ = split_jwt jwt in
     let header = Yojson.Safe.from_string (Base64url.decode header_b64) in
@@ -232,6 +248,7 @@ module Xrpc = struct
       raw = jwt;
     }
 
+  (** JSON body for [com.atproto.server.getServiceAuth]. *)
   let service_auth_body ~aud ?lxm ?exp () : Yojson.Safe.t =
     if not (Syntax.Syntax.is_valid_did_ref aud) then
       fail "getServiceAuth aud must be a DID (optional #service fragment)";
@@ -250,9 +267,11 @@ module Xrpc = struct
     in
     `Assoc fields
 
+  (** [Authorization: Bearer] header for a service-auth JWT. *)
   let service_auth_header (jwt : string) : string * string =
     ("Authorization", "Bearer " ^ jwt)
 
+  (** Random [jti] (hex) for service-auth replay protection. *)
   let random_jti () : string =
     Lazy.force ensure_rng;
     let buf = Bytes.create 16 in
@@ -284,6 +303,7 @@ module Xrpc = struct
   let finish_jwt unsigned signature =
     unsigned ^ "." ^ Base64url.encode signature
 
+  (** Mint an ES256 service-auth JWT (P-256). *)
   let sign_service_jwt_p256 ~(priv : Mirage_crypto_ec.P256.Dsa.priv) ~iss ~aud
       ?lxm ?exp ?iat ?jti ?(kid = default_kid) ?(now = Unix.gettimeofday ()) ()
       : string =
@@ -313,6 +333,7 @@ module Xrpc = struct
     in
     finish_jwt unsigned (r ^ s)
 
+  (** Mint an ES256K service-auth JWT (secp256k1). *)
   let sign_service_jwt_k256 ~(priv : K256.K256.priv) ~iss ~aud ?lxm ?exp ?iat
       ?jti ?(kid = default_kid) ?(now = Unix.gettimeofday ()) () : string =
     if not (Syntax.Syntax.is_valid_did iss) then
@@ -338,6 +359,7 @@ module Xrpc = struct
   type sig_status =
     [ `Valid | `Invalid | `Unsupported_curve of string | `Missing ]
 
+  (** Verify the JWT signature against [keys] ([did:key] or multibase). *)
   let verify_service_sig ~(keys : string list) (jwt : string) : sig_status =
     let header_b64, payload_b64, sig_b64 = split_jwt jwt in
     if sig_b64 = "" || sig_b64 = "sig" then `Missing
@@ -394,6 +416,8 @@ module Xrpc = struct
         in
         try_keys parsed
 
+  (** True when [claims.aud] matches [expected] ([did] or [did#service]).
+      A bare DID is not a wildcard for a service fragment. *)
   let audience_matches ~(expected : string) (claims : service_auth) : bool =
     if claims.aud = expected then true
     else
@@ -406,6 +430,7 @@ module Xrpc = struct
           claims.aud_service = None
       | Some frag -> claims.aud_service = Some frag
 
+  (** True when [exp] is missing or past ([leeway] seconds, default 5). *)
   let is_expired ?(now = Unix.gettimeofday ()) ?(leeway = 5L)
       (claims : service_auth) : bool =
     match claims.exp with
@@ -414,6 +439,8 @@ module Xrpc = struct
         let now_i = Int64.of_float now in
         Int64.compare now_i (Int64.add exp leeway) > 0
 
+  (** Parse and verify a service-auth JWT (signature, optional [aud] /
+      [lxm], expiry). *)
   let verify_service_jwt ~keys ?aud ?lxm ?now ?(require_lxm = false)
       ?(require_jti = false) (jwt : string) : service_auth =
     let claims = parse_service_auth jwt in
@@ -451,9 +478,11 @@ module Xrpc = struct
     cap : int;
   }
 
+  (** Replay-protection cache for service-auth [jti] values. *)
   let create_jti_cache ?(cap = 4096) () : jti_cache =
     { seen = Hashtbl.create cap; order = Queue.create (); cap }
 
+  (** Record [claims.jti]; [true] if it was already seen. *)
   let remember_jti ?(now = Unix.gettimeofday ()) (c : jti_cache)
       (claims : service_auth) : bool =
     match claims.jti with
@@ -469,5 +498,6 @@ module Xrpc = struct
              Hashtbl.remove c.seen old);
           false)
 
+  (** True when [jti] is in [c]. *)
   let jti_seen (c : jti_cache) (jti : string) : bool = Hashtbl.mem c.seen jti
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only function-level `(** *)` odoc on remaining XRPC / HTTP plumbing helpers that still lacked a comment immediately above the public `let`. Targets current `main` (`6607813e`, after pin-bump #132).

Style matches existing function-level odoc in `src/error.ml` and `src/identity.ml`: a short `(** ... *)` above each public `let`, naming the AT Protocol / XRPC meaning. Private string/socket/JWT construction helpers are left uncommented unless they are neighboring public API (same as #126 / #130).

### Documented

- `Error.parse_error_from_json`, `contains_ci`, `is_feature_disabled`, `is_not_implemented_json` (other Error entry points already had odoc from #126)
- `Xrpc.parse_proxy`, `proxy_to_string`, `labeler_proxy`, `chat_proxy`, `appview_proxy`, `parse_labelers`, `labelers_to_string`, `parse_rate_limit`, `repo_rev_header`, service-auth JWT mint/verify (`parse_service_auth`, `sign_service_jwt_p256` / `_k256`, `verify_service_jwt`, `jti` cache)
- `Request.user_agent`, `put`, `delete` (`create` / `get` / `post` already documented)
- `Response.header`, `content_type`
- `Http_client.parse_url`, `get_addr_info`, `patch`, `get_host`, `xrpc_put`, `xrpc_delete`, `xrpc_patch` (`request` / `get` / `post` / `xrpc_get` / `xrpc_post` already documented)
- `Websocket.accept_key`, frame encode/decode, `send` / `recv_message`, `parse_url` / `parse_wss_url`, `offered_subprotocols` / `check_subprotocol_echo`, `close` / `with_connection` (`connect` already documented)

`Http_method.lookup_http_method` / `to_string` already had odoc; the file was not restyled.

CHANGELOG 0.1.0 notes this PR. Hosted-only chat / video / Tap and public opam-repository stay listed as not in this release. No leftover-field restyles, no logic or test changes, no pin bump, no OCaml 5.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef1fcf52-62c3-4645-9f7c-88f3e1b8aa2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef1fcf52-62c3-4645-9f7c-88f3e1b8aa2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

