### PR TITLE
Add function-level odoc on remaining Admin XRPC wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-Notes for the packaged **0.1.0** library. This file records what actually
-shipped through [#136](https://github.com/david-engelmann/atproto/pull/136)
+Notes for the packaged **0.1.0** library. [#135](https://github.com/david-engelmann/atproto/pull/135)
+adds remaining function-level odoc on Admin XRPC wrappers. This file
+records what actually shipped through
+[#136](https://github.com/david-engelmann/atproto/pull/136)
 (remaining function-level odoc on Server XRPC wrappers), including
 [#134](https://github.com/david-engelmann/atproto/pull/134)
 (function-level odoc on remaining Error / Xrpc / Request / Response /
@@ -249,6 +251,13 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `create_invite_codes`, `request_account_delete`, `delete_account`,
   `reset_password`, `revoke_app_password`, `request_email_confirmation`,
   `request_email_update`). Comment-only
+- [#135](https://github.com/david-engelmann/atproto/pull/135): remaining
+  function-level odoc on Admin XRPC wrappers (`get_account_infos`,
+  `enable_account_invites` / `disable_account_invites`, `send_email`,
+  `get_invite_codes` / `disable_invite_codes`, `delete_account`,
+  `update_account_email` / `update_account_handle` /
+  `update_account_password` / `update_account_signing_key`).
+  Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/admin.ml
+++ b/src/admin.ml
@@ -159,6 +159,7 @@ module Admin = struct
     in
     `Assoc fields
 
+  (** JSON body for [com.atproto.admin.enableAccountInvites]. *)
   let enable_invites_body ~account ?note () : Yojson.Safe.t =
     let fields =
       ("account", `String account)
@@ -166,9 +167,11 @@ module Admin = struct
     in
     `Assoc fields
 
+  (** JSON body for [com.atproto.admin.disableAccountInvites]. *)
   let disable_invites_body ~account ?note () : Yojson.Safe.t =
     enable_invites_body ~account ?note ()
 
+  (** JSON body for [com.atproto.admin.sendEmail]. *)
   let send_email_body ~recipient_did ~content ?subject ?sender_did () :
       Yojson.Safe.t =
     let fields =
@@ -205,6 +208,7 @@ module Admin = struct
       [ ("did", did) ]
     |> parse_account_info
 
+  (** Account views for [dids] via [com.atproto.admin.getAccountInfos]. *)
   let get_account_infos (s : Session.session) ~dids () : account_info list =
     Client.get_json ~session:s "com.atproto.admin.getAccountInfos"
       (Client.repeat_param "dids" dids)
@@ -221,16 +225,21 @@ module Admin = struct
       (Client.opt_pair "email" email @ Client.opt_pair "cursor" cursor)
     |> parse_accounts
 
+  (** Enable invites for [account] via
+      [com.atproto.admin.enableAccountInvites]. *)
   let enable_account_invites (s : Session.session) ~account ?note () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.enableAccountInvites"
          (Yojson.Safe.to_string (enable_invites_body ~account ?note ())))
 
+  (** Disable invites for [account] via
+      [com.atproto.admin.disableAccountInvites]. *)
   let disable_account_invites (s : Session.session) ~account ?note () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.disableAccountInvites"
          (Yojson.Safe.to_string (disable_invites_body ~account ?note ())))
 
+  (** Send an admin email via [com.atproto.admin.sendEmail]. *)
   let send_email (s : Session.session) ~recipient_did ~content ?subject
       ?sender_did () : Yojson.Safe.t =
     Client.post_json ~session:s "com.atproto.admin.sendEmail"
@@ -276,6 +285,7 @@ module Admin = struct
       codes = List.map parse_invite_code (Client.list_member json "codes");
     }
 
+  (** JSON body for [com.atproto.admin.disableInviteCodes]. *)
   let disable_invite_codes_body ?(codes = []) ?(accounts = []) () :
       Yojson.Safe.t =
     let fields =
@@ -289,21 +299,28 @@ module Admin = struct
     in
     `Assoc fields
 
+  (** JSON body for [com.atproto.admin.deleteAccount]. *)
   let delete_account_body ~did () : Yojson.Safe.t =
     `Assoc [ ("did", `String did) ]
 
+  (** JSON body for [com.atproto.admin.updateAccountEmail]. *)
   let update_account_email_body ~account ~email () : Yojson.Safe.t =
     `Assoc [ ("account", `String account); ("email", `String email) ]
 
+  (** JSON body for [com.atproto.admin.updateAccountHandle]. *)
   let update_account_handle_body ~did ~handle () : Yojson.Safe.t =
     `Assoc [ ("did", `String did); ("handle", `String handle) ]
 
+  (** JSON body for [com.atproto.admin.updateAccountPassword]. *)
   let update_account_password_body ~did ~password () : Yojson.Safe.t =
     `Assoc [ ("did", `String did); ("password", `String password) ]
 
+  (** JSON body for [com.atproto.admin.updateAccountSigningKey]. *)
   let update_account_signing_key_body ~did ~signing_key () : Yojson.Safe.t =
     `Assoc [ ("did", `String did); ("signingKey", `String signing_key) ]
 
+  (** Invite codes via [com.atproto.admin.getInviteCodes]. Optional
+      [sort] / [limit] / [cursor] map to the lexicon query. *)
   let get_invite_codes (s : Session.session) ?sort ?limit ?cursor () :
       invite_codes =
     Client.get_json ~session:s "com.atproto.admin.getInviteCodes"
@@ -312,33 +329,41 @@ module Admin = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_invite_codes
 
+  (** Disable invite [codes] or all codes for [accounts] via
+      [com.atproto.admin.disableInviteCodes]. *)
   let disable_invite_codes (s : Session.session) ?(codes = []) ?(accounts = [])
       () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.disableInviteCodes"
          (Yojson.Safe.to_string (disable_invite_codes_body ~codes ~accounts ())))
 
+  (** Delete [did] via [com.atproto.admin.deleteAccount]. *)
   let delete_account (s : Session.session) ~did () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.deleteAccount"
          (Yojson.Safe.to_string (delete_account_body ~did ())))
 
+  (** Update [account] email via [com.atproto.admin.updateAccountEmail]. *)
   let update_account_email (s : Session.session) ~account ~email () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.updateAccountEmail"
          (Yojson.Safe.to_string (update_account_email_body ~account ~email ())))
 
+  (** Update [did] handle via [com.atproto.admin.updateAccountHandle]. *)
   let update_account_handle (s : Session.session) ~did ~handle () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.updateAccountHandle"
          (Yojson.Safe.to_string (update_account_handle_body ~did ~handle ())))
 
+  (** Update [did] password via [com.atproto.admin.updateAccountPassword]. *)
   let update_account_password (s : Session.session) ~did ~password () : unit =
     ignore
       (Client.post_json ~session:s "com.atproto.admin.updateAccountPassword"
          (Yojson.Safe.to_string
             (update_account_password_body ~did ~password ())))
 
+  (** Update [did] signing key via
+      [com.atproto.admin.updateAccountSigningKey]. *)
   let update_account_signing_key (s : Session.session) ~did ~signing_key () :
       unit =
     ignore


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only odoc on remaining public `Admin` XRPC wrappers in `src/admin.ml` that still lacked `(**` immediately above the `let`. Matches `src/identity.ml` / existing Admin odoc style (`get_subject_status`, `update_subject_status`, `get_account_info`, `search_accounts` left unchanged).

Documented wrappers:

- `get_account_infos`
- `enable_account_invites` / `disable_account_invites`
- `send_email`
- `get_invite_codes` / `disable_invite_codes`
- `delete_account`
- `update_account_email` / `update_account_handle` / `update_account_password` / `update_account_signing_key`

Plus matching `*_body` helpers (`enable_invites_body`, `disable_invites_body`, `send_email_body`, `disable_invite_codes_body`, `delete_account_body`, `update_account_*_body`).

No logic restyle. Does not touch tests, `ozone.ml`, lexicons, or files owned by #129 / #133 / #134. No live admin tests.

CHANGELOG 0.1.0 notes this remaining Admin wrapper odoc. Hosted-only chat / video / Tap and opam-repository stay listed as not in this release.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23838e2f-750b-48cb-af37-9dec0fb5390e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23838e2f-750b-48cb-af37-9dec0fb5390e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

