### PR TITLE
Add remaining function-level odoc on Session / Moderation / Temp helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,12 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
 - This PR: function-level odoc on remaining Tid / At_uri / Dag_cbor /
   K256 / Did_key / Did_web helpers (`of_int64`, `to_string`, `as_text`,
   `low_s`, `is_did_key`, `is_web_did`). Comment-only
+- function-level odoc on remaining Session / Moderation / Temp helpers
+  (`refresh_token_from_session`, `get_session_request`, reason-type
+  constants, `create_report_data_from_*`, `check_signup_queue`,
+  `dereference_scope`, `add_reserved_handle`,
+  `request_phone_verification`, `revoke_account_credentials`).
+  Comment-only; hosted-only phone verification stays listed not faked
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 Notes for the packaged **0.1.0** library. [#135](https://github.com/david-engelmann/atproto/pull/135)
-adds remaining function-level odoc on Admin XRPC wrappers. This file
-records what actually shipped through
+adds remaining function-level odoc on Admin XRPC wrappers.
+[#138](https://github.com/david-engelmann/atproto/pull/138) adds
+remaining function-level odoc on Session / Moderation / Temp helpers.
+This file records what actually shipped through
 [#137](https://github.com/david-engelmann/atproto/pull/137)
 (live TestNetwork `getAccountPreferences`), including
 [#136](https://github.com/david-engelmann/atproto/pull/136)
@@ -271,7 +273,8 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
 - This PR: function-level odoc on remaining Tid / At_uri / Dag_cbor /
   K256 / Did_key / Did_web helpers (`of_int64`, `to_string`, `as_text`,
   `low_s`, `is_did_key`, `is_web_did`). Comment-only
-- function-level odoc on remaining Session / Moderation / Temp helpers
+- [#138](https://github.com/david-engelmann/atproto/pull/138):
+  function-level odoc on remaining Session / Moderation / Temp helpers
   (`refresh_token_from_session`, `get_session_request`, reason-type
   constants, `create_report_data_from_*`, `check_signup_queue`,
   `dereference_scope`, `add_reserved_handle`,

--- a/src/moderation.ml
+++ b/src/moderation.ml
@@ -18,12 +18,25 @@ module Moderation = struct
     mod_tool : mod_tool option;
   }
 
+  (** [com.atproto.moderation.defs#reasonSpam] report reason. *)
   let reason_spam = "com.atproto.moderation.defs#reasonSpam"
+
+  (** [com.atproto.moderation.defs#reasonViolation] report reason. *)
   let reason_violation = "com.atproto.moderation.defs#reasonViolation"
+
+  (** [com.atproto.moderation.defs#reasonMisleading] report reason. *)
   let reason_misleading = "com.atproto.moderation.defs#reasonMisleading"
+
+  (** [com.atproto.moderation.defs#reasonSexual] report reason. *)
   let reason_sexual = "com.atproto.moderation.defs#reasonSexual"
+
+  (** [com.atproto.moderation.defs#reasonRude] report reason. *)
   let reason_rude = "com.atproto.moderation.defs#reasonRude"
+
+  (** [com.atproto.moderation.defs#reasonOther] report reason. *)
   let reason_other = "com.atproto.moderation.defs#reasonOther"
+
+  (** [com.atproto.moderation.defs#reasonAppeal] report reason. *)
   let reason_appeal = "com.atproto.moderation.defs#reasonAppeal"
 
   let parse_mod_tool json : mod_tool option =
@@ -105,12 +118,16 @@ module Moderation = struct
     | Some t -> [ ("modTool", mod_tool_json t) ]
     | None -> []
 
+  (** JSON body for [com.atproto.moderation.createReport] on a record
+      ([com.atproto.repo.strongRef]). *)
   let create_report_data_from_strong_ref (reason_type : string) ?reason
       ?mod_tool (subject : strong_ref) : string =
     let subject = create_subject_from_strong_ref subject in
     Yojson.Safe.to_string
       (`Assoc (report_fields reason_type ?reason ?mod_tool subject))
 
+  (** JSON body for [com.atproto.moderation.createReport] on an
+      account ([com.atproto.admin.defs#repoRef]). *)
   let create_report_data_from_repo_ref (reason_type : string) ?reason ?mod_tool
       (subject : repo_ref) : string =
     let subject = create_subject_from_repo_ref subject in

--- a/src/session.ml
+++ b/src/session.ml
@@ -93,10 +93,12 @@ module Session = struct
     let bearer_header = "Bearer " ^ s.auth.token in
     ("Authorization", bearer_header)
 
+  (** [Authorization: Bearer] header pair from the session refresh JWT. *)
   let refresh_token_from_session (s : session) : string * string =
     let bearer_header = "Bearer " ^ Option.get s.auth.refresh_token in
     ("Authorization", bearer_header)
 
+  (** Raw JSON from [com.atproto.server.getSession] for [s]. *)
   let get_session_request (s : session) : string =
     let base_endpoint = Auth.get_base_endpoint in
     let get_session_endpoint = Auth.create_server_endpoint "getSession" in

--- a/src/temp.ml
+++ b/src/temp.ml
@@ -78,10 +78,12 @@ module Temp = struct
   let parse_scope_deref json : scope_deref =
     { scope = Client.string_member json "scope"; original = json }
 
+  (** Signup-queue status via [com.atproto.temp.checkSignupQueue]. *)
   let check_signup_queue ?session ?host () : signup_queue =
     Client.get_json ?session ?host "com.atproto.temp.checkSignupQueue" []
     |> parse_signup_queue
 
+  (** Resolve [scope] via [com.atproto.temp.dereferenceScope]. *)
   let dereference_scope ?session ?host ~scope () : scope_deref =
     Client.get_json ?session ?host "com.atproto.temp.dereferenceScope"
       [ ("scope", scope) ]
@@ -100,11 +102,16 @@ module Temp = struct
      operator session and are not invented here. fetchLabels is deprecated
      in favor of Label.query_labels. *)
 
+  (** Reserve [handle] via [com.atproto.temp.addReservedHandle].
+      Privileged / hosted-PDS client; live calls need a real operator
+      session and are not invented here. *)
   let add_reserved_handle ?session ?host ~handle () : unit =
     ignore
       (Client.post_json ?session ?host "com.atproto.temp.addReservedHandle"
          (Yojson.Safe.to_string (add_reserved_handle_body ~handle ())))
 
+  (** Request SMS via [com.atproto.temp.requestPhoneVerification].
+      Hosted-only; this is a client wrapper and is not faked. *)
   let request_phone_verification ?session ?host ~phone_number () : unit =
     ignore
       (Client.post_json ?session ?host
@@ -112,6 +119,10 @@ module Temp = struct
          (Yojson.Safe.to_string
             (request_phone_verification_body ~phone_number ())))
 
+  (** Revoke sessions and passwords via
+      [com.atproto.temp.revokeAccountCredentials]. Privileged /
+      hosted-PDS client; live calls need a real operator session and
+      are not invented here. *)
   let revoke_account_credentials ?session ?host ~account () : unit =
     ignore
       (Client.post_json ?session ?host


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public Session / Moderation / Temp helpers that still lacked a function-level comment immediately above the `let`. Matches `src/identity.ml` and the existing comments in these modules.

Already documented (skipped): `Session.create_session` / `get_session` / `refresh_session` / `delete_session` / `bearer_token_from_session`, `Moderation.create_report_with_strong_ref` / `create_report_with_repo_ref`, `Temp.check_handle_availability`.

Documented in this PR:

- `Session.refresh_token_from_session`
- `Session.get_session_request`
- `Moderation.reason_spam` / `reason_violation` / `reason_misleading` / `reason_sexual` / `reason_rude` / `reason_other` / `reason_appeal`
- `Moderation.create_report_data_from_strong_ref` / `create_report_data_from_repo_ref`
- `Temp.check_signup_queue`
- `Temp.dereference_scope`
- `Temp.add_reserved_handle`
- `Temp.request_phone_verification`
- `Temp.revoke_account_credentials`

Short comments with NSID names. Did not restyle logic. Did not touch tests, `src/admin.ml` (#135), encoding/DID src (#133), or `test/test_local_ozone.ml` (#137). Hosted-only phone verification stays listed not faked. Hosted-only chat / video / Tap and opam-repository stay listed, not faked.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Session / Moderation / Temp headers unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc57aa32-d387-47d5-865e-aecd735077ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc57aa32-d387-47d5-865e-aecd735077ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

