### PR TITLE
Add remaining function-level odoc on Germnetwork / Lexicon helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,10 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `get_head` / `get_checkout` / `notify_of_update` wrap
   `getLatestCommit` / `getRepo` / `requestCrawl` (coverage-skips, not
   leftover hops)
+- [#140](https://github.com/david-engelmann/atproto/pull/140): remaining
+  function-level odoc on Germnetwork / Lexicon (`nsid_declaration`,
+  `show_*`, `bytes_to_json` / `bytes_of_json`, `message_me` /
+  `parse_declaration`, `of_json`, lookup / `to_ocaml`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/germnetwork.ml
+++ b/src/germnetwork.ml
@@ -3,9 +3,17 @@ open Base64url
 
 (** Typed builder/parser for `com.germnetwork.declaration`. *)
 module Germnetwork = struct
+  (** NSID for [com.germnetwork.declaration]. *)
   let nsid_declaration = "com.germnetwork.declaration"
+
+  (** [messageMe.showButtonTo] value: hide the Message Me button. *)
   let show_none = "none"
+
+  (** [messageMe.showButtonTo] value: show the button to accounts the
+      author follows. *)
   let show_users_i_follow = "usersIFollow"
+
+  (** [messageMe.showButtonTo] value: show the button to everyone. *)
   let show_everyone = "everyone"
 
   type message_me = { show_button_to : string; message_me_url : string }
@@ -18,14 +26,19 @@ module Germnetwork = struct
     continuity_proofs : string list;
   }
 
+  (** Encode raw bytes as a lexicon [$bytes] object (standard
+      base64url). *)
   let bytes_to_json (raw : string) : Yojson.Safe.t =
     `Assoc [ ("$bytes", `String (Base64url.encode_std raw)) ]
 
+  (** Decode a lexicon bytes object (or raw base64url string) to octets. *)
   let bytes_of_json json : string option = Label.bytes_of_json json
 
+  (** Build a [messageMe] object ([showButtonTo] / [messageMeUrl]). *)
   let message_me ~show_button_to ~message_me_url : message_me =
     { show_button_to; message_me_url }
 
+  (** JSON object for [messageMe] ([showButtonTo], [messageMeUrl]). *)
   let message_me_to_json (m : message_me) : Yojson.Safe.t =
     `Assoc
       [
@@ -33,6 +46,8 @@ module Germnetwork = struct
         ("messageMeUrl", `String m.message_me_url);
       ]
 
+  (** Parse a [messageMe] object. Missing [showButtonTo] defaults to
+      [show_none]; missing [messageMeUrl] is empty. *)
   let parse_message_me json : message_me =
     {
       show_button_to =
@@ -69,6 +84,8 @@ module Germnetwork = struct
     in
     `Assoc fields
 
+  (** Parse a [com.germnetwork.declaration] record. Missing fields
+      become empty strings / [None] / []. *)
   let parse_declaration json : declaration =
     {
       version =

--- a/src/lexicon.ml
+++ b/src/lexicon.ml
@@ -48,6 +48,8 @@ module Lexicon = struct
     defs : def list;
   }
 
+  (** Map a lexicon [type] string to a [primitive] ([boolean],
+      [cid-link], [bytes], ...). Unknown names become [Unknown]. *)
   let lookup_primitive prim =
     match prim with
     | "boolean" -> Boolean
@@ -61,6 +63,9 @@ module Lexicon = struct
     | "bytes" -> Bytes
     | _ -> Unknown
 
+  (** Map a lexicon definition [type] string to a [definition]
+      ([record], [query], [permission-set], ...). Unknown names become
+      [Unknown_def]. *)
   let lookup_definition def =
     match def with
     | "record" -> Record
@@ -165,6 +170,7 @@ module Lexicon = struct
       output = parse_io_schema json "output";
     }
 
+  (** Parse a Lexicon 1 document from JSON. Fails when [id] is missing. *)
   let of_json json : document =
     let open Yojson.Safe.Util in
     let lexicon = match json |> member "lexicon" with `Int n -> n | _ -> 1 in
@@ -229,6 +235,8 @@ module Lexicon = struct
         match List.assoc_opt "main" fields with Some m -> m | None -> json)
     | _ -> json
 
+  (** Parse a [permission-set] document (or its [defs.main]) into
+      [permission_set]. *)
   let parse_permission_set json : permission_set =
     let body = permission_set_body json in
     {
@@ -244,6 +252,7 @@ module Lexicon = struct
         | _ -> []);
     }
 
+  (** The [main] definition of [doc], if present. *)
   let main (doc : document) : def option =
     List.find_opt (fun d -> d.name = "main") doc.defs
 
@@ -287,6 +296,8 @@ module Lexicon = struct
     | Permission_set -> "permission-set"
     | Unknown_def s -> s
 
+  (** Emit a generated OCaml module from [doc] (id, defs, input/output
+      records). *)
   let to_ocaml (doc : document) : string =
     let buf = Buffer.create 256 in
     let modname = String.capitalize_ascii (ocaml_ident doc.id) in
@@ -341,6 +352,7 @@ module Lexicon = struct
     | (Union _ | Unknown), _ -> true
     | _ -> false
 
+  (** Validate [json] against [d]'s required fields and property types. *)
   let validate (d : def) (json : Yojson.Safe.t) : (unit, string) result =
     match json with
     | `Assoc fields ->
@@ -398,6 +410,8 @@ module Lexicon = struct
     document : document option;
   }
 
+  (** Parse [com.atproto.lexicon.resolveLexicon] output ([uri], [cid],
+      [schema], optional parsed [document]). *)
   let parse_resolved_lexicon json : resolved_lexicon =
     let schema =
       match Yojson.Safe.Util.member "schema" json with
@@ -412,6 +426,7 @@ module Lexicon = struct
       document;
     }
 
+  (** Resolve [nsid] via [com.atproto.lexicon.resolveLexicon]. *)
   let resolve_lexicon ?session ?host ~nsid () : resolved_lexicon =
     Client.Client.get_json ?session ?host "com.atproto.lexicon.resolveLexicon"
       [ ("nsid", nsid) ]
@@ -573,6 +588,7 @@ module Lexicon = struct
   let official_auth_manage_profile =
     {|{"lexicon":1,"id":"app.bsky.authManageProfile","defs":{"main":{"type":"permission-set","title":"Manage Bluesky Profile","detail":"Update profile data, as well as status and public chat visibility.","permissions":[{"type":"permission","resource":"repo","action":["create","update","delete"],"collection":["app.bsky.actor.profile","app.bsky.actor.status","app.bsky.notification.declaration"]}]}}}|}
 
+  (** Bundled official lexicon JSON strings keyed by NSID. *)
   let official_lexicons : (string * string) list =
     [
       ("app.bsky.graph.listitem", official_listitem);
@@ -639,6 +655,7 @@ module Lexicon = struct
       ("app.bsky.authManageProfile", official_auth_manage_profile);
     ]
 
+  (** Parse every bundled official lexicon document. *)
   let official_documents () : document list =
     List.map (fun (_id, body) -> of_string body) official_lexicons
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` on remaining public Germnetwork and Lexicon helpers that still lacked function-level odoc immediately above the `let`. Matches `src/identity.ml` / `src/hash.ml` style.

Rebased onto current `main` (`90611cfd` after #142). CHANGELOG keeps notes already on main (including #141 Repo odoc and #142 Sync odoc) and adds this PR's Germnetwork / Lexicon bullet only.

**Germnetwork:** `nsid_declaration`, `show_none` / `show_users_i_follow` / `show_everyone`, `bytes_to_json` / `bytes_of_json`, `message_me` / `message_me_to_json` / `parse_message_me`, `parse_declaration`. Existing `declaration` odoc is unchanged.

**Lexicon:** `of_json`, `lookup_primitive` / `lookup_definition`, `parse_permission_set`, `main`, `to_ocaml`, `validate`, `parse_resolved_lexicon`, `resolve_lexicon`, `official_lexicons` / `official_documents`. Internal `parse_property` / `parse_def` left without odoc.

No logic restyle. Tests, `src/oauth_scope.ml`, and `src/syntax.ml` are untouched. Hosted-only chat / video / Tap and opam-repository stay listed, not faked.

`dune build @fmt --auto-promote` was run after the rebase (no further changes).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ee2bfdd-6639-42a8-a585-ebfe54c896e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ee2bfdd-6639-42a8-a585-ebfe54c896e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

