### PR TITLE
Add remaining function-level odoc on Repo XRPC wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Error / Xrpc / HTTP, [#135](https://github.com/david-engelmann/atproto/pull/135)
 Admin, [#136](https://github.com/david-engelmann/atproto/pull/136) Server,
 [#138](https://github.com/david-engelmann/atproto/pull/138)
 Session / Moderation / Temp).
+This PR adds remaining function-level odoc on Repo XRPC wrappers.
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
@@ -244,6 +245,12 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `dereference_scope`, `add_reserved_handle`,
   `request_phone_verification`, `revoke_account_credentials`).
   Comment-only; hosted-only phone verification stays listed not faked
+- This PR: remaining function-level odoc on Repo XRPC wrappers
+  (`describe_repo` / `describe_repo_parsed`, `list_records` /
+  `list_records_parsed`, `get_record_parsed`, `put_record`,
+  `delete_record`, `apply_writes_body`, `write_op_to_json`,
+  `upload_blob`, `verify_blob_bytes`, `list_missing_blobs`,
+  `import_repo`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/repo.ml
+++ b/src/repo.ml
@@ -150,11 +150,15 @@ module Repo = struct
       results = (match json |> member "results" with `List xs -> xs | _ -> []);
     }
 
+  (** Parsed [com.atproto.repo.describeRepo] (handle, DID, collections).
+      Works without a session. *)
   let describe_repo_parsed ?session ?host ~repo () : repo_description =
     Client.Client.get_json ?session ?host "com.atproto.repo.describeRepo"
       [ ("repo", repo) ]
     |> parse_repo_description
 
+  (** Parsed [com.atproto.repo.getRecord] ([uri], optional [cid], [value]).
+      Works without a session. *)
   let get_record_parsed ?session ?host ~repo ~collection ~rkey ?cid () :
       record_get =
     Client.Client.get_json ?session ?host "com.atproto.repo.getRecord"
@@ -162,6 +166,8 @@ module Repo = struct
       @ Client.Client.opt_pair "cid" cid)
     |> parse_record_get
 
+  (** Parsed [com.atproto.repo.listRecords]. Optional [limit] / [cursor] /
+      [reverse] map to the lexicon query. Works without a session. *)
   let list_records_parsed ?session ?host ~repo ~collection ?limit ?cursor
       ?reverse () : listed_records =
     Client.Client.get_json ?session ?host "com.atproto.repo.listRecords"
@@ -174,6 +180,7 @@ module Repo = struct
   let create_repo_endpoint (query_name : string) : string =
     "com.atproto.repo" ^ "." ^ query_name
 
+  (** Raw JSON from [com.atproto.repo.describeRepo] for [repo]. *)
   let describe_repo (s : Session.session) (repo : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let application_json = Cohttp_client.application_json_setting_tuple in
@@ -221,6 +228,8 @@ module Repo = struct
     in
     record
 
+  (** List records via [com.atproto.repo.listRecords]. Returns the raw JSON
+      body. *)
   let list_records (s : Session.session) (repo : string) (collection : string)
       (limit : int) (reverse : bool) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -284,6 +293,9 @@ module Repo = struct
     in
     created_record
 
+  (** Put a record via [com.atproto.repo.putRecord]. [record] is a JSON
+      object string; optional [rkey], [swap_record], and [swap_commit] map
+      to the lexicon inputs. *)
   let put_record (s : Session.session) (repo : string) (collection : string)
       ?rkey ?(validate = true) ?swap_record ?swap_commit (record : string) :
       string =
@@ -321,6 +333,8 @@ module Repo = struct
     in
     puted_record
 
+  (** Delete a record via [com.atproto.repo.deleteRecord]. Optional
+      [swap_record] / [swap_commit] map to the lexicon inputs. *)
   let delete_record (s : Session.session) (repo : string) (collection : string)
       ?swap_record ?swap_commit (rkey : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
@@ -362,6 +376,8 @@ module Repo = struct
     | Update of { collection : string; rkey : string; value : Yojson.Safe.t }
     | Delete of { collection : string; rkey : string }
 
+  (** JSON for one [com.atproto.repo.applyWrites] create / update / delete
+      op. *)
   let write_op_to_json = function
     | Create { collection; rkey; value } ->
         `Assoc
@@ -387,6 +403,7 @@ module Repo = struct
             ("rkey", `String rkey);
           ]
 
+  (** JSON body for [com.atproto.repo.applyWrites]. *)
   let apply_writes_body ~repo ~writes ?(validate = true) ?swap_commit () :
       Yojson.Safe.t =
     let fields =
@@ -428,6 +445,8 @@ module Repo = struct
     original : Yojson.Safe.t;
   }
 
+  (** Blob CID for [bytes] (CIDv1 raw + SHA-256). Optional [expected]
+      must match. *)
   let verify_blob_bytes ?expected (bytes : string) : Cid.Cid.t =
     Cid.Cid.verify_blob ?expected bytes
 
@@ -453,6 +472,8 @@ module Repo = struct
     App.create_endpoint_url (App.create_base_url s)
       (create_repo_endpoint "uploadBlob")
 
+  (** Upload bytes via [com.atproto.repo.uploadBlob]. Optional
+      [content_type] defaults to [application/octet-stream]. *)
   let upload_blob (s : Session.session)
       ?(content_type = "application/octet-stream") (bytes : string) : blob_ref =
     let bearer_token = Session.bearer_token_from_session s in
@@ -492,6 +513,8 @@ module Repo = struct
         | _ -> []);
     }
 
+  (** Missing blobs via [com.atproto.repo.listMissingBlobs]. Optional
+      [cursor] / [limit] map to the lexicon query. *)
   let list_missing_blobs (s : Session.session) ?cursor ?limit () :
       list_missing_blobs =
     let bearer_token = Session.bearer_token_from_session s in
@@ -518,6 +541,7 @@ module Repo = struct
     App.create_endpoint_url (App.create_base_url s)
       (create_repo_endpoint "importRepo")
 
+  (** Import a CAR via [com.atproto.repo.importRepo]. *)
   let import_repo (s : Session.session) (car_bytes : string) : string =
     let bearer_token = Session.bearer_token_from_session s in
     let headers =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Repo` XRPC wrappers in `src/repo.ml` that still lacked a function-level comment immediately above the `let`. Matches #135 Admin / #136 Server remaining-wrapper style.

Rebased onto `main` after [#139](https://github.com/david-engelmann/atproto/pull/139) (`509e8e27`). CHANGELOG keeps the through-#138 notes from main plus this PR's Repo odoc bullet.

Already documented (skipped): `get_record`, `create_record`, `apply_writes`.

Documented in this PR:

- `describe_repo` / `describe_repo_parsed`
- `list_records` / `list_records_parsed`
- `get_record_parsed`
- `put_record`
- `delete_record`
- `apply_writes_body`
- `write_op_to_json`
- `upload_blob`
- `verify_blob_bytes`
- `list_missing_blobs`
- `import_repo`

Short comments with NSID names. Did not restyle logic. Did not document `parse_*` internals. Did not touch tests, `src/sync.ml`, `src/oauth_scope.ml`, `src/syntax.ml`, `src/germnetwork.ml`, or `src/lexicon.ml` (parallel PRs). Hosted-only chat / video / Tap and opam-repository stay listed, not faked.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Repo header unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6eaaea-b972-4965-9ba0-8fbb92744e52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6eaaea-b972-4965-9ba0-8fbb92744e52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

