### PR TITLE
Add remaining function-level odoc on Oauth_scope / Syntax helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Admin, [#136](https://github.com/david-engelmann/atproto/pull/136) Server,
 [#138](https://github.com/david-engelmann/atproto/pull/138)
 Session / Moderation / Temp).
 This PR adds remaining function-level odoc on Repo XRPC wrappers.
+This PR adds remaining function-level odoc on Oauth_scope / Syntax.
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
@@ -265,6 +266,11 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   function-level odoc on Germnetwork / Lexicon (`nsid_declaration`,
   `show_*`, `bytes_to_json` / `bytes_of_json`, `message_me` /
   `parse_declaration`, `of_json`, lookup / `to_ocaml`). Comment-only
+- This PR: remaining function-level odoc on Oauth_scope / Syntax
+  (`resource_name`, `resource_of_string`, `collections_of`,
+  `actions_of`, `lxm_of`, `aud_of`, `validate`, `to_string`,
+  `is_valid_datetime` / `is_valid_language`, `parse_nsid` /
+  `parse_did_ref`, `normalize_handle`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Admin, [#136](https://github.com/david-engelmann/atproto/pull/136) Server,
 [#138](https://github.com/david-engelmann/atproto/pull/138)
 Session / Moderation / Temp).
 This PR adds remaining function-level odoc on Repo XRPC wrappers.
-This PR adds remaining function-level odoc on Oauth_scope / Syntax.
+[#143](https://github.com/david-engelmann/atproto/pull/143) adds remaining
+function-level odoc on Oauth_scope / Syntax.
 
 This package is **not** published to the public
 [opam-repository](https://github.com/ocaml/opam-repository). Depend on it by
@@ -266,7 +267,8 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   function-level odoc on Germnetwork / Lexicon (`nsid_declaration`,
   `show_*`, `bytes_to_json` / `bytes_of_json`, `message_me` /
   `parse_declaration`, `of_json`, lookup / `to_ocaml`). Comment-only
-- This PR: remaining function-level odoc on Oauth_scope / Syntax
+- [#143](https://github.com/david-engelmann/atproto/pull/143): remaining
+  function-level odoc on Oauth_scope / Syntax
   (`resource_name`, `resource_of_string`, `collections_of`,
   `actions_of`, `lxm_of`, `aud_of`, `validate`, `to_string`,
   `is_valid_datetime` / `is_valid_language`, `parse_nsid` /

--- a/src/oauth_scope.ml
+++ b/src/oauth_scope.ml
@@ -30,6 +30,8 @@ module Oauth_scope = struct
     params : (string * string) list;
   }
 
+  (** Canonical resource-name string for a [resource_kind] ([atproto],
+      [repo], …). *)
   let resource_name = function
     | Atproto -> "atproto"
     | Transition -> "transition"
@@ -41,6 +43,7 @@ module Oauth_scope = struct
     | Include -> "include"
     | Other s -> s
 
+  (** Parse a resource-name string into [resource_kind] ([Other] if unknown). *)
   let resource_of_string = function
     | "atproto" -> Atproto
     | "transition" -> Transition
@@ -76,23 +79,29 @@ module Oauth_scope = struct
   let param_one key params =
     match params_get key params with [] -> None | hd :: _ -> Some hd
 
+  (** Collection NSIDs on a [repo] scope: positional plus [collection] params. *)
   let collections_of (s : t) : string list =
     match s.positional with
     | Some p when p <> "" -> p :: params_get "collection" s.params
     | _ -> params_get "collection" s.params
 
+  (** [action] values on a [repo] scope. Defaults to create/update/delete. *)
   let actions_of (s : t) : string list =
     let acts = params_get "action" s.params in
     if acts = [] then [ "create"; "update"; "delete" ] else acts
 
+  (** Lexicon method NSIDs ([lxm]) on an [rpc] scope. *)
   let lxm_of (s : t) : string list =
     match s.positional with
     | Some p when p <> "" -> p :: params_get "lxm" s.params
     | _ -> params_get "lxm" s.params
 
+  (** Audience DIDs ([aud]) on an [rpc] or [include] scope. *)
   let aud_of (s : t) : string list = params_get "aud" s.params
+
   let is_wildcard = function "*" -> true | _ -> false
 
+  (** Check [s] against the granular-scope grammar. Raises [Invalid]. *)
   let validate (s : t) : unit =
     match s.resource with
     | Atproto ->
@@ -152,7 +161,8 @@ module Oauth_scope = struct
         | None -> fail "include scope requires a permission-set NSID")
     | Blob | Other _ -> ()
 
-  (* Official AT Protocol permission-set NSIDs referenced by include:. *)
+  (** Official [app.bsky.auth*] / [chat.bsky.authFullChatClient]
+      permission-set NSIDs referenced by [include:]. *)
   let official_include_nsids =
     [
       "app.bsky.authCreatePosts";
@@ -167,9 +177,11 @@ module Oauth_scope = struct
       "chat.bsky.authFullChatClient";
     ]
 
+  (** True when [nsid] is a bundled official permission-set. *)
   let is_official_include (nsid : string) : bool =
     List.mem nsid official_include_nsids
 
+  (** Expand one lexicon [permission] into granular scope tokens. *)
   let scopes_of_permission (p : Lexicon.Lexicon.permission) : t list =
     match p.resource with
     | "repo" ->
@@ -193,9 +205,11 @@ module Oauth_scope = struct
           lxms
     | _ -> []
 
+  (** Expand a parsed permission-set into granular scope tokens. *)
   let expand_include (set : Lexicon.Lexicon.permission_set) : t list =
     List.concat (List.map scopes_of_permission set.permissions)
 
+  (** Expand a bundled official permission-set NSID, or [None] if unknown. *)
   let expand_include_nsid (nsid : string) : t list option =
     match List.assoc_opt nsid Lexicon.Lexicon.official_lexicons with
     | None -> None
@@ -205,6 +219,7 @@ module Oauth_scope = struct
              (Lexicon.Lexicon.parse_permission_set
                 (Yojson.Safe.from_string body)))
 
+  (** Parse and validate one scope token. Raises [Invalid]. *)
   let parse_one (raw : string) : t =
     let token = String.trim raw in
     if token = "" then fail "empty scope token";
@@ -232,6 +247,7 @@ module Oauth_scope = struct
       Does not require [atproto] — use [parse_and_require] for that. *)
   let parse (scope : string) : t list = List.map parse_one (split_scopes scope)
 
+  (** Serialize one scope token ([resource[:positional][?k=v]]). *)
   let to_string (s : t) : string =
     let head =
       match s.positional with
@@ -245,21 +261,26 @@ module Oauth_scope = struct
         ^ String.concat "&"
             (List.map (fun (k, v) -> pct_encode k ^ "=" ^ pct_encode v) ps)
 
+  (** Space-separated serialization of [scopes]. *)
   let serialize (scopes : t list) : string =
     String.concat " " (List.map to_string scopes)
 
+  (** True when [scopes] includes the mandatory [atproto] token. *)
   let has_atproto (scopes : t list) : bool =
     List.exists (fun s -> s.resource = Atproto) scopes
 
+  (** Raise [Invalid] unless [scopes] includes [atproto]. *)
   let require_atproto (scopes : t list) : unit =
     if not (has_atproto scopes) then fail "scope list must include atproto"
 
   let token_set scope = split_scopes scope |> List.sort_uniq String.compare
 
+  (** True when every token in [requested] appears in [declared]. *)
   let is_subset ~requested ~declared =
     let dec = token_set declared in
     List.for_all (fun t -> List.mem t dec) (split_scopes requested)
 
+  (** [parse] then [require_atproto]. Raises [Invalid] if [atproto] is missing. *)
   let parse_and_require (scope : string) : t list =
     let scopes = parse scope in
     require_atproto scopes;

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -78,13 +78,17 @@ module Syntax = struct
   let ensure_handle s =
     if not (is_valid_handle s) then fail ("invalid handle " ^ s)
 
+  (** Lowercase [s] for handle comparison (DNS is case-insensitive). *)
   let normalize_handle s = ascii_lower s
 
+  (** Lowercase [s] and raise [Invalid] if it is not a valid handle. *)
   let normalize_and_ensure_handle s =
     let n = normalize_handle s in
     ensure_handle n;
     n
 
+  (** True when [handle]'s TLD is allowed for resolution (rejects
+      [.onion], [.local], [.arpa], …). *)
   let is_valid_tld (handle : string) : bool =
     let lower = ascii_lower handle in
     not (List.exists (fun tld -> ends_with lower tld) disallowed_tlds)
@@ -145,6 +149,7 @@ module Syntax = struct
         ( String.sub input 0 i,
           Some (String.sub input (i + 1) (String.length input - i - 1)) )
 
+  (** True when [frag] is a valid DID service/key fragment (no [#]). *)
   let is_valid_did_fragment (frag : string) : bool =
     let n = String.length frag in
     n > 0
@@ -158,11 +163,14 @@ module Syntax = struct
     in
     loop 0
 
+  (** True when [input] is a DID plus optional [#fragment] (service-auth
+      [aud], [atproto-proxy]). *)
   let is_valid_did_ref (input : string) : bool =
     let did, frag = split_did_ref input in
     is_valid_did did
     && match frag with None -> true | Some f -> is_valid_did_fragment f
 
+  (** Parse a DID plus optional [#fragment]. Raises [Invalid]. *)
   let parse_did_ref (input : string) : did_ref =
     let did, frag = split_did_ref input in
     ensure_did did;
@@ -172,12 +180,14 @@ module Syntax = struct
     | None -> ());
     { did; fragment = frag }
 
+  (** Serialize a [did_ref] as [did] or [did#fragment]. *)
   let did_ref_to_string (r : did_ref) : string =
     match r.fragment with None -> r.did | Some f -> r.did ^ "#" ^ f
 
   let ensure_did_ref s =
     if not (is_valid_did_ref s) then fail ("invalid DID reference " ^ s)
 
+  (** DID method name ([plc], [web], [key]) when [input] is a valid DID. *)
   let did_method (input : string) : string option =
     if not (is_valid_did input) then None
     else
@@ -185,6 +195,7 @@ module Syntax = struct
       | "did" :: method_ :: _ -> Some method_
       | _ -> None
 
+  (** True when [s] is a blessed AT Protocol DID method ([plc] or [web]). *)
   let is_blessed_did s =
     match did_method s with Some "plc" | Some "web" -> true | _ -> false
 
@@ -196,6 +207,7 @@ module Syntax = struct
     | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' -> true
     | _ -> false
 
+  (** True when [v] is a valid NSID name segment (no leading digit). *)
   let is_valid_identifier_name (v : string) : bool =
     String.length v > 0
     && (not (is_ascii_digit v.[0]))
@@ -238,25 +250,32 @@ module Syntax = struct
 
   type nsid = { segments : string list }
 
+  (** Split a valid NSID into segments. Raises [Invalid]. *)
   let parse_nsid (input : string) : nsid =
     ensure_nsid input;
     { segments = String.split_on_char '.' input }
 
+  (** Last segment of [n] (the name). *)
   let nsid_name (n : nsid) : string = List.hd (List.rev n.segments)
 
-  (* DNS hostname form, matching @atproto/syntax (com.example.foo -> example.com). *)
+  (** DNS hostname form of [n] ([com.example.foo] → [example.com]). *)
   let nsid_authority (n : nsid) : string =
     n.segments |> List.rev |> List.tl |> String.concat "."
 
+  (** Authority prefix of [n] in NSID order ([com.example.foo] →
+      [com.example]). *)
   let nsid_authority_nsid (n : nsid) : string =
     n.segments |> List.rev |> List.tl |> List.rev |> String.concat "."
 
+  (** Join [n]'s segments with dots. *)
   let nsid_to_string (n : nsid) : string = String.concat "." n.segments
 
+  (** Build an NSID from a DNS [authority] and [name]. Raises [Invalid]. *)
   let create_nsid ~authority ~name : nsid =
     let segs = List.rev (String.split_on_char '.' authority) @ [ name ] in
     parse_nsid (String.concat "." segs)
 
+  (** True when [input] is [*] or an authority glob ([com.atproto.*]). *)
   let is_valid_nsid_glob (input : string) : bool =
     if input = "*" then true
     else if ends_with input ".*" then
@@ -268,6 +287,8 @@ module Syntax = struct
 
   type nsid_ref = { nsid : string; fragment : string option }
 
+  (** Parse an NSID plus optional [#fragment] (not empty or [#main]).
+      Raises [Invalid]. *)
   let parse_nsid_ref (input : string) : nsid_ref =
     match String.index_opt input '#' with
     | None ->
@@ -306,8 +327,9 @@ module Syntax = struct
   let ensure_record_key s =
     if not (is_valid_record_key s) then fail ("invalid record key " ^ s)
 
-  (* Repo paths are exactly `collection/rkey` (no leading slash, two segments).
-     https://atproto.com/specs/repository#repository-paths *)
+  (** Split a repo path into [collection] / [rkey], or [None].
+      Paths are exactly [collection/rkey] (no leading slash).
+      https://atproto.com/specs/repository#repository-paths *)
   let split_repo_path (input : string) : (string * string) option =
     match String.index_opt input '/' with
     | None -> None
@@ -316,6 +338,7 @@ module Syntax = struct
         let rkey = String.sub input (i + 1) (String.length input - i - 1) in
         if String.contains rkey '/' then None else Some (collection, rkey)
 
+  (** True when [input] is [collection/rkey] (NSID and record key). *)
   let is_valid_repo_path (input : string) : bool =
     match split_repo_path input with
     | None -> false
@@ -327,6 +350,7 @@ module Syntax = struct
 
   (* ---- at-identifier (handle or DID) ----------------------------------- *)
 
+  (** True when [s] is a valid handle or DID. *)
   let is_valid_at_identifier s = is_valid_did s || is_valid_handle s
 
   let ensure_at_identifier s =
@@ -353,6 +377,8 @@ module Syntax = struct
     in
     loop 0
 
+  (** True when [input] is a valid AT Protocol datetime (ISO-8601 with
+      timezone; no [-00:00]). *)
   let is_valid_datetime (input : string) : bool =
     let len = String.length input in
     if len < 20 || len > datetime_max_len then false
@@ -442,6 +468,7 @@ module Syntax = struct
   let ensure_datetime s =
     if not (is_valid_datetime s) then fail ("invalid datetime " ^ s)
 
+  (** Current UTC time as an AT Protocol datetime. *)
   let now_datetime () : string =
     let tm = Unix.gmtime (Unix.gettimeofday ()) in
     Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02d.000Z" (tm.Unix.tm_year + 1900)
@@ -504,6 +531,7 @@ module Syntax = struct
       "zh-xiang";
     ]
 
+  (** True when [input] is a well-formed BCP 47 language tag. *)
   let is_valid_language (input : string) : bool =
     if input = "" then false
     else
@@ -576,10 +604,12 @@ module Syntax = struct
 
   (* ---- Handle resolution helpers (no network) -------------------------- *)
 
+  (** DNS TXT name for handle resolution ([_atproto.] plus normalized handle). *)
   let handle_txt_name (handle : string) : string =
     ensure_handle handle;
     "_atproto." ^ normalize_handle handle
 
+  (** Parse a [did=…] TXT record value, or [None] if invalid. *)
   let parse_txt_did (value : string) : string option =
     let v = String.trim value in
     if starts_with v "did=" then
@@ -587,11 +617,13 @@ module Syntax = struct
       if is_valid_did did then Some did else None
     else None
 
+  (** HTTPS [.well-known/atproto-did] URL for [handle]. *)
   let handle_well_known_url (handle : string) : string =
     ensure_handle handle;
     Printf.sprintf "https://%s/.well-known/atproto-did"
       (normalize_handle handle)
 
+  (** Parse a well-known DID body (trimmed), or [None] if invalid. *)
   let parse_well_known_did (body : string) : string option =
     let did = String.trim body in
     if is_valid_did did then Some did else None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public Oauth_scope / Syntax helpers that still lacked a function-level comment immediately above the `let`. Matches `src/identity.ml` / `src/hash.ml` and the existing comments from #125 (`parse`, `is_valid_handle` / `is_valid_did` / `is_valid_nsid` / `is_valid_record_key`).

Already documented (skipped): `Oauth_scope.parse`, `Syntax.is_valid_handle` / `is_valid_did` / `is_valid_nsid` / `is_valid_record_key`.

Documented in this PR:

- `Oauth_scope.resource_name` / `resource_of_string`
- `Oauth_scope.collections_of` / `actions_of` / `lxm_of` / `aud_of`
- `Oauth_scope.validate`
- `Oauth_scope.parse_one` / `to_string` / `serialize` / `parse_and_require`
- `Oauth_scope.has_atproto` / `require_atproto` / `is_subset`
- `Oauth_scope.official_include_nsids` / `is_official_include` / `scopes_of_permission` / `expand_include` / `expand_include_nsid`
- `Syntax.normalize_handle` / `normalize_and_ensure_handle` / `is_valid_tld`
- `Syntax.is_valid_did_ref` / `parse_did_ref` / `did_ref_to_string` / `did_method` / `is_blessed_did`
- `Syntax.parse_nsid` / `is_valid_nsid_glob` / `parse_nsid_ref` / `create_nsid`
- `Syntax.is_valid_repo_path` / `is_valid_at_identifier`
- `Syntax.is_valid_datetime` / `now_datetime` / `is_valid_language`
- handle-resolution `parse_txt_did` / `parse_well_known_did`

Skipped tiny private helpers (`fail`, `is_ascii_*`, `split_once`, `pct_*`, `parse_params`). Did not restyle logic. Did not touch tests. AT URI / TID / CID validators live in other modules (#133) and were not edited.

CHANGELOG keeps notes already on `main` through #138 plus a short 0.1.0 bullet for this PR. Hosted-only chat / video / Tap and opam-repository stay listed, not faked.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Oauth_scope / Syntax headers unchanged)
- [x] User-facing change is noted in CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71155fc9-9419-4c94-9bf0-7284792e8adb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71155fc9-9419-4c94-9bf0-7284792e8adb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

