### PR TITLE
Add remaining function-level odoc on Graph XRPC wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,14 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `get_quotes`, `get_actor_likes`, `send_interactions` /
   `send_interactions_body`). Comment-only; does not host a feed
   generator. Hosted-only video / chat / Tap stay listed not faked
+- This PR: remaining function-level odoc on Graph XRPC wrappers
+  (`get_followers_page` / `get_follows_page`, `mute_actor_body`,
+  `get_list_mutes` / `get_list_blocks`, `mute_actor_list` /
+  `unmute_actor_list`, `mute_thread` / `unmute_thread`,
+  `get_starter_pack` / `get_starter_packs` / `get_actor_starter_packs`,
+  `search_starter_packs` / `search_starter_packs_v2`,
+  `get_lists_with_membership` / `get_starter_packs_with_membership`,
+  `get_known_followers`, `get_suggested_follows_by_actor`). Comment-only
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -189,6 +189,7 @@ module Graph = struct
 
   (* app.bsky.graph.muteActor — optional onlyReposts / onlyQuoteposts replace
      a full mute with a scoped mute. Repeat calls replace the stored scope. *)
+
   (** JSON body for [app.bsky.graph.muteActor]. Optional [only_reposts] /
       [only_quoteposts] store a scoped mute; later calls replace the stored
       scope. *)

--- a/src/bsky/graph.ml
+++ b/src/bsky/graph.ml
@@ -124,6 +124,10 @@ module Graph = struct
     in
     followers |> convert_body_to_json |> parse_followers
 
+  (** Paginated followers of [actor] via [app.bsky.graph.getFollowers].
+      Optional [limit] / [cursor] / [sort] map to the lexicon query
+      ([sort_latest] / [sort_top]). Works without a session against public
+      AppView. *)
   let get_followers_page ?session ?host ~actor ?limit ?cursor ?sort () :
       followers =
     Client.Client.get_json ?session ?host "app.bsky.graph.getFollowers"
@@ -153,6 +157,10 @@ module Graph = struct
     in
     follows |> convert_body_to_json |> parse_follows
 
+  (** Paginated accounts [actor] follows via [app.bsky.graph.getFollows].
+      Optional [limit] / [cursor] / [sort] map to the lexicon query
+      ([sort_latest] / [sort_top]). Works without a session against public
+      AppView. *)
   let get_follows_page ?session ?host ~actor ?limit ?cursor ?sort () : follows =
     Client.Client.get_json ?session ?host "app.bsky.graph.getFollows"
       (follow_page_pairs ~actor ?limit ?cursor ?sort ())
@@ -181,6 +189,9 @@ module Graph = struct
 
   (* app.bsky.graph.muteActor — optional onlyReposts / onlyQuoteposts replace
      a full mute with a scoped mute. Repeat calls replace the stored scope. *)
+  (** JSON body for [app.bsky.graph.muteActor]. Optional [only_reposts] /
+      [only_quoteposts] store a scoped mute; later calls replace the stored
+      scope. *)
   let mute_actor_body ~actor ?only_reposts ?only_quoteposts () : Yojson.Safe.t =
     let fields =
       ("actor", `String actor)
@@ -702,38 +713,50 @@ module Graph = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_lists
 
+  (** Lists the session mutes via [app.bsky.graph.getListMutes]. Optional
+      [limit] / [cursor] map to the lexicon query. *)
   let get_list_mutes (s : Session.session) ?limit ?cursor () : lists =
     Client.Client.get_json ~session:s "app.bsky.graph.getListMutes"
       (Client.Client.opt_int "limit" limit
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_lists
 
+  (** Lists the session blocks via [app.bsky.graph.getListBlocks]. Optional
+      [limit] / [cursor] map to the lexicon query. *)
   let get_list_blocks (s : Session.session) ?limit ?cursor () : lists =
     Client.Client.get_json ~session:s "app.bsky.graph.getListBlocks"
       (Client.Client.opt_int "limit" limit
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_lists
 
+  (** Mute list [list] (AT URI) via [app.bsky.graph.muteActorList]. *)
   let mute_actor_list (s : Session.session) ~list () : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.graph.muteActorList"
          (Yojson.Safe.to_string (`Assoc [ ("list", `String list) ])))
 
+  (** Unmute list [list] (AT URI) via [app.bsky.graph.unmuteActorList]. *)
   let unmute_actor_list (s : Session.session) ~list () : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.graph.unmuteActorList"
          (Yojson.Safe.to_string (`Assoc [ ("list", `String list) ])))
 
+  (** Mute the thread rooted at [root] (AT URI) via
+      [app.bsky.graph.muteThread]. *)
   let mute_thread (s : Session.session) ~root () : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.graph.muteThread"
          (Yojson.Safe.to_string (`Assoc [ ("root", `String root) ])))
 
+  (** Unmute the thread rooted at [root] (AT URI) via
+      [app.bsky.graph.unmuteThread]. *)
   let unmute_thread (s : Session.session) ~root () : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.graph.unmuteThread"
          (Yojson.Safe.to_string (`Assoc [ ("root", `String root) ])))
 
+  (** Starter pack [starter_pack] (AT URI) via [app.bsky.graph.getStarterPack].
+      Works without a session against public AppView. *)
   let get_starter_pack ?session ?host ~starter_pack () : starter_pack =
     Client.Client.get_json ?session ?host "app.bsky.graph.getStarterPack"
       [ ("starterPack", starter_pack) ]
@@ -742,12 +765,18 @@ module Graph = struct
     | `Assoc _ as sp -> parse_starter_pack sp
     | _ -> parse_starter_pack json
 
+  (** Starter packs for [uris] via [app.bsky.graph.getStarterPacks]. Works
+      without a session against public AppView. *)
   let get_starter_packs ?session ?host ~uris () : starter_pack list =
     Client.Client.get_json ?session ?host "app.bsky.graph.getStarterPacks"
       (Client.Client.repeat_param "uris" uris)
     |> parse_starter_packs
     |> fun (p : starter_packs) -> p.starter_packs
 
+  (** Starter packs created by [actor] via
+      [app.bsky.graph.getActorStarterPacks]. Optional [limit] / [cursor]
+      map to the lexicon query. Works without a session against public
+      AppView. *)
   let get_actor_starter_packs ?session ?host ~actor ?limit ?cursor () :
       starter_packs =
     Client.Client.get_json ?session ?host "app.bsky.graph.getActorStarterPacks"
@@ -755,12 +784,18 @@ module Graph = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_starter_packs
 
+  (** Search starter packs for [q] via [app.bsky.graph.searchStarterPacks].
+      Optional [limit] / [cursor] map to the lexicon query. Works without a
+      session against public AppView. *)
   let search_starter_packs ?session ?host ~q ?limit ?cursor () : starter_packs =
     Client.Client.get_json ?session ?host "app.bsky.graph.searchStarterPacks"
       ((("q", q) :: Client.Client.opt_int "limit" limit)
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_starter_packs
 
+  (** Search starter packs for [q] via [app.bsky.graph.searchStarterPacksV2].
+      Optional [limit] / [cursor] map to the lexicon query. Works without a
+      session against public AppView. *)
   let search_starter_packs_v2 ?session ?host ~q ?limit ?cursor () :
       starter_packs =
     Client.Client.get_json ?session ?host "app.bsky.graph.searchStarterPacksV2"
@@ -768,6 +803,9 @@ module Graph = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_starter_packs
 
+  (** [actor]'s lists plus the session's membership via
+      [app.bsky.graph.getListsWithMembership]. Optional [limit] / [cursor]
+      / [purposes] map to the lexicon query. *)
   let get_lists_with_membership (s : Session.session) ~actor ?limit ?cursor
       ?(purposes = []) () : lists_with_membership =
     Client.Client.get_json ~session:s "app.bsky.graph.getListsWithMembership"
@@ -776,6 +814,9 @@ module Graph = struct
       @ Client.Client.repeat_param "purposes" purposes)
     |> parse_lists_with_membership
 
+  (** [actor]'s starter packs plus the session's membership via
+      [app.bsky.graph.getStarterPacksWithMembership]. Optional [limit] /
+      [cursor] map to the lexicon query. *)
   let get_starter_packs_with_membership (s : Session.session) ~actor ?limit
       ?cursor () : starter_packs_with_membership =
     Client.Client.get_json ~session:s
@@ -792,6 +833,9 @@ module Graph = struct
       :: Client.Client.repeat_param "others" (Option.value others ~default:[]))
     |> parse_relationships
 
+  (** Followers of [actor] that the session also follows via
+      [app.bsky.graph.getKnownFollowers]. Optional [limit] / [cursor] map
+      to the lexicon query. *)
   let get_known_followers ?session ?host ~actor ?limit ?cursor () : followers =
     Client.Client.get_json ?session ?host "app.bsky.graph.getKnownFollowers"
       ((("actor", actor) :: Client.Client.opt_int "limit" limit)
@@ -833,6 +877,9 @@ module Graph = struct
         | _ -> None);
     }
 
+  (** Suggested follows for [actor] via
+      [app.bsky.graph.getSuggestedFollowsByActor]. Works without a session
+      against public AppView. *)
   let get_suggested_follows_by_actor ?session ?host ~actor () :
       suggested_follows =
     Client.Client.get_json ?session ?host


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Graph` XRPC wrappers in `src/bsky/graph.ml` that still lacked a function-level comment immediately above the `let`. Matches #141 Repo / #142 Sync remaining-wrapper style.

Rebased onto `main` after [#144](https://github.com/david-engelmann/atproto/pull/144) (`0276c7b7`). CHANGELOG keeps the notes already on main (including #143 and #144) plus this PR's Graph odoc bullet.

Already documented (skipped): `get_blocks`, `get_followers`, `get_follows`, `get_mutes`, `mute_actor`, `unmute_actor`, `get_list`, `get_lists`, `get_relationships`.

Documented in this PR:

- `get_followers_page` / `get_follows_page`
- `mute_actor_body`
- `get_list_mutes` / `get_list_blocks`
- `mute_actor_list` / `unmute_actor_list`
- `mute_thread` / `unmute_thread`
- `get_starter_pack` / `get_starter_packs` / `get_actor_starter_packs`
- `search_starter_packs` / `search_starter_packs_v2`
- `get_lists_with_membership` / `get_starter_packs_with_membership`
- `get_known_followers`
- `get_suggested_follows_by_actor`

Short comments with NSID names. Did not restyle logic. Did not document `parse_*` internals. Did not touch tests, `src/oauth_scope.ml`, `src/syntax.ml`, or `src/bsky/feed.ml`. Hosted-only chat / video / Tap and opam-repository stay listed, not faked.

`dune build @fmt --auto-promote` on the edited files (ocamlformat inserted a blank line between the existing muteActor scope comment and `mute_actor_body`'s odoc).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Graph header unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95e19a48-27ef-43be-9b86-19089804481e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95e19a48-27ef-43be-9b86-19089804481e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

