### PR TITLE
Add remaining function-level odoc on Notification XRPC wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,14 +273,16 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `actions_of`, `lxm_of`, `aud_of`, `validate`, `to_string`,
   `is_valid_datetime` / `is_valid_language`, `parse_nsid` /
   `parse_did_ref`, `normalize_handle`). Comment-only
-- This PR: remaining function-level odoc on Feed XRPC wrappers
+- [#144](https://github.com/david-engelmann/atproto/pull/144): remaining
+  function-level odoc on Feed XRPC wrappers
   (`get_reposted_by`, `get_feed_skeleton` / `get_feed_skeleton_parsed`,
   `get_feed_generator` / `get_feed_generators`, `get_actor_feeds`,
   `get_suggested_feeds`, `describe_feed_generator`, `search_posts_v2`,
   `get_quotes`, `get_actor_likes`, `send_interactions` /
   `send_interactions_body`). Comment-only; does not host a feed
   generator. Hosted-only video / chat / Tap stay listed not faked
-- This PR: remaining function-level odoc on Graph XRPC wrappers
+- [#145](https://github.com/david-engelmann/atproto/pull/145): remaining
+  function-level odoc on Graph XRPC wrappers
   (`get_followers_page` / `get_follows_page`, `mute_actor_body`,
   `get_list_mutes` / `get_list_blocks`, `mute_actor_list` /
   `unmute_actor_list`, `mute_thread` / `unmute_thread`,
@@ -288,6 +290,12 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `search_starter_packs` / `search_starter_packs_v2`,
   `get_lists_with_membership` / `get_starter_packs_with_membership`,
   `get_known_followers`, `get_suggested_follows_by_actor`). Comment-only
+- This PR: remaining function-level odoc on Notification XRPC wrappers
+  (`put_preferences` / `put_preferences_v2`,
+  `list_activity_subscriptions`, `put_activity_subscription`,
+  `register_push` / `unregister_push`, `list_notifications_page`).
+  Comment-only; client wrappers for a hosted push service stay listed
+  not faked. Hosted-only video / chat / Tap stay listed not faked
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/bsky/notification.ml
+++ b/src/bsky/notification.ml
@@ -353,6 +353,10 @@ module Notification = struct
     |> parse_notification_page
     |> fun (p : notification_page) -> p.notifications
 
+  (** Paginated notifications via
+      [app.bsky.notification.listNotifications]. Optional [reasons] /
+      [priority] / [cursor] / [seen_at] / [limit] map to the lexicon
+      query. *)
   let list_notifications_page (s : Session.session) ?reasons ?priority ?cursor
       ?seen_at ?limit () : notification_page =
     Client.Client.get_json ~session:s "app.bsky.notification.listNotifications"
@@ -526,11 +530,14 @@ module Notification = struct
     Client.Client.get_json ~session:s "app.bsky.notification.getPreferences" []
     |> parse_preferences
 
+  (** Set [priority] via [app.bsky.notification.putPreferences]. *)
   let put_preferences (s : Session.session) ~priority () : unit =
     ignore
       (Client.Client.post_json ~session:s "app.bsky.notification.putPreferences"
          (Yojson.Safe.to_string (`Assoc [ ("priority", `Bool priority) ])))
 
+  (** Replace notification preferences via
+      [app.bsky.notification.putPreferencesV2]. *)
   let put_preferences_v2 (s : Session.session) (prefs : preferences) :
       preferences =
     Client.Client.post_json ~session:s "app.bsky.notification.putPreferencesV2"
@@ -564,6 +571,9 @@ module Notification = struct
         | _ -> []);
     }
 
+  (** Activity subscriptions via
+      [app.bsky.notification.listActivitySubscriptions]. Optional
+      [limit] / [cursor] map to the lexicon query. *)
   let list_activity_subscriptions (s : Session.session) ?limit ?cursor () :
       activity_subscription_page =
     Client.Client.get_json ~session:s
@@ -572,6 +582,8 @@ module Notification = struct
       @ Client.Client.opt_pair "cursor" cursor)
     |> parse_activity_subscription_page
 
+  (** Put an activity subscription for [subject] via
+      [app.bsky.notification.putActivitySubscription]. *)
   let put_activity_subscription (s : Session.session) ~subject
       ~(activity_subscription : activity_subscription) () :
       string * activity_subscription option =
@@ -592,6 +604,10 @@ module Notification = struct
       | `Assoc _ as a -> Some (parse_activity_subscription a)
       | _ -> None )
 
+  (** Register a push token via [app.bsky.notification.registerPush].
+      Client wrapper for a hosted push service; this library does not
+      send push or fake a live hop. Optional [age_restricted] maps to
+      the lexicon body. *)
   let register_push (s : Session.session) ~service_did ~token ~platform ~app_id
       ?age_restricted () : unit =
     let fields =
@@ -610,6 +626,9 @@ module Notification = struct
       (Client.Client.post_json ~session:s "app.bsky.notification.registerPush"
          (Yojson.Safe.to_string (`Assoc fields)))
 
+  (** Unregister a push token via [app.bsky.notification.unregisterPush].
+      Client wrapper for a hosted push service; this library does not
+      send push or fake a live hop. *)
   let unregister_push (s : Session.session) ~service_did ~token ~platform
       ~app_id () : unit =
     ignore


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Notification` XRPC wrappers in `src/bsky/notification.ml` that still lacked a function-level comment immediately above the `let`. Matches #141 Repo / #144 Feed remaining-wrapper style.

Rebased onto current `main` (`3c9a54a5` after [#145](https://github.com/david-engelmann/atproto/pull/145)). CHANGELOG keeps notes already on main through #144 Feed and #145 Graph, plus this PR's Notification odoc bullet only.

Already documented (skipped): `get_unread_count`, `list_notifications`, `update_seen`, `get_preferences`.

Documented in this PR:

- `put_preferences`
- `put_preferences_v2`
- `list_activity_subscriptions`
- `put_activity_subscription`
- `register_push`
- `unregister_push`
- `list_notifications_page`

Short comments with NSID names. Did not restyle logic. Did not document `parse_*` internals. Did not touch tests, `src/bsky/graph.ml`, or `src/bsky/feed.ml`. `register_push` / `unregister_push` stay client wrappers for a hosted push service (no live push hop). Hosted-only video / chat / Tap and opam-repository stay listed, not faked.

`dune build @fmt --auto-promote` was run after the rebase (no further changes).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Notification header unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-556c3356-30a4-4dba-8085-59c4e9eb8d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-556c3356-30a4-4dba-8085-59c4e9eb8d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

