### PR TITLE
Add remaining function-level odoc on Unspecced XRPC wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,19 +290,30 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `search_starter_packs` / `search_starter_packs_v2`,
   `get_lists_with_membership` / `get_starter_packs_with_membership`,
   `get_known_followers`, `get_suggested_follows_by_actor`). Comment-only
-- This PR: remaining function-level odoc on Notification XRPC wrappers
+- [#146](https://github.com/david-engelmann/atproto/pull/146): remaining
+  function-level odoc on Notification XRPC wrappers
   (`put_preferences` / `put_preferences_v2`,
   `list_activity_subscriptions`, `put_activity_subscription`,
   `register_push` / `unregister_push`, `list_notifications_page`).
   Comment-only; client wrappers for a hosted push service stay listed
   not faked. Hosted-only video / chat / Tap stay listed not faked
-- This PR: remaining function-level odoc on Records builders
+- [#147](https://github.com/david-engelmann/atproto/pull/147): remaining
+  function-level odoc on Records builders
   (`repost`, `block`, `listblock`, `list` / `listitem`,
   `referencelistoptout`, `starterpack`, `profile`, `status`,
   `content_visibility_declaration`, `verification`, `threadgate` /
   `postgate`, `generator`, `labeler_service`,
   `notification_declaration`, `lexicon_schema`, `chat_declaration`).
   Comment-only. Hosted-only chat / video / Tap stay listed not faked
+- This PR: remaining function-level odoc on Unspecced XRPC wrappers
+  (`search_actors_skeleton` / `search_starter_packs_skeleton`,
+  `get_config`, `get_popular_feed_generators`, `get_tagged_suggestions`,
+  `get_age_assurance_state`, `init_age_assurance` /
+  `init_age_assurance_body`, `get_trends` / `get_trends_skeleton`,
+  `get_suggestions_skeleton`, `get_suggested_*` /
+  `get_onboarding_*` skeletons, `get_post_thread_v2` /
+  `get_post_thread_other_v2`). Comment-only. Hosted-only video / chat /
+  Tap stay listed not faked
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/bsky/unspecced.ml
+++ b/src/bsky/unspecced.ml
@@ -163,6 +163,9 @@ module Unspecced = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_skeleton_posts
 
+  (** Actor search skeleton via [app.bsky.unspecced.searchActorsSkeleton].
+      Optional [viewer] / [typeahead] / [limit] / [cursor] map to the
+      lexicon query. Works without a session against public AppView. *)
   let search_actors_skeleton ?session ?host ~q ?viewer ?typeahead ?limit ?cursor
       () : skeleton_actors =
     Client.get_json ?session ?host "app.bsky.unspecced.searchActorsSkeleton"
@@ -173,6 +176,10 @@ module Unspecced = struct
       @ Client.opt_pair "cursor" cursor)
     |> parse_skeleton_actors
 
+  (** Starter pack search skeleton via
+      [app.bsky.unspecced.searchStarterPacksSkeleton]. Optional [viewer] /
+      [limit] / [cursor] map to the lexicon query. Works without a session
+      against public AppView. *)
   let search_starter_packs_skeleton ?session ?host ~q ?viewer ?limit ?cursor ()
       : skeleton_starter_packs =
     Client.get_json ?session ?host
@@ -189,10 +196,16 @@ module Unspecced = struct
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> parse_trending_topics
 
+  (** Runtime config via [app.bsky.unspecced.getConfig]. Works without a
+      session against public AppView. *)
   let get_config ?session ?host () : config =
     Client.get_json ?session ?host "app.bsky.unspecced.getConfig" []
     |> parse_config
 
+  (** Popular feed generators via
+      [app.bsky.unspecced.getPopularFeedGenerators]. Optional [query] /
+      [limit] / [cursor] map to the lexicon query. Works without a session
+      against public AppView. *)
   let get_popular_feed_generators ?session ?host ?query ?limit ?cursor () :
       generators =
     Client.get_json ?session ?host "app.bsky.unspecced.getPopularFeedGenerators"
@@ -469,14 +482,19 @@ module Unspecced = struct
   let parse_thread_other_v2 json : thread_other_v2 =
     { thread = List.map parse_thread_item (Client.list_member json "thread") }
 
+  (** Tagged suggestions via [app.bsky.unspecced.getTaggedSuggestions].
+      Works without a session against public AppView. *)
   let get_tagged_suggestions ?session ?host () : tagged_suggestions =
     Client.get_json ?session ?host "app.bsky.unspecced.getTaggedSuggestions" []
     |> parse_tagged_suggestions
 
+  (** Age-assurance state via [app.bsky.unspecced.getAgeAssuranceState]
+      (session required). *)
   let get_age_assurance_state (s : Session.session) : age_assurance_state =
     Client.get_json ~session:s "app.bsky.unspecced.getAgeAssuranceState" []
     |> parse_age_assurance_state
 
+  (** JSON body for [app.bsky.unspecced.initAgeAssurance]. *)
   let init_age_assurance_body ~email ~language ~country_code : Yojson.Safe.t =
     `Assoc
       [
@@ -485,6 +503,8 @@ module Unspecced = struct
         ("countryCode", `String country_code);
       ]
 
+  (** Start age assurance via [app.bsky.unspecced.initAgeAssurance]
+      (session required). *)
   let init_age_assurance (s : Session.session) ~email ~language ~country_code ()
       : age_assurance_state =
     Client.post_json ~session:s "app.bsky.unspecced.initAgeAssurance"
@@ -492,16 +512,25 @@ module Unspecced = struct
          (init_age_assurance_body ~email ~language ~country_code))
     |> parse_age_assurance_state
 
+  (** Trends via [app.bsky.unspecced.getTrends]. Optional [limit] maps to
+      the lexicon query. Works without a session against public AppView. *)
   let get_trends ?session ?host ?limit () : trends =
     Client.get_json ?session ?host "app.bsky.unspecced.getTrends"
       (Client.opt_int "limit" limit)
     |> parse_trends
 
+  (** Trend skeleton via [app.bsky.unspecced.getTrendsSkeleton]. Optional
+      [viewer] / [limit] map to the lexicon query. Works without a session
+      against public AppView. *)
   let get_trends_skeleton ?session ?host ?viewer ?limit () : trends_skeleton =
     Client.get_json ?session ?host "app.bsky.unspecced.getTrendsSkeleton"
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> parse_trends_skeleton
 
+  (** Suggested-actor skeleton via
+      [app.bsky.unspecced.getSuggestionsSkeleton]. Optional [viewer] /
+      [limit] / [cursor] / [relative_to_did] map to the lexicon query.
+      Works without a session against public AppView. *)
   let get_suggestions_skeleton ?session ?host ?viewer ?limit ?cursor
       ?relative_to_did () : suggestions_skeleton =
     Client.get_json ?session ?host "app.bsky.unspecced.getSuggestionsSkeleton"
@@ -511,11 +540,18 @@ module Unspecced = struct
       @ Client.opt_pair "relativeToDid" relative_to_did)
     |> parse_suggestions_skeleton
 
+  (** Suggested feeds via [app.bsky.unspecced.getSuggestedFeeds]. Optional
+      [limit] maps to the lexicon query. Works without a session against
+      public AppView. *)
   let get_suggested_feeds ?session ?host ?limit () : suggested_feeds =
     Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedFeeds"
       (Client.opt_int "limit" limit)
     |> parse_suggested_feeds
 
+  (** Suggested-feed skeleton via
+      [app.bsky.unspecced.getSuggestedFeedsSkeleton]. Optional [viewer] /
+      [limit] map to the lexicon query. Works without a session against
+      public AppView. *)
   let get_suggested_feeds_skeleton ?session ?host ?viewer ?limit () :
       uri_skeleton =
     Client.get_json ?session ?host
@@ -523,11 +559,18 @@ module Unspecced = struct
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> fun json -> parse_uri_list json "feeds"
 
+  (** Suggested users via [app.bsky.unspecced.getSuggestedUsers]. Optional
+      [category] / [limit] map to the lexicon query. Works without a
+      session against public AppView. *)
   let get_suggested_users ?session ?host ?category ?limit () : suggested_users =
     Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedUsers"
       (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
     |> parse_suggested_users
 
+  (** Suggested-user skeleton via
+      [app.bsky.unspecced.getSuggestedUsersSkeleton]. Optional [viewer] /
+      [category] / [limit] map to the lexicon query. Works without a
+      session against public AppView. *)
   let get_suggested_users_skeleton ?session ?host ?viewer ?category ?limit () :
       did_skeleton =
     Client.get_json ?session ?host
@@ -537,6 +580,10 @@ module Unspecced = struct
       @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
+  (** Suggested starter packs via
+      [app.bsky.unspecced.getSuggestedStarterPacks]. Optional [limit] maps
+      to the lexicon query. Works without a session against public
+      AppView. *)
   let get_suggested_starter_packs ?session ?host ?limit () :
       Graph.starter_pack list =
     Client.get_json ?session ?host "app.bsky.unspecced.getSuggestedStarterPacks"
@@ -544,6 +591,10 @@ module Unspecced = struct
     |> fun json ->
     List.map Graph.parse_starter_pack (Client.list_member json "starterPacks")
 
+  (** Suggested starter-pack skeleton via
+      [app.bsky.unspecced.getSuggestedStarterPacksSkeleton]. Optional
+      [viewer] / [limit] map to the lexicon query. Works without a session
+      against public AppView. *)
   let get_suggested_starter_packs_skeleton ?session ?host ?viewer ?limit () :
       uri_skeleton =
     Client.get_json ?session ?host
@@ -551,6 +602,10 @@ module Unspecced = struct
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> fun json -> parse_uri_list json "starterPacks"
 
+  (** Onboarding suggested starter packs via
+      [app.bsky.unspecced.getOnboardingSuggestedStarterPacks]. Optional
+      [limit] maps to the lexicon query. Works without a session against
+      public AppView. *)
   let get_onboarding_suggested_starter_packs ?session ?host ?limit () :
       Graph.starter_pack list =
     Client.get_json ?session ?host
@@ -559,6 +614,10 @@ module Unspecced = struct
     |> fun json ->
     List.map Graph.parse_starter_pack (Client.list_member json "starterPacks")
 
+  (** Onboarding suggested starter-pack skeleton via
+      [app.bsky.unspecced.getOnboardingSuggestedStarterPacksSkeleton].
+      Optional [viewer] / [limit] map to the lexicon query. Works without
+      a session against public AppView. *)
   let get_onboarding_suggested_starter_packs_skeleton ?session ?host ?viewer
       ?limit () : uri_skeleton =
     Client.get_json ?session ?host
@@ -566,6 +625,10 @@ module Unspecced = struct
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> fun json -> parse_uri_list json "starterPacks"
 
+  (** Onboarding suggested users via
+      [app.bsky.unspecced.getSuggestedOnboardingUsers]. Optional
+      [category] / [limit] map to the lexicon query. Works without a
+      session against public AppView. *)
   let get_suggested_onboarding_users ?session ?host ?category ?limit () :
       suggested_users =
     Client.get_json ?session ?host
@@ -573,6 +636,10 @@ module Unspecced = struct
       (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
     |> parse_suggested_users
 
+  (** Onboarding suggested-user skeleton via
+      [app.bsky.unspecced.getOnboardingSuggestedUsersSkeleton]. Optional
+      [viewer] / [category] / [limit] map to the lexicon query. Works
+      without a session against public AppView. *)
   let get_onboarding_suggested_users_skeleton ?session ?host ?viewer ?category
       ?limit () : did_skeleton =
     Client.get_json ?session ?host
@@ -582,6 +649,10 @@ module Unspecced = struct
       @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
+  (** Discover suggested users via
+      [app.bsky.unspecced.getSuggestedUsersForDiscover]. Optional [limit]
+      maps to the lexicon query. Works without a session against public
+      AppView. *)
   let get_suggested_users_for_discover ?session ?host ?limit () :
       suggested_users =
     Client.get_json ?session ?host
@@ -589,6 +660,10 @@ module Unspecced = struct
       (Client.opt_int "limit" limit)
     |> parse_suggested_users
 
+  (** Discover suggested-user skeleton via
+      [app.bsky.unspecced.getSuggestedUsersForDiscoverSkeleton]. Optional
+      [viewer] / [limit] map to the lexicon query. Works without a session
+      against public AppView. *)
   let get_suggested_users_for_discover_skeleton ?session ?host ?viewer ?limit ()
       : did_skeleton =
     Client.get_json ?session ?host
@@ -596,6 +671,10 @@ module Unspecced = struct
       (Client.opt_pair "viewer" viewer @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
+  (** Explore suggested users via
+      [app.bsky.unspecced.getSuggestedUsersForExplore]. Optional
+      [category] / [limit] map to the lexicon query. Works without a
+      session against public AppView. *)
   let get_suggested_users_for_explore ?session ?host ?category ?limit () :
       suggested_users =
     Client.get_json ?session ?host
@@ -603,6 +682,10 @@ module Unspecced = struct
       (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
     |> parse_suggested_users
 
+  (** Explore suggested-user skeleton via
+      [app.bsky.unspecced.getSuggestedUsersForExploreSkeleton]. Optional
+      [viewer] / [category] / [limit] map to the lexicon query. Works
+      without a session against public AppView. *)
   let get_suggested_users_for_explore_skeleton ?session ?host ?viewer ?category
       ?limit () : did_skeleton =
     Client.get_json ?session ?host
@@ -612,6 +695,10 @@ module Unspecced = struct
       @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
+  (** See-more suggested users via
+      [app.bsky.unspecced.getSuggestedUsersForSeeMore]. Optional
+      [category] / [limit] map to the lexicon query. Works without a
+      session against public AppView. *)
   let get_suggested_users_for_see_more ?session ?host ?category ?limit () :
       suggested_users =
     Client.get_json ?session ?host
@@ -619,6 +706,10 @@ module Unspecced = struct
       (Client.opt_pair "category" category @ Client.opt_int "limit" limit)
     |> parse_suggested_users
 
+  (** See-more suggested-user skeleton via
+      [app.bsky.unspecced.getSuggestedUsersForSeeMoreSkeleton]. Optional
+      [viewer] / [category] / [limit] map to the lexicon query. Works
+      without a session against public AppView. *)
   let get_suggested_users_for_see_more_skeleton ?session ?host ?viewer ?category
       ?limit () : did_skeleton =
     Client.get_json ?session ?host
@@ -628,6 +719,9 @@ module Unspecced = struct
       @ Client.opt_int "limit" limit)
     |> parse_did_skeleton
 
+  (** Post thread (v2) via [app.bsky.unspecced.getPostThreadV2]. Optional
+      [above] / [below] / [branching_factor] / [sort] map to the lexicon
+      query. Works without a session against public AppView. *)
   let get_post_thread_v2 ?session ?host ~anchor ?above ?below ?branching_factor
       ?sort () : thread_v2 =
     Client.get_json ?session ?host "app.bsky.unspecced.getPostThreadV2"
@@ -638,6 +732,9 @@ module Unspecced = struct
       @ Client.opt_pair "sort" sort)
     |> parse_thread_v2
 
+  (** Additional thread replies (v2) via
+      [app.bsky.unspecced.getPostThreadOtherV2]. Works without a session
+      against public AppView. *)
   let get_post_thread_other_v2 ?session ?host ~anchor () : thread_other_v2 =
     Client.get_json ?session ?host "app.bsky.unspecced.getPostThreadOtherV2"
       [ ("anchor", anchor) ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Unspecced` XRPC wrappers in `src/bsky/unspecced.ml` that still lacked a function-level comment immediately above the `let`. Matches #144 Feed / #146 Notification remaining-wrapper style.

Rebased onto current `main` (`d175f368` after [#147](https://github.com/david-engelmann/atproto/pull/147)). CHANGELOG keeps notes already on main through #146 Notification and #147 Records, plus this PR's Unspecced odoc bullet only.

Already documented (skipped): `search_posts_skeleton`, `get_trending_topics`.

Documented in this PR:

- `search_actors_skeleton` / `search_starter_packs_skeleton`
- `get_config`
- `get_popular_feed_generators`
- `get_tagged_suggestions`
- `get_age_assurance_state`
- `init_age_assurance` / `init_age_assurance_body`
- `get_trends` / `get_trends_skeleton`
- `get_suggestions_skeleton`
- `get_suggested_feeds` / `get_suggested_feeds_skeleton`
- `get_suggested_users` / `get_suggested_users_skeleton`
- `get_suggested_starter_packs` / `get_suggested_starter_packs_skeleton`
- `get_onboarding_suggested_starter_packs` / `get_onboarding_suggested_starter_packs_skeleton`
- `get_suggested_onboarding_users` / `get_onboarding_suggested_users_skeleton`
- `get_suggested_users_for_discover` / `get_suggested_users_for_discover_skeleton`
- `get_suggested_users_for_explore` / `get_suggested_users_for_explore_skeleton`
- `get_suggested_users_for_see_more` / `get_suggested_users_for_see_more_skeleton`
- `get_post_thread_v2` / `get_post_thread_other_v2`

Short comments with NSID names. Did not restyle logic. Did not document `parse_*` internals. Did not touch tests or `src/bsky/records.ml` (#147, now on main). Hosted-only video / chat / Tap and opam-repository stay listed, not faked.

`dune build @fmt --auto-promote` was run after the rebase (no further changes).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Unspecced header unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5125d18f-8c28-4883-8eff-e4706fc007d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5125d18f-8c28-4883-8eff-e4706fc007d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

