### PR TITLE
Add remaining function-level odoc on Label helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,7 +305,8 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `postgate`, `generator`, `labeler_service`,
   `notification_declaration`, `lexicon_schema`, `chat_declaration`).
   Comment-only. Hosted-only chat / video / Tap stay listed not faked
-- This PR: remaining function-level odoc on Unspecced XRPC wrappers
+- [#148](https://github.com/david-engelmann/atproto/pull/148): remaining
+  function-level odoc on Unspecced XRPC wrappers
   (`search_actors_skeleton` / `search_starter_packs_skeleton`,
   `get_config`, `get_popular_feed_generators`, `get_tagged_suggestions`,
   `get_age_assurance_state`, `init_age_assurance` /
@@ -314,6 +315,10 @@ CI and `make test-pds` start published `@atproto/dev-env@0.6.4`
   `get_onboarding_*` skeletons, `get_post_thread_v2` /
   `get_post_thread_other_v2`). Comment-only. Hosted-only video / chat /
   Tap stay listed not faked
+- This PR: remaining function-level odoc on Label helpers
+  (`query_labels_parsed`, `query_labels_body`, `subscribe` /
+  `subscribe_one`, `encode_unsigned` / `encode_signed`). Comment-only.
+  Hosted-only chat / video / Tap stay listed not faked
 - `examples/offline.ml` typechecks against the public API under
   `dune build` / `dune runtest`
 

--- a/src/label.ml
+++ b/src/label.ml
@@ -193,6 +193,8 @@ module Label = struct
   let create_label_endpoint (query_name : string) : string =
     "com.atproto.label" ^ "." ^ query_name
 
+  (** Query-string pairs for [com.atproto.label.queryLabels]. Optional
+      [sources], [limit], and [cursor]. *)
   let query_labels_body ?(uri_patterns = []) ?sources ?limit ?cursor () :
       (string * string) list =
     let pairs =
@@ -228,6 +230,8 @@ module Label = struct
     in
     labels
 
+  (** Parsed [com.atproto.label.queryLabels] for [uri_patterns]. Optional
+      [sources], [limit], and [cursor]. *)
   let query_labels_parsed (s : Session.session) ~uri_patterns ?sources ?limit
       ?cursor () : query_labels =
     let bearer_token = Session.bearer_token_from_session s in
@@ -251,6 +255,8 @@ module Label = struct
 
   (* ---- signed labels (com.atproto.label.defs#label) -------------------- *)
 
+  (** DAG-CBOR encode [l] without [sig] ([com.atproto.label.defs#label]).
+      Used as the signing input. *)
   let encode_unsigned (l : label) : string =
     let fields =
       [
@@ -268,6 +274,8 @@ module Label = struct
     in
     Dag_cbor.encode (Dag_cbor.Map fields)
 
+  (** DAG-CBOR encode [l] including [sig] when present
+      ([com.atproto.label.defs#label]). *)
   let encode_signed (l : label) : string =
     match l.sig_ with
     | None -> encode_unsigned l
@@ -482,6 +490,8 @@ module Label = struct
     in
     header ^ body
 
+  (** Stream [com.atproto.label.subscribeLabels] frames to [f]. Optional
+      [host], [cursor], and [max_messages]. *)
   let subscribe ?(host = "bsky.network") ?cursor ?max_messages f =
     let url = subscribe_url ~host ?cursor () in
     Websocket.Websocket.with_connection url (fun ws ->
@@ -500,6 +510,8 @@ module Label = struct
         in
         loop 0)
 
+  (** Receive one [com.atproto.label.subscribeLabels] frame (default
+      [bsky.network]). Optional [host] and [cursor]. *)
   let subscribe_one ?host ?cursor () : header * message =
     let cell = ref None in
     subscribe ?host ?cursor ~max_messages:1 (fun frame -> cell := Some frame);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Label` helpers in `src/label.ml` that still lacked a function-level comment immediately above the `let`. Matches #144 Feed remaining-wrapper style.

Rebased onto current `main` (`51859c8e` after [#148](https://github.com/david-engelmann/atproto/pull/148)). CHANGELOG keeps notes already on main (including #144 Feed, #145 Graph, #146 Notification, #147 Records, and #148 Unspecced) plus this PR's Label helpers bullet only.

Already documented (skipped): `query_labels`, `subscribe_url`.

Documented in this PR:

- `query_labels_parsed`
- `query_labels_body`
- `subscribe`
- `subscribe_one`
- `encode_unsigned`
- `encode_signed`

Short comments with NSID names. Did not restyle logic. Did not document `parse_*` internals. Did not touch tests or `src/bsky/unspecced.ml` (#148, merged). Hosted-only video / chat / Tap and opam-repository stay listed, not faked.

`dune build @fmt --auto-promote` was run after the rebase (no further changes). `ocamlc -stop-after parsing` on `src/label.ml` succeeds; comments terminate correctly.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Label header unchanged)
- [x] User-facing change is noted in CHANGELOG.md

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be9fef2e-2836-40ec-80ec-3625b668baee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be9fef2e-2836-40ec-80ec-3625b668baee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

