### PR TITLE
Live TestNetwork hops for remaining com.atproto.server NSIDs

### DIFF
--- a/test/test_local_pds.ml
+++ b/test/test_local_pds.ml
@@ -1141,6 +1141,83 @@ let test_leftover_admin _ =
        (Yojson.Safe.to_string
           (Admin.delete_account_body ~did:doomed.auth.did ())))
 
+(* Remaining com.atproto.server NSIDs whose wrappers already exist
+   (#136) and are not already live-called. createInviteCode(s) may
+   be admin-only — reuse admin_leftover_post / admin_basic_extra if
+   the session JWT is not an operator token. Email/password token
+   hops skip InvalidToken / email-token / SMTP policy (TestNetwork
+   cannot deliver mail). Empty-body POSTs send "" not "{}" (same as
+   requestAccountDelete). Destructive hops use a throwaway account,
+   never alice.test. Does not invent SMTP or a hosted mailer. *)
+let test_leftover_server _ =
+  let admin = admin_session () in
+  let alice = session () in
+  let doomed = throwaway_session "srv" "local-server-throwaway-password" in
+  if doomed.username = "alice.test" || doomed.auth.did = alice.auth.did then
+    failwith "refusing leftover server hops on alice.test";
+  (match
+     admin_leftover_post admin "com.atproto.server.createInviteCode"
+       (Yojson.Safe.to_string
+          (Server.create_invite_code_body ~use_count:1
+             ~for_account:doomed.auth.did ()))
+   with
+  | None -> ()
+  | Some json ->
+      OUnit2.assert_bool "createInviteCode"
+        (match Yojson.Safe.Util.member "code" json with
+        | `String c -> String.length c > 0
+        | _ -> false));
+  (match
+     admin_leftover_post admin "com.atproto.server.createInviteCodes"
+       (Yojson.Safe.to_string
+          (Server.create_invite_codes_body ~code_count:1 ~use_count:1
+             ~for_accounts:[ doomed.auth.did ] ()))
+   with
+  | None -> ()
+  | Some json ->
+      OUnit2.assert_bool "createInviteCodes"
+        (match Yojson.Safe.Util.member "codes" json with
+        | `List _ -> true
+        | _ -> false));
+  (* Empty body, same as requestAccountDelete. PDS 0.5.31 rejects
+     JSON {} when none was expected. *)
+  ignore
+    (admin_leftover_json
+       (Client.post_json ~session:doomed ~host:(pds_host ())
+          "com.atproto.server.requestEmailConfirmation" ""));
+  ignore
+    (pds_leftover_json
+       (Client.post_json ~session:doomed ~host:(pds_host ())
+          "com.atproto.server.confirmEmail"
+          (Yojson.Safe.to_string
+             (Server.confirm_email_body
+                ~email:(doomed.username ^ "@test.local")
+                ~token:"not-an-email-token"))));
+  ignore
+    (pds_leftover_json
+       (Client.post_json ~session:doomed ~host:(pds_host ())
+          "com.atproto.server.updateEmail"
+          (Yojson.Safe.to_string
+             (Server.update_email_body
+                ~email:(unique_handle "srve" ^ "@test.local")
+                ~token:"not-an-email-token" ()))));
+  ignore
+    (admin_leftover_json
+       (Client.post_json ~session:doomed ~host:(pds_host ())
+          "com.atproto.server.requestPasswordReset"
+          (Yojson.Safe.to_string
+             (Server.request_password_reset_body
+                ~email:(doomed.username ^ "@test.local")))));
+  if doomed.username = "alice.test" then
+    failwith "refusing resetPassword on alice.test";
+  ignore
+    (pds_leftover_json
+       (Client.post_json ~session:doomed ~host:(pds_host ())
+          "com.atproto.server.resetPassword"
+          (Yojson.Safe.to_string
+             (Server.reset_password_body ~token:"not-an-email-token"
+                ~password:"local-server-reset-password"))))
+
 let suite =
   "local_pds"
   >::: [
@@ -1168,6 +1245,7 @@ let suite =
          "test_plc_directory_write" >:: test_plc_directory_write;
          "test_leftover_served" >:: test_leftover_served;
          "test_leftover_admin" >:: test_leftover_admin;
+         "test_leftover_server" >:: test_leftover_server;
        ]
 
 let () =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds skip-if-not-served live TestNetwork hops for remaining `com.atproto.server` wrappers that already exist on main (`src/server.ml`, documented in [#136](https://github.com/david-engelmann/atproto/pull/136)) and were not live-called after [#150](https://github.com/david-engelmann/atproto/pull/150) leftover admin hops.

Targets current `main` at `b57bc88c` ([#150](https://github.com/david-engelmann/atproto/pull/150)).

- Touches **only** `test/test_local_pds.ml` (no CHANGELOG / README / `src/` / other tests)
- Does **not** reopen or duplicate leftover `com.atproto.admin` NSIDs from `test_leftover_admin`
- `createInviteCode` / `createInviteCodes` reuse `admin_leftover_post` / `admin_basic_extra` / `is_admin_policy_invalid` when the session JWT is not an operator token
- `requestEmailConfirmation` POSTs `""` not `"{}"` (same as `requestAccountDelete`; PDS rejects a body when none is expected)
- `confirmEmail` / `updateEmail` / `requestPasswordReset` / `resetPassword` skip InvalidToken / email-token / SMTP policy via `pds_leftover_json` / `admin_leftover_json` / `is_policy_invalid` (TestNetwork cannot deliver mail; skip is correct)
- Destructive hops use a throwaway account, never `alice.test`

Already live, not redone: `describeServer`, `createAccount`, `createSession`, `getSession`, `refreshSession`, `deleteSession`, `getAccountInviteCodes`, `createAppPassword` (known 500), `listAppPasswords`, `revokeAppPassword` (when create is not 500), `requestEmailUpdate`, `requestAccountDelete`, `deleteAccount`, `deactivate`/`activate`, `getServiceAuth`, `reserveSigningKey`, `checkAccountStatus`.

### NSIDs hopped
- `com.atproto.server.createInviteCode` / `createInviteCodes`
- `com.atproto.server.requestEmailConfirmation`
- `com.atproto.server.confirmEmail`
- `com.atproto.server.updateEmail`
- `com.atproto.server.requestPasswordReset` / `resetPassword`

Does **not** invent OSS chat, a video transcoder, Tap, phone/contacts verify, push, leftover-field restyles, or an opam-repository publish. Does not invent SMTP or a hosted mailer.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md (n/a — test-only leftover hops; CHANGELOG left on main)

Fixes # (n/a — leftover live coverage after #136 / #129 / #150)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca46c754-33ce-4d2d-9a14-f37482362c56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca46c754-33ce-4d2d-9a14-f37482362c56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

