### PR TITLE
Live TestNetwork hops for leftover AppView sendInteractions and prefs

### DIFF
--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -1236,6 +1236,55 @@ let test_unspecced_and_ageassurance _ =
       let state = Ageassurance.parse_state json in
       OUnit2.assert_bool "ageassurance.begin" (String.length state.status >= 0)
 
+(* Unique leftover AppView NSIDs whose wrappers exist on main and are
+   not live above. Skip if this revision 501s the method or TestNetwork
+   policy InvalidRequest (is_policy_invalid). chat.bsky.* / video.* /
+   Tap / contact.* / push register-unregister / unhosted getFeed stay
+   listed not faked. describeFeedGenerator is a feed-generator service
+   method — do not treat a skip as a hosted generator. *)
+let test_leftover_feed_notification _ =
+  let s = session () in
+  (match
+     Yojson.Safe.Util.member "feed"
+       (av_get "app.bsky.feed.getAuthorFeed"
+          [ ("actor", "alice.test"); ("limit", "1") ])
+   with
+  | `List (item :: _) -> (
+      match Yojson.Safe.Util.member "post" item with
+      | `Assoc _ as post -> (
+          match Yojson.Safe.Util.member "uri" post with
+          | `String uri when String.length uri > 0 -> (
+              match
+                av_post_leftover ~session:s "app.bsky.feed.sendInteractions"
+                  (Yojson.Safe.to_string
+                     (Feed.send_interactions_body
+                        [
+                          {
+                            item = Some uri;
+                            event = Some "app.bsky.feed.defs#interactionLike";
+                            feed_context = None;
+                            req_id = None;
+                          };
+                        ]))
+              with
+              | None -> ()
+              | Some _ -> OUnit2.assert_bool "sendInteractions" true)
+          | _ -> ())
+      | _ -> ())
+  | _ -> ());
+  (match av_get_leftover "app.bsky.feed.describeFeedGenerator" [] with
+  | None -> ()
+  | Some json ->
+      let desc = Feed.parse_describe_feed_generator json in
+      OUnit2.assert_bool "describeFeedGenerator"
+        (String.length desc.did >= 0 && List.length desc.feeds >= 0));
+  match
+    av_post_leftover ~session:s "app.bsky.notification.putPreferences"
+      (Yojson.Safe.to_string (`Assoc [ ("priority", `Bool false) ]))
+  with
+  | None -> ()
+  | Some _ -> OUnit2.assert_bool "putPreferences v1" true
+
 let suite =
   "local_appview"
   >::: [
@@ -1252,6 +1301,7 @@ let suite =
          "test_put_preferences_v2" >:: test_put_preferences_v2;
          "test_leftover_served" >:: test_leftover_served;
          "test_unspecced_and_ageassurance" >:: test_unspecced_and_ageassurance;
+         "test_leftover_feed_notification" >:: test_leftover_feed_notification;
        ]
 
 let () =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds skip-if-not-served live TestNetwork hops for unique leftover AppView NSIDs whose wrappers already exist on `main` (`b57bc88c`) and were **not** already called in `test/test_local_appview.ml`.

Verified on current `main` first. Only `test/test_local_appview.ml` changes — a sibling docs PR owns CHANGELOG / README notes.

Uses existing leftover helpers (`av_get_leftover` / `av_post_leftover` / `is_policy_invalid`). **Does not fail** the suite on TestNetwork-policy `InvalidRequest` (unhosted feed generator DID, not-implemented) or when the NSID is not served.

### Unique leftover hops
- `app.bsky.feed.sendInteractions` — `Feed.send_interactions` / `send_interactions_body` (odoc in [#144](https://github.com/david-engelmann/atproto/pull/144)). Live-calls a small interactions body when a post uri is available from `getAuthorFeed`. Skip if not served / policy / no post uri.
- `app.bsky.feed.describeFeedGenerator` — wrapper exists and was not already live. Skip if not served. Does **not** claim a hosted feed generator; unhosted generator DID is already skip-policy (`could not find feed` / `invalid feed generator service details`).
- `app.bsky.notification.putPreferences` (v1, **not** `putPreferencesV2` which is already live). Distinct NSID + wrapper; skip-if-not-served.

### Stay listed not faked
- `chat.bsky.*` (no OSS chat backend)
- `app.bsky.video.*` (no hosted transcoder)
- hosted Tap
- phone / contacts (`app.bsky.contact.*`)
- push `registerPush` / `unregisterPush` (hosted push)
- unhosted feed generator `getFeed` against suggested feeds

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (sibling docs PR owns notes)

Fixes # (n/a — leftover live coverage after #144 / #129)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51a0da6-a4cd-409d-8f35-81974e43f2c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51a0da6-a4cd-409d-8f35-81974e43f2c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

