### PR TITLE
Live TestNetwork hops for tools.ozone.report getAssignments and unassignModerator

### DIFF
--- a/test/test_local_ozone.ml
+++ b/test/test_local_ozone.ml
@@ -800,7 +800,11 @@ let test_leftover_served _ =
   | Some id -> ignore (Ozone.delete_queue s ~proxy:p ~queue_id:id ())
   | None -> ()
 
-(* Remaining ozone NSIDs whose wrappers already exist. Skip if not served. *)
+(* Remaining ozone NSIDs whose wrappers already exist. Skip if not served.
+   Live tools.ozone.report.getAssignments / unassignModerator when a
+   report id is available. Skip if not served / MethodNotImplemented /
+   feature-disabled / UpstreamFailure (leftover_served). Do not invent
+   a hosted ozone report store. *)
 let test_leftover_remaining _ =
   let s = admin_session () in
   let p = proxy () in
@@ -951,6 +955,30 @@ let test_leftover_remaining _ =
               let assigned = Ozone.parse_assignment_view json in
               OUnit2.assert_bool "report.assignModerator"
                 (String.length assigned.did >= 0)
+          | _ -> ());
+          (match
+             ozone_json s p "tools.ozone.report.getAssignments"
+               [ ("limit", "10"); ("reportIds", string_of_int rid) ]
+           with
+          | json when leftover_served json ->
+              let page = Ozone.parse_assignments json in
+              OUnit2.assert_bool "report.getAssignments"
+                (List.length page.assignments >= 0);
+              let via_wrapper =
+                Ozone.get_report_assignments s ~proxy:p ~report_ids:[ rid ]
+                  ~limit:10 ()
+              in
+              OUnit2.assert_bool "get_report_assignments"
+                (List.length via_wrapper.assignments >= 0)
+          | _ -> ());
+          (match
+             ozone_post s p "tools.ozone.report.unassignModerator"
+               (`Assoc [ ("reportId", `Int rid) ])
+           with
+          | json when leftover_served json ->
+              let view = Ozone.parse_assignment_view json in
+              OUnit2.assert_bool "report.unassignModerator"
+                (String.length view.did >= 0)
           | _ -> ());
           (match
              ozone_json s p "tools.ozone.report.listActivities"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds skip-if-not-served live TestNetwork hops for the two leftover `tools.ozone.report` NSIDs whose wrappers already exist on `main` (`Ozone.get_report_assignments` / `Ozone.unassign_report_moderator`). These were not live-called yet; do not confuse them with `tools.ozone.queue.getAssignments` / `queue.unassignModerator`, which are already covered.

Extends `test_leftover_remaining` in `test/test_local_ozone.ml` only. When a report id is available (after the existing create-report / `report.assignModerator` flow):

- GET `tools.ozone.report.getAssignments` (`limit` 10, `reportIds`) and parse with `Ozone.parse_assignments` / `Ozone.get_report_assignments`
- POST `tools.ozone.report.unassignModerator` with `reportId` after assign

Uses existing helpers (`leftover_served`, `is_policy_invalid`, `ozone_json`, `ozone_post`). Skip when not served, MethodNotImplemented, feature-disabled, UpstreamFailure, or other TestNetwork policy. Does not fail the suite on those. Does not invent a hosted ozone report store. Destructive hops never target `alice.test`.

CHANGELOG / README / `src/` are intentionally untouched — a sibling docs PR owns the notes.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (sibling docs PR)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c2cca3a-4e70-47ac-8f5c-b8af5b45f9db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c2cca3a-4e70-47ac-8f5c-b8af5b45f9db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

