### PR TITLE
Add remaining function-level odoc on Contact XRPC wrappers

### DIFF
--- a/src/bsky/contact.ml
+++ b/src/bsky/contact.ml
@@ -50,6 +50,8 @@ module Contact = struct
         List.map Actor.parse_short_profile (Client.list_member json "matches");
     }
 
+  (** JSON body for [app.bsky.contact.importContacts]
+      ([token] from [verify_phone]). *)
   let import_contacts_body ~token ~contacts : Yojson.Safe.t =
     `Assoc
       [
@@ -57,15 +59,19 @@ module Contact = struct
         ("contacts", `List (List.map (fun p -> `String p) contacts));
       ]
 
+  (** JSON body for [app.bsky.contact.dismissMatch]. *)
   let dismiss_match_body ~subject : Yojson.Safe.t =
     `Assoc [ ("subject", `String subject) ]
 
+  (** JSON body for [app.bsky.contact.startPhoneVerification]. *)
   let start_phone_verification_body ~phone : Yojson.Safe.t =
     `Assoc [ ("phone", `String phone) ]
 
+  (** JSON body for [app.bsky.contact.verifyPhone]. *)
   let verify_phone_body ~phone ~code : Yojson.Safe.t =
     `Assoc [ ("phone", `String phone); ("code", `String code) ]
 
+  (** JSON body for [app.bsky.contact.sendNotification]. *)
   let send_notification_body ~from ~to_ : Yojson.Safe.t =
     `Assoc [ ("from", `String from); ("to", `String to_) ]
 
@@ -75,6 +81,7 @@ module Contact = struct
       (Client.opt_int "limit" limit @ Client.opt_pair "cursor" cursor)
     |> parse_matches_page
 
+  (** Contact import status via [app.bsky.contact.getSyncStatus]. *)
   let get_sync_status (s : Session.session) : sync_status_opt =
     Client.get_json ~session:s "app.bsky.contact.getSyncStatus" []
     |> parse_sync_status_opt
@@ -87,24 +94,30 @@ module Contact = struct
       (Yojson.Safe.to_string (import_contacts_body ~token ~contacts))
     |> parse_import_result
 
+  (** Dismiss match [subject] via [app.bsky.contact.dismissMatch]. *)
   let dismiss_match (s : Session.session) ~subject () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.contact.dismissMatch"
          (Yojson.Safe.to_string (dismiss_match_body ~subject)))
 
+  (** Remove stored hashes and matches via [app.bsky.contact.removeData]. *)
   let remove_data (s : Session.session) : unit =
     ignore (Client.post_json ~session:s "app.bsky.contact.removeData" "{}")
 
+  (** Start SMS verification via [app.bsky.contact.startPhoneVerification]. *)
   let start_phone_verification (s : Session.session) ~phone () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.contact.startPhoneVerification"
          (Yojson.Safe.to_string (start_phone_verification_body ~phone)))
 
+  (** Verify [phone] / [code] via [app.bsky.contact.verifyPhone]
+      (returns [token] for [import_contacts]). *)
   let verify_phone (s : Session.session) ~phone ~code () : string =
     Client.post_json ~session:s "app.bsky.contact.verifyPhone"
       (Yojson.Safe.to_string (verify_phone_body ~phone ~code))
     |> fun json -> Client.string_member json "token"
 
+  (** Contact-import notification via [app.bsky.contact.sendNotification]. *)
   let send_notification (s : Session.session) ~from ~to_ () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.contact.sendNotification"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Contact` XRPC wrappers and their matching `*_body` helpers in `src/bsky/contact.ml`. Matches existing Contact tone (`get_matches` / `import_contacts`) and #144 Feed remaining-wrapper style.

Branched from current `main` (`b57bc88c` after [#150](https://github.com/david-engelmann/atproto/pull/150) admin hops). Touches **only** `src/bsky/contact.ml`. Did not touch `CHANGELOG.md`, `README.md`, tests, or other src files (sibling PRs own those).

Already documented (skipped): `get_matches`, `import_contacts`.

Documented in this PR:

- `get_sync_status`
- `dismiss_match` / `dismiss_match_body`
- `remove_data`
- `start_phone_verification` / `start_phone_verification_body`
- `verify_phone` / `verify_phone_body`
- `send_notification` / `send_notification_body`
- `import_contacts_body` (ships with the already-documented wrapper)

Short comments with NSID names in `[brackets]`. Did not restyle logic. Did not document `parse_*` internals. Did **not** add live TestNetwork hops for `app.bsky.contact.*` — phone/contacts stay listed not faked (no hosted contacts service in TestNetwork). Hosted-only chat/video/Tap/opam stay listed not faked. No empty leftover-field PR.

Local check: every public wrapper/`*_body` has function-level odoc immediately above it; `parse_*` stay undocumented; diff is `src/bsky/contact.ml` only.

Body helpers:

[Contact *_body helpers with function-level odoc](https://cursor.com/agents/bc-2d8848dc-55ee-468a-8294-4e0278595ef5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_body_helpers_odoc.webp)

Wrappers (`get_sync_status` through `dismiss_match`):

[Contact wrappers get_sync_status import_contacts dismiss_match odoc](https://cursor.com/agents/bc-2d8848dc-55ee-468a-8294-4e0278595ef5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_wrappers_get_sync_status.webp)

Wrappers (`remove_data` through `send_notification`):

[Contact wrappers remove_data verify_phone send_notification odoc](https://cursor.com/agents/bc-2d8848dc-55ee-468a-8294-4e0278595ef5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_wrappers_remaining.webp)

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Contact header unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (sibling PR owns CHANGELOG / remaining-gaps)

Fixes # (issue)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d8848dc-55ee-468a-8294-4e0278595ef5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d8848dc-55ee-468a-8294-4e0278595ef5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

