### PR TITLE
Add remaining function-level odoc on Site record builders

### DIFF
--- a/src/bsky/site.ml
+++ b/src/bsky/site.ml
@@ -3,12 +3,25 @@ open Label
 
 (** Typed builders and parsers for official `site.standard.*` records. *)
 module Site = struct
+  (** NSID for [site.standard.document]. *)
   let nsid_document = "site.standard.document"
+
+  (** NSID for [site.standard.publication]. *)
   let nsid_publication = "site.standard.publication"
+
+  (** NSID for [site.standard.graph.recommend]. *)
   let nsid_recommend = "site.standard.graph.recommend"
+
+  (** NSID for [site.standard.graph.subscription]. *)
   let nsid_subscription = "site.standard.graph.subscription"
+
+  (** NSID for [site.standard.theme.basic]. *)
   let nsid_theme_basic = "site.standard.theme.basic"
+
+  (** NSID for [site.standard.theme.color#rgb]. *)
   let nsid_theme_color_rgb = "site.standard.theme.color#rgb"
+
+  (** NSID for [site.standard.theme.color#rgba]. *)
   let nsid_theme_color_rgba = "site.standard.theme.color#rgba"
 
   type contributor = {
@@ -82,9 +95,12 @@ module Site = struct
   let list_member json field =
     match Yojson.Safe.Util.member field json with `List xs -> xs | _ -> []
 
+  (** Build a document [contributor] ([did] / optional [display_name] /
+      [role]). *)
   let contributor ~did ?display_name ?role () : contributor =
     { did; display_name; role }
 
+  (** JSON object for [contributor] ([did], [displayName], [role]). *)
   let contributor_to_json (c : contributor) : Yojson.Safe.t =
     let fields =
       ("did", `String c.did)
@@ -103,9 +119,16 @@ module Site = struct
       role = string_opt json "role";
     }
 
+  (** Build an RGB color ([r] / [g] / [b]) for
+      [site.standard.theme.color#rgb]. *)
   let rgb ~r ~g ~b : rgb = { r; g; b }
+
+  (** Build an RGBA color ([r] / [g] / [b] / [a]) for
+      [site.standard.theme.color#rgba]. *)
   let rgba ~r ~g ~b ~a : rgba = { r; g; b; a }
 
+  (** JSON object for a theme color ([site.standard.theme.color#rgb] or
+      [#rgba]). *)
   let color_to_json (c : color) : Yojson.Safe.t =
     match c with
     | `Rgb c ->
@@ -171,9 +194,12 @@ module Site = struct
               }
         | _ -> `Unknown json)
 
+  (** Build a [site.standard.theme.basic] color set ([background] /
+      [foreground] / [accent] / [accent_foreground]). *)
   let theme ~background ~foreground ~accent ~accent_foreground : theme =
     { background; foreground; accent; accent_foreground }
 
+  (** JSON object for [site.standard.theme.basic]. *)
   let theme_to_json (t : theme) : Yojson.Safe.t =
     `Assoc
       [
@@ -193,6 +219,9 @@ module Site = struct
         parse_color (Yojson.Safe.Util.member "accentForeground" json);
     }
 
+  (** Build a [site.standard.theme.basic] record. [background],
+      [foreground], [accent], and [accent_foreground] map to the
+      lexicon. *)
   let theme_basic ~background ~foreground ~accent ~accent_foreground () :
       Yojson.Safe.t =
     theme_to_json (theme ~background ~foreground ~accent ~accent_foreground)
@@ -274,6 +303,9 @@ module Site = struct
         | j -> Some j);
     }
 
+  (** Build a [site.standard.publication] record. [url] and [name] are
+      required; optional [description] / [icon] / [self_labels] /
+      [basic_theme] / [show_in_discover] map to the lexicon. *)
   let publication ~url ~name ?description ?icon ?self_labels ?basic_theme
       ?show_in_discover () : Yojson.Safe.t =
     let fields =
@@ -322,6 +354,8 @@ module Site = struct
         | _ -> None);
     }
 
+  (** Build a [site.standard.graph.recommend] record for [document]
+      (AT-URI). [created_at] is required. *)
   let recommend ~document ~created_at () : Yojson.Safe.t =
     `Assoc
       [
@@ -336,6 +370,9 @@ module Site = struct
       created_at = string_member json "createdAt";
     }
 
+  (** Build a [site.standard.graph.subscription] record for
+      [publication] (AT-URI). Optional [created_at] maps to the
+      lexicon. *)
   let subscription ~publication ?created_at () : Yojson.Safe.t =
     let fields =
       [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Site` record builders in `src/bsky/site.ml` that still lacked a function-level comment immediately above the `let`. Matches existing `document` / Records / Germnetwork tone. These are local `site.standard.*` record builders, not a hosted site service.

Started from current `main` (`aaa4471` after [#152](https://github.com/david-engelmann/atproto/pull/152)–[#155](https://github.com/david-engelmann/atproto/pull/155)). Touched only `src/bsky/site.ml`. Did not touch CHANGELOG.md, README.md, tests, or other src files.

Already documented (skipped): `document`.

Documented in this PR:

- `nsid_document`, `nsid_publication`, `nsid_recommend`, `nsid_subscription`
- `nsid_theme_basic`, `nsid_theme_color_rgb`, `nsid_theme_color_rgba`
- `contributor` / `contributor_to_json`
- `rgb` / `rgba` / `color_to_json`
- `theme` / `theme_to_json` / `theme_basic`
- `publication`, `recommend`, `subscription`

Did not restyle logic. Did not document `parse_*` internals. Did not rewrite the existing `document` comment.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Site header unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (left unchanged; this PR is comment-only on `src/bsky/site.ml` only)

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a0cfb06-9e95-4591-b372-18725767c669?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a0cfb06-9e95-4591-b372-18725767c669&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

