### PR TITLE
Add remaining function-level odoc on public Draft helpers

### DIFF
--- a/src/bsky/draft.ml
+++ b/src/bsky/draft.ml
@@ -190,6 +190,8 @@ module Draft = struct
   let caption_json (c : caption) : Yojson.Safe.t =
     `Assoc [ ("lang", `String c.lang); ("content", `String c.content) ]
 
+  (** Build an [app.bsky.draft.defs#draftEmbedImage] object ([localRef] plus
+      optional [alt]). *)
   let embed_image_json (i : embed_image) : Yojson.Safe.t =
     let fields =
       ("localRef", local_ref_json i.local_ref)
@@ -197,6 +199,8 @@ module Draft = struct
     in
     `Assoc fields
 
+  (** Build an [app.bsky.draft.defs#draftEmbedVideo] object ([localRef] plus
+      optional [alt] / [captions]). *)
   let embed_video_json (v : embed_video) : Yojson.Safe.t =
     let fields =
       [ ("localRef", local_ref_json v.local_ref) ]
@@ -230,6 +234,8 @@ module Draft = struct
         `Assoc [ ("$type", `String "app.bsky.feed.postgate#disableRule") ]
     | `Unknown j -> j
 
+  (** Build an [app.bsky.draft.defs#draftPost] object ([text] plus optional
+      embed-image / gallery / video / external / record fields). *)
   let draft_post_json (p : draft_post) : Yojson.Safe.t =
     let fields =
       [ ("text", `String p.text) ]
@@ -279,6 +285,9 @@ module Draft = struct
     in
     `Assoc fields
 
+  (** Build an [app.bsky.draft.defs#draft] object. [posts] is required;
+      optional [device_id] / [device_name] / [langs] /
+      [postgate_embedding_rules] / [threadgate_allow] map to the lexicon. *)
   let draft_json ?(device_id : string option) ?(device_name : string option)
       ?(langs = []) ?(postgate_embedding_rules = []) ?(threadgate_allow = [])
       ~posts () : Yojson.Safe.t =
@@ -306,11 +315,14 @@ module Draft = struct
     in
     `Assoc fields
 
+  (** JSON body for [app.bsky.draft.createDraft]. *)
   let create_draft_body draft : Yojson.Safe.t = `Assoc [ ("draft", draft) ]
 
+  (** JSON body for [app.bsky.draft.updateDraft]. [id] is the draft TID. *)
   let update_draft_body ~id draft : Yojson.Safe.t =
     `Assoc [ ("draft", `Assoc [ ("id", `String id); ("draft", draft) ]) ]
 
+  (** JSON body for [app.bsky.draft.deleteDraft]. [id] is the draft TID. *)
   let delete_draft_body ~id : Yojson.Safe.t = `Assoc [ ("id", `String id) ]
 
   (** Private stash drafts via [app.bsky.draft.getDrafts]. *)
@@ -325,11 +337,13 @@ module Draft = struct
       (Yojson.Safe.to_string (create_draft_body draft))
     |> fun json -> { id = Client.string_member json "id" }
 
+  (** Update a stash draft via [app.bsky.draft.updateDraft]. *)
   let update_draft (s : Session.session) ~id draft : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.draft.updateDraft"
          (Yojson.Safe.to_string (update_draft_body ~id draft)))
 
+  (** Delete a stash draft via [app.bsky.draft.deleteDraft]. *)
   let delete_draft (s : Session.session) ~id () : unit =
     ignore
       (Client.post_json ~session:s "app.bsky.draft.deleteDraft"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Draft` helpers in `src/bsky/draft.ml` that still lacked a function-level comment immediately above the `let`. Matches existing Draft tone (`get_drafts` / `create_draft`) and #149 Label / #151 Chat remaining-helper style.

Branched from current `main` (`aaa4471` after [#155](https://github.com/david-engelmann/atproto/pull/155)). Touches **only** `src/bsky/draft.ml`. CHANGELOG.md, README.md, tests, and other `src` files are left to sibling PRs ([#156](https://github.com/david-engelmann/atproto/pull/156) Contact / [#157](https://github.com/david-engelmann/atproto/pull/157) Video).

Already documented (left unchanged): `get_drafts`, `create_draft`.

Documented in this PR:

- `update_draft` / `delete_draft`
- `draft_json` / `draft_post_json`
- `embed_image_json` / `embed_video_json`
- `create_draft_body` / `update_draft_body` / `delete_draft_body`

Short comments with NSID names in `[brackets]`. Did not restyle logic. Did not document `parse_*` internals. Did **not** add live TestNetwork hops for extra `app.bsky.draft.*` coverage — AppView draft create/get/update/delete is already hop-covered. Hosted-only chat / video / Tap / phone / contacts / opam-repository stay listed, not faked.

Local check: `ocamlc -stop-after parsing` on `src/bsky/draft.ml` succeeds (OCaml 4.14.1). A line-by-line scan found `(** *)` immediately above all 11 listed public entry points (9 new + the two already documented). `parse_*` internals remain undocumented. Diff is comment-only (`+14` / `-0`).

[Draft odoc on update_draft, delete_draft, and *_draft_body helpers](https://cursor.com/agents/bc-f74537e9-fc54-46ab-b18a-0d1156cc6d67/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraft_odoc_update_delete_and_bodies.webp)
[Draft odoc on embed-json and draft_json / draft_post_json builders](https://cursor.com/agents/bc-f74537e9-fc54-46ab-b18a-0d1156cc6d67/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdraft_odoc_embed_and_builders.webp)

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Draft header unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (sibling PRs own CHANGELOG / README)

Fixes # (issue)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f74537e9-fc54-46ab-b18a-0d1156cc6d67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f74537e9-fc54-46ab-b18a-0d1156cc6d67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

