### PR TITLE
Add remaining function-level odoc on Ozone constructors

### DIFF
--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -1376,6 +1376,7 @@ module Ozone = struct
 
   (* Official addRule / updateRule / removeRule take `pattern` (not
      patternType) and return tools.ozone.safelink.defs#event. *)
+
   (** JSON body for [tools.ozone.safelink.addRule]. *)
   let add_safelink_rule_body ~url ~pattern ~action ~reason ?comment ?created_by
       () : Yojson.Safe.t =

--- a/src/ozone.ml
+++ b/src/ozone.ml
@@ -526,12 +526,14 @@ module Ozone = struct
       original = json;
     }
 
+  (** [com.atproto.admin.defs#repoRef] subject ([did]). *)
   let repo_ref did : Yojson.Safe.t =
     `Assoc
       [
         ("$type", `String "com.atproto.admin.defs#repoRef"); ("did", `String did);
       ]
 
+  (** [com.atproto.repo.strongRef] subject ([uri] / [cid]). *)
   let strong_ref ~uri ~cid : Yojson.Safe.t =
     `Assoc
       [
@@ -540,6 +542,8 @@ module Ozone = struct
         ("cid", `String cid);
       ]
 
+  (** [tools.ozone.moderation.emitEvent#reportAction] payload ([ids] /
+      [types] / [all] / [note]). *)
   let report_action ?ids ?(types = []) ?all ?note () : Yojson.Safe.t =
     `Assoc
       ((match ids with
@@ -551,6 +555,7 @@ module Ozone = struct
       @ (match all with Some b -> [ ("all", `Bool b) ] | None -> [])
       @ match note with Some n -> [ ("note", `String n) ] | None -> [])
 
+  (** JSON body for [tools.ozone.moderation.emitEvent]. *)
   let emit_event_body ~event ~subject ~created_by ?subject_blob_cids
       ?external_id ?mod_tool ?report_action () : Yojson.Safe.t =
     let fields =
@@ -570,6 +575,8 @@ module Ozone = struct
     in
     `Assoc fields
 
+  (** [tools.ozone.moderation.defs#modEventComment] event. Optional
+      [sticky]. *)
   let comment_event ?(sticky = false) comment : Yojson.Safe.t =
     `Assoc
       [
@@ -578,6 +585,7 @@ module Ozone = struct
         ("sticky", `Bool sticky);
       ]
 
+  (** [tools.ozone.moderation.defs#modEventAcknowledge] event. *)
   let acknowledge_event ?comment () : Yojson.Safe.t =
     let fields =
       [ ("$type", `String "tools.ozone.moderation.defs#modEventAcknowledge") ]
@@ -585,6 +593,7 @@ module Ozone = struct
     in
     `Assoc fields
 
+  (** [tools.ozone.moderation.defs#modEventTakedown] event. *)
   let takedown_event ?comment ?(acknowledge_account_subjects = false) () :
       Yojson.Safe.t =
     let fields =
@@ -902,6 +911,7 @@ module Ozone = struct
       | Some s -> [ ("executeUntil", `String s) ]
       | None -> [])
 
+  (** [tools.ozone.moderation.scheduleAction#takedown] action. *)
   let takedown_action ?comment ?duration_in_hours
       ?(acknowledge_account_subjects = false) () : Yojson.Safe.t =
     let fields =
@@ -917,6 +927,7 @@ module Ozone = struct
     in
     `Assoc fields
 
+  (** JSON body for [tools.ozone.moderation.scheduleAction]. *)
   let schedule_action_body ~action ~subjects ~created_by ~scheduling ?mod_tool
       () : Yojson.Safe.t =
     let fields =
@@ -1016,6 +1027,7 @@ module Ozone = struct
       "tools.ozone.communication.listTemplates" []
     |> parse_templates
 
+  (** JSON body for [tools.ozone.communication.createTemplate]. *)
   let create_template_body ~name ~content_markdown ?subject ?lang ?created_by ()
       : Yojson.Safe.t =
     `Assoc
@@ -1364,6 +1376,7 @@ module Ozone = struct
 
   (* Official addRule / updateRule / removeRule take `pattern` (not
      patternType) and return tools.ozone.safelink.defs#event. *)
+  (** JSON body for [tools.ozone.safelink.addRule]. *)
   let add_safelink_rule_body ~url ~pattern ~action ~reason ?comment ?created_by
       () : Yojson.Safe.t =
     `Assoc
@@ -1378,10 +1391,12 @@ module Ozone = struct
       | Some d -> [ ("createdBy", `String d) ]
       | None -> [])
 
+  (** JSON body for [tools.ozone.safelink.updateRule]. *)
   let update_safelink_rule_body ~url ~pattern ~action ~reason ?comment
       ?created_by () : Yojson.Safe.t =
     add_safelink_rule_body ~url ~pattern ~action ~reason ?comment ?created_by ()
 
+  (** JSON body for [tools.ozone.safelink.removeRule]. *)
   let remove_safelink_rule_body ~url ~pattern ?comment ?created_by () :
       Yojson.Safe.t =
     `Assoc
@@ -1464,6 +1479,7 @@ module Ozone = struct
          (remove_safelink_rule_body ~url ~pattern ?comment ?created_by ()))
     |> parse_safelink_event
 
+  (** JSON body for [tools.ozone.safelink.queryEvents]. *)
   let query_safelink_events_body ?cursor ?limit ?(urls = []) ?pattern_type
       ?sort_direction () : Yojson.Safe.t =
     `Assoc
@@ -1630,6 +1646,8 @@ module Ozone = struct
           (Client.list_member json "failedRevocations");
     }
 
+  (** [tools.ozone.verification.grantVerifications#verificationInput]
+      item ([subject] / [handle] / [display_name]). *)
   let verification_input ~subject ~handle ~display_name ?created_at () :
       Yojson.Safe.t =
     `Assoc
@@ -1641,9 +1659,11 @@ module Ozone = struct
       | Some t -> [ ("createdAt", `String t) ]
       | None -> []))
 
+  (** JSON body for [tools.ozone.verification.grantVerifications]. *)
   let grant_verifications_body ~verifications () : Yojson.Safe.t =
     `Assoc [ ("verifications", `List verifications) ]
 
+  (** JSON body for [tools.ozone.verification.revokeVerifications]. *)
   let revoke_verifications_body ~uris ?revoke_reason () : Yojson.Safe.t =
     `Assoc
       (("uris", `List (List.map (fun u -> `String u) uris))
@@ -1865,6 +1885,7 @@ module Ozone = struct
       unmatched = Client.int_member json "unmatched";
     }
 
+  (** JSON body for [tools.ozone.queue.createQueue]. *)
   let create_queue_body ~name ?(subject_types = []) ?collection
       ?(report_types = []) ?description ?(recommended_policies = []) () :
       Yojson.Safe.t =
@@ -1884,6 +1905,7 @@ module Ozone = struct
       | [] -> []
       | xs -> [ ("recommendedPolicies", json_strings xs) ])
 
+  (** JSON body for [tools.ozone.queue.updateQueue]. *)
   let update_queue_body ~queue_id ?name ?enabled ?description
       ?recommended_policies () : Yojson.Safe.t =
     `Assoc
@@ -1895,6 +1917,7 @@ module Ozone = struct
       | Some xs -> [ ("recommendedPolicies", json_strings xs) ]
       | None -> [])
 
+  (** JSON body for [tools.ozone.queue.deleteQueue]. *)
   let delete_queue_body ~queue_id ?migrate_to_queue_id () : Yojson.Safe.t =
     `Assoc
       (("queueId", `Int queue_id)
@@ -2058,10 +2081,19 @@ module Ozone = struct
   type historical_stats = { cursor : string option; stats : report_stats list }
   type close_reports_result = { closed_count : int; report_ids : int list }
 
+  (** Prefix [name] as [tools.ozone.report.defs#name]. *)
   let report_reason name = "tools.ozone.report.defs#" ^ name
+
+  (** [tools.ozone.report.defs#reasonAppeal] report reason. *)
   let reason_appeal = report_reason "reasonAppeal"
+
+  (** [tools.ozone.report.defs#reasonOther] report reason. *)
   let reason_other = report_reason "reasonOther"
+
+  (** [tools.ozone.report.defs#reasonViolenceThreats] report reason. *)
   let reason_violence_threats = report_reason "reasonViolenceThreats"
+
+  (** [tools.ozone.report.defs#reasonMisleadingSpam] report reason. *)
   let reason_misleading_spam = report_reason "reasonMisleadingSpam"
 
   let parse_report_activity json : report_activity =
@@ -2190,23 +2222,30 @@ module Ozone = struct
       (("$type", `String ("tools.ozone.report.defs#" ^ kind))
       :: opt_json_str "previousStatus" previous_status)
 
+  (** [tools.ozone.report.defs#queueActivity] activity. *)
   let queue_activity ?previous_status () =
     activity_json "queueActivity" ?previous_status ()
 
+  (** [tools.ozone.report.defs#assignmentActivity] activity. *)
   let assignment_activity ?previous_status () =
     activity_json "assignmentActivity" ?previous_status ()
 
+  (** [tools.ozone.report.defs#escalationActivity] activity. *)
   let escalation_activity ?previous_status () =
     activity_json "escalationActivity" ?previous_status ()
 
+  (** [tools.ozone.report.defs#closeActivity] activity. *)
   let close_activity ?previous_status () =
     activity_json "closeActivity" ?previous_status ()
 
+  (** [tools.ozone.report.defs#reopenActivity] activity. *)
   let reopen_activity ?previous_status () =
     activity_json "reopenActivity" ?previous_status ()
 
+  (** [tools.ozone.report.defs#noteActivity] activity. *)
   let note_activity () = activity_json "noteActivity" ()
 
+  (** JSON body for [tools.ozone.report.createActivity]. *)
   let create_activity_body ~activity ?report_id ?event_id ?internal_note
       ?public_note ?is_automated () : Yojson.Safe.t =
     `Assoc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public Ozone constructors in `src/ozone.ml` that still lacked a function-level comment immediately above the `let`. XRPC wrappers were already documented in [#128](https://github.com/david-engelmann/atproto/pull/128); this PR is leftover constructors, not a body-only leftover-field pass on admin/server helpers.

Started from current `main` after [#152](https://github.com/david-engelmann/atproto/pull/152)–[#155](https://github.com/david-engelmann/atproto/pull/155) (`aaa4471`). Touches only `src/ozone.ml`. CHANGELOG / README / remaining-gaps stay on main for a later pointer PR (same split as leftover-odoc vs [#155](https://github.com/david-engelmann/atproto/pull/155)).

Already documented (skipped): `tools.ozone.*` XRPC wrappers, `parse_*` internals, `labeler_proxy` / `proxy_headers`.

Documented in this PR:

- `repo_ref` / `strong_ref`
- `report_action` / `emit_event_body`
- `comment_event` / `acknowledge_event` / `takedown_event`
- `takedown_action` / `schedule_action_body`
- `create_template_body`
- safelink `add_safelink_rule_body` / `update_safelink_rule_body` / `remove_safelink_rule_body` / `query_safelink_events_body`
- `verification_input` / `grant_verifications_body` / `revoke_verifications_body`
- `create_queue_body` / `update_queue_body` / `delete_queue_body`
- `report_reason` / `reason_appeal` / `reason_other` / `reason_violence_threats` / `reason_misleading_spam`
- `queue_activity` / `assignment_activity` / `escalation_activity` / `close_activity` / `reopen_activity` / `note_activity`
- `create_activity_body`

One or two sentences with NSID / `#def` names in `[brackets]`. Did not restyle logic. Did not add live hops. Did not invent a hosted ozone store. Hosted-only video / chat / Tap and opam-repository stay listed, not faked.

Each listed constructor has `(** *)` immediately above the `let`. `(*` / `*)` comments in `src/ozone.ml` are balanced. Follow-up commit adds the blank line ocamlformat requires between the existing safelink `(* pattern *)` note and `add_safelink_rule_body` odoc (`lint-fmt` on `e253260`).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Ozone header unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (intentionally left for a pointer PR; this change is comment-only on `src/ozone.ml`)

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a7ac32e-5265-47e7-a4b9-46b9d7edd501?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a7ac32e-5265-47e7-a4b9-46b9d7edd501&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

