### PR TITLE
Add remaining function-level odoc on public Ageassurance helpers

### DIFF
--- a/src/bsky/ageassurance.ml
+++ b/src/bsky/ageassurance.ml
@@ -130,6 +130,7 @@ module Ageassurance = struct
       original = json;
     }
 
+  (** JSON body for [app.bsky.ageassurance.begin]. *)
   let begin_body ~email ~language ~country_code ?region_code () : Yojson.Safe.t
       =
     let fields =
@@ -145,6 +146,8 @@ module Ageassurance = struct
     in
     `Assoc fields
 
+  (** Age-assurance config via [app.bsky.ageassurance.getConfig]. Works
+      without a session against public AppView. *)
   let get_config ?session ?host () : config =
     Client.get_json ?session ?host "app.bsky.ageassurance.getConfig" []
     |> parse_config


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** *)` odoc on remaining public `Ageassurance` helpers in `src/bsky/ageassurance.ml` that still lacked a function-level comment immediately above the `let`. Matches existing Ageassurance tone (`get_state` / `begin_assurance`) and #156 Contact / #159 Draft remaining-helper style.

Branched from current `main` (`1356152` after [#160](https://github.com/david-engelmann/atproto/pull/160) Ozone constructors). Touches **only** `src/bsky/ageassurance.ml`. CHANGELOG.md, README.md, tests, and other `src` files are left to a sibling docs PR.

Already documented (left unchanged): `get_state`, `begin_assurance`.

Documented in this PR:

- `begin_body`
- `get_config`

Short comments with NSID names in `[brackets]`. Did not restyle logic. Did not document `parse_*` internals or helpers like `ends_with` / `string_list`. Did **not** add live TestNetwork hops for extra `app.bsky.ageassurance.*` coverage — dedicated getConfig / getState / begin hops already exist in `test_local_appview.ml`. Hosted-only chat / video / Tap / phone stay listed, not faked.

Each listed public entry point has `(** *)` immediately above the `let`. Diff is comment-only (`+3` / `-0`) on `src/bsky/ageassurance.ml` only.

[Ageassurance public helpers with function-level odoc](https://cursor.com/agents/bc-13399f67-e3aa-4aad-8484-c4d0394b34be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fageassurance_public_helpers_odoc.webp)

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (no new modules; existing Ageassurance header unchanged)
- [ ] User-facing change is noted in CHANGELOG.md (sibling PR owns CHANGELOG / README)

Fixes # (issue)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13399f67-e3aa-4aad-8484-c4d0394b34be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13399f67-e3aa-4aad-8484-c4d0394b34be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

