### PR TITLE
Live TestNetwork hops for remaining com.atproto.temp operator NSIDs

### DIFF
--- a/test/test_local_pds.ml
+++ b/test/test_local_pds.ml
@@ -1238,7 +1238,8 @@ let test_leftover_temp _ =
     failwith "refusing addReservedHandle on alice.test";
   ignore
     (admin_leftover_post admin "com.atproto.temp.addReservedHandle"
-       (Yojson.Safe.to_string (Temp.add_reserved_handle_body ~handle:reserved ())));
+       (Yojson.Safe.to_string
+          (Temp.add_reserved_handle_body ~handle:reserved ())));
   let doomed = throwaway_session "rvk" "local-temp-revoke-password" in
   if doomed.username = "alice.test" || doomed.auth.did = alice.auth.did then
     failwith "refusing leftover temp hops on alice.test";

--- a/test/test_local_pds.ml
+++ b/test/test_local_pds.ml
@@ -1218,6 +1218,37 @@ let test_leftover_server _ =
              (Server.reset_password_body ~token:"not-an-email-token"
                 ~password:"local-server-reset-password"))))
 
+(* Remaining com.atproto.temp operator NSIDs whose wrappers already
+   exist and are not already live-called. checkHandleAvailability /
+   dereferenceScope / checkSignupQueue are already hopped;
+   fetchLabels is a coverage-skip. Reuse admin_leftover_post /
+   admin_basic_extra / is_admin_policy_invalid (session JWT may not
+   be an operator token). Skip if not served / MethodNotImplemented /
+   InvalidToken / policy. addReservedHandle uses a unique throwaway
+   handle prefix, never alice.test. revokeAccountCredentials is
+   destructive and uses a throwaway account only, never alice.test.
+   requestPhoneVerification stays listed (no hosted phone in
+   TestNetwork) and is not faked. Does not invent an operator panel.
+   PDS 0.5.x TestNetwork may 501 these; skip is correct. *)
+let test_leftover_temp _ =
+  let admin = admin_session () in
+  let alice = session () in
+  let reserved = unique_handle "rsvh" in
+  if reserved = "alice.test" then
+    failwith "refusing addReservedHandle on alice.test";
+  ignore
+    (admin_leftover_post admin "com.atproto.temp.addReservedHandle"
+       (Yojson.Safe.to_string (Temp.add_reserved_handle_body ~handle:reserved ())));
+  let doomed = throwaway_session "rvk" "local-temp-revoke-password" in
+  if doomed.username = "alice.test" || doomed.auth.did = alice.auth.did then
+    failwith "refusing leftover temp hops on alice.test";
+  if doomed.username = "alice.test" then
+    failwith "refusing revokeAccountCredentials on alice.test";
+  ignore
+    (admin_leftover_post admin "com.atproto.temp.revokeAccountCredentials"
+       (Yojson.Safe.to_string
+          (Temp.revoke_account_credentials_body ~account:doomed.auth.did ())))
+
 let suite =
   "local_pds"
   >::: [
@@ -1246,6 +1277,7 @@ let suite =
          "test_leftover_served" >:: test_leftover_served;
          "test_leftover_admin" >:: test_leftover_admin;
          "test_leftover_server" >:: test_leftover_server;
+         "test_leftover_temp" >:: test_leftover_temp;
        ]
 
 let () =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds skip-if-not-served live TestNetwork hops for remaining `com.atproto.temp` operator wrappers that already exist on main (`src/temp.ml`) and were not live-called after leftover admin/server hops.

Targets current `main` at `d10c5a0e` ([#161](https://github.com/david-engelmann/atproto/pull/161)).

- Touches **only** `test/test_local_pds.ml` (no CHANGELOG / README / `src/` / other tests)
- Does **not** reopen or duplicate already-live `checkHandleAvailability` / `dereferenceScope` / `checkSignupQueue`, or coverage-skip `fetchLabels`
- `addReservedHandle` reuses `admin_leftover_post` / `admin_basic_extra` / `is_admin_policy_invalid` when the session JWT is not an operator token. Unique throwaway handle prefix (`rsvh`), never `alice.test`
- `revokeAccountCredentials` is destructive: throwaway account only (`rvk`), never `alice.test`. Skip InvalidToken / not-implemented / policy via `admin_leftover_post`
- `requestPhoneVerification` stays listed (no hosted phone in TestNetwork) and is **not** faked

PDS 0.5.x TestNetwork may 501 these NSIDs; skip is correct. Does not invent an operator panel.

### NSIDs hopped
- `com.atproto.temp.addReservedHandle`
- `com.atproto.temp.revokeAccountCredentials`

Stay listed not faked: `com.atproto.temp.requestPhoneVerification`.

Already live, not redone: `com.atproto.temp.checkHandleAvailability`, `com.atproto.temp.dereferenceScope`, `com.atproto.temp.checkSignupQueue`, `com.atproto.temp.fetchLabels` (coverage-skip).

Does **not** invent OSS chat, a video transcoder, Tap, phone/contacts verify, push, leftover-field restyles, or an opam-repository publish. Does not invent an operator panel.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md (n/a — test-only leftover hops; CHANGELOG left on main)

Fixes # (n/a — leftover live coverage after #129 / #150 / #152)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b4ae6f6-8005-4a2d-beb9-aa8b8a5bc1c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b4ae6f6-8005-4a2d-beb9-aa8b8a5bc1c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

