### PR TITLE
Live TestNetwork hop for leftover AppView getFeedSkeleton

### DIFF
--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -1047,20 +1047,20 @@ let test_leftover_served _ =
      TestNetwork services. Unhosted generator DID is already skip-policy
      (av_get_until_or_skip / is_policy_invalid). *)
   (match generator_info with
-  | Some info when info.is_online ->
+  | Some info when info.is_online -> (
       (match av_get_feed_if_hosted generated.uri with
       | None -> ()
       | Some json ->
           let page = Feed.parse_timeline json in
           OUnit2.assert_bool "getFeed" (List.length page.feed >= 0));
-      (match
-         av_get_leftover "app.bsky.feed.getFeedSkeleton"
-           [ ("feed", generated.uri); ("limit", "5") ]
-       with
-       | None -> ()
-       | Some json ->
-           let page = Feed.parse_feed_skeleton json in
-           OUnit2.assert_bool "getFeedSkeleton" (List.length page.feed >= 0))
+      match
+        av_get_leftover "app.bsky.feed.getFeedSkeleton"
+          [ ("feed", generated.uri); ("limit", "5") ]
+      with
+      | None -> ()
+      | Some json ->
+          let page = Feed.parse_feed_skeleton json in
+          OUnit2.assert_bool "getFeedSkeleton" (List.length page.feed >= 0))
   | _ -> ());
   let bob = bob_session () in
   (match

--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -1042,15 +1042,25 @@ let test_leftover_served _ =
         OUnit2.assert_equal ~printer:(fun x -> x) generated.uri info.view.uri;
         Some info
   in
-  (* getFeed only against OUR generator, and only if AppView marked it
-     online. Suggested feeds are not live TestNetwork services. *)
+  (* getFeed / getFeedSkeleton only against OUR leftover generator, and
+     only if AppView marked it online. Suggested feeds are not live
+     TestNetwork services. Unhosted generator DID is already skip-policy
+     (av_get_until_or_skip / is_policy_invalid). *)
   (match generator_info with
-  | Some info when info.is_online -> (
-      match av_get_feed_if_hosted generated.uri with
+  | Some info when info.is_online ->
+      (match av_get_feed_if_hosted generated.uri with
       | None -> ()
       | Some json ->
           let page = Feed.parse_timeline json in
-          OUnit2.assert_bool "getFeed" (List.length page.feed >= 0))
+          OUnit2.assert_bool "getFeed" (List.length page.feed >= 0));
+      (match
+         av_get_leftover "app.bsky.feed.getFeedSkeleton"
+           [ ("feed", generated.uri); ("limit", "5") ]
+       with
+       | None -> ()
+       | Some json ->
+           let page = Feed.parse_feed_skeleton json in
+           OUnit2.assert_bool "getFeedSkeleton" (List.length page.feed >= 0))
   | _ -> ());
   let bob = bob_session () in
   (match
@@ -1239,9 +1249,10 @@ let test_unspecced_and_ageassurance _ =
 (* Unique leftover AppView NSIDs whose wrappers exist on main and are
    not live above. Skip if this revision 501s the method or TestNetwork
    policy InvalidRequest (is_policy_invalid). chat.bsky.* / video.* /
-   Tap / contact.* / push register-unregister / unhosted getFeed stay
-   listed not faked. describeFeedGenerator is a feed-generator service
-   method — do not treat a skip as a hosted generator. *)
+   Tap / contact.* / push register-unregister / unhosted getFeed /
+   getFeedSkeleton stay listed not faked. describeFeedGenerator is a
+   feed-generator service method — do not treat a skip as a hosted
+   generator. *)
 let test_leftover_feed_notification _ =
   let s = session () in
   (match


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a skip-if-not-served live TestNetwork hop for leftover AppView NSID `app.bsky.feed.getFeedSkeleton`. Wrapper `Feed.get_feed_skeleton` / `get_feed_skeleton_parsed` already exists on `main` (odoc in [#144](https://github.com/david-engelmann/atproto/pull/144)) and was **not** already live-called in `test/test_local_appview.ml` on current `main` (`d10c5a0e`).

Only `test/test_local_appview.ml` changes — a sibling docs PR owns CHANGELOG / README notes.

Reuses existing leftover helpers (`av_get_leftover` / `av_get_until_or_skip` / `is_policy_invalid`). **Does not fail** the suite on TestNetwork-policy `InvalidRequest` (unhosted feed generator DID: `could not find feed` / `invalid feed generator service details`) or when the NSID is not served.

### Hop policy
- Call `getFeedSkeleton` only against **our leftover `getFeedGenerator` URI**, and only when AppView marked that generator `isOnline`.
- If no hosted generator, skip.
- Do **not** call `getFeedSkeleton` against suggested public feeds.

### Stay listed not faked
- `chat.bsky.*` (no OSS chat backend)
- `app.bsky.video.*` (no hosted transcoder)
- hosted Tap
- phone / contacts (`app.bsky.contact.*`)
- push `registerPush` / `unregisterPush` (hosted push)

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (sibling docs PR owns notes)

Fixes # (n/a — leftover live coverage after #144 / #129)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76359462-6b44-44d2-9ae0-6484c5a889e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76359462-6b44-44d2-9ae0-6484c5a889e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

