### PR TITLE
Add leftover AppView/record modules to the odoc landing map

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -52,7 +52,7 @@ OAuth / DPoP
 
 AppView
 
-{!modules: Atproto.Actor Atproto.Feed Atproto.Graph Atproto.Bookmark Atproto.Notification Atproto.Labeler Atproto.Unspecced Atproto.Video}
+{!modules: Atproto.Actor Atproto.Feed Atproto.Graph Atproto.Bookmark Atproto.Notification Atproto.Labeler Atproto.Unspecced Atproto.Video Atproto.Draft Atproto.Contact Atproto.Ageassurance Atproto.Site}
 
 Ozone
 
@@ -63,5 +63,5 @@ Chat client
 {!modules: Atproto.Chat}
 
 Also {!Atproto.Repo}, {!Atproto.Records}, {!Atproto.Server},
-{!Atproto.Sync}, {!Atproto.Label}, {!Atproto.Lexicon}, and
-{!Atproto.Http_client}.
+{!Atproto.Sync}, {!Atproto.Label}, {!Atproto.Lexicon},
+{!Atproto.Http_client}, and {!Atproto.Germnetwork}.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only update to `doc/index.mld` so the public-module map matches modules that already ship on `main` (`6191a177`).

- AppView `{!modules:}` now includes leftover public modules `Atproto.Draft`, `Atproto.Contact`, `Atproto.Ageassurance`, and `Atproto.Site`.
- The leftover Also line now includes public `Atproto.Germnetwork` (`com.germnetwork.declaration`), after Repo / Records / Server / Sync / Label / Lexicon / Http_client.
- Hosted-only leftovers stay listed not faked (no PDS / OSS chat backend / video transcoder / Tap in this package). Landing page stays short.
- Comment/docs-only. No `CHANGELOG.md` or `README.md` (owned by [#164](https://github.com/david-engelmann/atproto/pull/164)). No `src/` or test edits.

[Landing-page module map](/opt/cursor/artifacts/odoc_landing_module_map.txt)
[index.mld diff vs main](/opt/cursor/artifacts/odoc_index_mld.diff)

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment (docs-only; no new modules)
- [ ] User-facing change is noted in CHANGELOG.md (intentionally left to [#164](https://github.com/david-engelmann/atproto/pull/164))

Fixes # (n/a — landing-page catch-up for leftover public modules already in the library)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-717275ba-f5d7-4603-95d1-b7deb57c7e52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-717275ba-f5d7-4603-95d1-b7deb57c7e52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

