### PR TITLE
leftover function-level odoc on Embed.get_embed_external_view

### DIFF
--- a/src/bsky/embed.ml
+++ b/src/bsky/embed.ml
@@ -1100,6 +1100,8 @@ module Embed = struct
         | _ -> []);
     }
 
+  (** External embed view via [app.bsky.embed.getEmbedExternalView]. GET hop
+      for [url] plus [uris]. *)
   let get_embed_external_view ?session ?host ~url ~uris () : embed_external_view
       =
     Client.Client.get_json ?session ?host "app.bsky.embed.getEmbedExternalView"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** ... *)` on the public `Embed.get_embed_external_view` wrapper (`app.bsky.embed.getEmbedExternalView`). GET hop; skips `parse_embed_external_view`. No tests. No CHANGELOG/README (another PR owns notes).

Hosted-only chat / video / Tap / phone / push / opam stay listed, not faked. This PR is unrelated to those.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8de47aa4-317a-4f96-980c-f16eaad48721?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8de47aa4-317a-4f96-980c-f16eaad48721&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

