### PR TITLE
Live TestNetwork hops for leftover Unspecced age-assurance NSIDs

### DIFF
--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -1092,8 +1092,10 @@ let test_leftover_served _ =
                   { Notification.post = false; reply = false } );
             ])))
 
-(* Remaining AppView unspecced skeletons / getSuggested* / getTrendsSkeleton
-   and app.bsky.ageassurance.* if this revision serves them. *)
+(* Remaining AppView unspecced skeletons / getSuggested* / getTrendsSkeleton,
+   leftover unspecced getAgeAssuranceState / initAgeAssurance (not the
+   dedicated app.bsky.ageassurance.* twins already hopped below), and
+   app.bsky.ageassurance.* if this revision serves them. *)
 let test_unspecced_and_ageassurance _ =
   let s = session () in
   let viewer = s.auth.did in
@@ -1226,6 +1228,21 @@ let test_unspecced_and_ageassurance _ =
       let page = Unspecced.parse_skeleton_starter_packs json in
       OUnit2.assert_bool "searchStarterPacksSkeleton"
         (List.length page.starter_packs >= 0));
+  get ~session:s "app.bsky.unspecced.getAgeAssuranceState" [] (fun json ->
+      let state = Unspecced.parse_age_assurance_state json in
+      OUnit2.assert_bool "unspecced.getAgeAssuranceState"
+        (String.length state.status >= 0));
+  (match
+     av_post_leftover ~session:s "app.bsky.unspecced.initAgeAssurance"
+       (Yojson.Safe.to_string
+          (Unspecced.init_age_assurance_body ~email:"alice@test.com"
+             ~language:"en" ~country_code:"US"))
+   with
+   | None -> ()
+   | Some json ->
+       let state = Unspecced.parse_age_assurance_state json in
+       OUnit2.assert_bool "unspecced.initAgeAssurance"
+         (String.length state.status >= 0));
   get "app.bsky.ageassurance.getConfig" [] (fun json ->
       let cfg = Ageassurance.parse_config json in
       OUnit2.assert_bool "ageassurance.getConfig" (List.length cfg.regions >= 0));

--- a/test/test_local_appview.ml
+++ b/test/test_local_appview.ml
@@ -1238,11 +1238,11 @@ let test_unspecced_and_ageassurance _ =
           (Unspecced.init_age_assurance_body ~email:"alice@test.com"
              ~language:"en" ~country_code:"US"))
    with
-   | None -> ()
-   | Some json ->
-       let state = Unspecced.parse_age_assurance_state json in
-       OUnit2.assert_bool "unspecced.initAgeAssurance"
-         (String.length state.status >= 0));
+  | None -> ()
+  | Some json ->
+      let state = Unspecced.parse_age_assurance_state json in
+      OUnit2.assert_bool "unspecced.initAgeAssurance"
+        (String.length state.status >= 0));
   get "app.bsky.ageassurance.getConfig" [] (fun json ->
       let cfg = Ageassurance.parse_config json in
       OUnit2.assert_bool "ageassurance.getConfig" (List.length cfg.regions >= 0));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds skip-if-not-served live TestNetwork hops for leftover AppView NSIDs `app.bsky.unspecced.getAgeAssuranceState` and `app.bsky.unspecced.initAgeAssurance`. Wrappers `Unspecced.get_age_assurance_state` / `init_age_assurance` already exist on `main` (`ab67812a`) and were **not** already live-called in `test/test_local_appview.ml` (the dedicated `app.bsky.ageassurance.*` hops in the same test are different NSIDs).

Only `test/test_local_appview.ml` changes. Reuses existing leftover helpers (`av_get_leftover` / `av_post_leftover` / `is_policy_invalid`). Skip when the NSID is not served or TestNetwork policy `InvalidRequest`. Does not fake a hosted age-assurance verifier.

### Hop policy
- GET `getAgeAssuranceState` with the alice session (lexicon: no query params).
- POST `initAgeAssurance` with the existing leftover body helper (`email` / `language` / `countryCode`).
- Dedicated `app.bsky.ageassurance.getConfig` / `getState` / `begin` hops stay unchanged.

### Stay listed not faked
- `chat.bsky.*` (no OSS chat backend)
- `app.bsky.video.*` (no hosted transcoder)
- hosted Tap
- phone / contacts (`app.bsky.contact.*`)
- push `registerPush` / `unregisterPush` (hosted push)
- `com.atproto.temp.requestPhoneVerification`
- unhosted feed generator
- Jetstream archive operator token
- public HTTPS client-metadata / production browser login
- permissioned data / spaces / LtHash
- opam-repository publish

Official lexicon pin `5c154f9c` is unchanged (`lexicons/` has not moved on bluesky-social/atproto `main`).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (live-hop only; notes PRs own CHANGELOG)

Fixes # (n/a — leftover live coverage after #129 / #163)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e59b739a-8eee-43ad-97e4-9355c2f67d37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e59b739a-8eee-43ad-97e4-9355c2f67d37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

