### PR TITLE
Add leftover Admin/Temp/Moderation/Embed/Facet/Tid modules to the odoc landing map

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -42,6 +42,10 @@ MST / CID / CAR
 
 {!modules: Atproto.Mst Atproto.Cid Atproto.Car Atproto.Dag_cbor Atproto.Repo_sync}
 
+TID / AT URI / syntax
+
+{!modules: Atproto.Tid Atproto.At_uri Atproto.Syntax}
+
 Firehose / Jetstream
 
 {!modules: Atproto.Firehose Atproto.Jetstream}
@@ -52,11 +56,15 @@ OAuth / DPoP
 
 AppView
 
-{!modules: Atproto.Actor Atproto.Feed Atproto.Graph Atproto.Bookmark Atproto.Notification Atproto.Labeler Atproto.Unspecced Atproto.Video Atproto.Draft Atproto.Contact Atproto.Ageassurance Atproto.Site}
+{!modules: Atproto.Actor Atproto.Feed Atproto.Graph Atproto.Bookmark Atproto.Notification Atproto.Labeler Atproto.Unspecced Atproto.Video Atproto.Draft Atproto.Contact Atproto.Ageassurance Atproto.Site Atproto.Embed Atproto.Facet}
 
 Ozone
 
 {!modules: Atproto.Ozone}
+
+Admin / temp / moderation
+
+{!modules: Atproto.Admin Atproto.Temp Atproto.Moderation}
 
 Chat client
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only `doc/index.mld` landing-map update. After #165 the AppView block and leftover Also line still omitted leftover *public protocol* modules that `src/dune` already exports.

- AppView `{!modules:}` also lists `Atproto.Embed` and `Atproto.Facet`.
- New `Admin / temp / moderation` `{!modules:}` block: `Atproto.Admin`, `Atproto.Temp`, `Atproto.Moderation`.
- New `TID / AT URI / syntax` `{!modules:}` block: `Atproto.Tid`, `Atproto.At_uri`, `Atproto.Syntax`.

Skips codec/HTTP internals (`User`, `Client`, `Cohttp_client`, `App`, `Error`, `Request`, `Response`, `Websocket`, `Varint`, `Base32`, `Base58`, `Base64url`, `Hash`, `Http_method`, `K256`, `Jetstream_zstd_dictionary`). Hosted-only leftovers wording and lexicon pin `5c154f9c` are unchanged. No CHANGELOG (notes PR owns that).

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md — skipped; notes PR owns CHANGELOG/README

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8d5a16c-1e6b-4353-9e2f-fe255e52bea6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8d5a16c-1e6b-4353-9e2f-fe255e52bea6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

