### PR TITLE
Typecheck leftover Ageassurance/Unspecced constructors in offline.ml

### DIFF
--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -692,6 +692,28 @@ let () =
       (`Assoc [ ("status", `String "unknown"); ("access", `String "unknown") ])
   in
   assert (aa.status = "unknown");
+  let aa_begin =
+    Ageassurance.begin_body ~email:"alice@test.com" ~language:"en"
+      ~country_code:"US" ()
+  in
+  assert (
+    match Yojson.Safe.Util.member "countryCode" aa_begin with
+    | `String "US" -> true
+    | _ -> false);
+  let aa_cfg = Ageassurance.parse_config (`Assoc [ ("regions", `List []) ]) in
+  assert (List.length aa_cfg.regions >= 0);
+  let ua_init =
+    Unspecced.init_age_assurance_body ~email:"alice@test.com" ~language:"en"
+      ~country_code:"US"
+  in
+  assert (
+    match Yojson.Safe.Util.member "countryCode" ua_init with
+    | `String "US" -> true
+    | _ -> false);
+  let ua_aa =
+    Unspecced.parse_age_assurance_state (`Assoc [ ("status", `String "unknown") ])
+  in
+  assert (String.length ua_aa.status >= 0);
   let contact_status = Contact.parse_sync_status_opt (`Assoc []) in
   assert (contact_status.sync_status = None);
   (match

--- a/examples/offline.ml
+++ b/examples/offline.ml
@@ -701,7 +701,7 @@ let () =
     | `String "US" -> true
     | _ -> false);
   let aa_cfg = Ageassurance.parse_config (`Assoc [ ("regions", `List []) ]) in
-  assert (List.length aa_cfg.regions >= 0);
+  assert (aa_cfg.regions = []);
   let ua_init =
     Unspecced.init_age_assurance_body ~email:"alice@test.com" ~language:"en"
       ~country_code:"US"
@@ -711,7 +711,8 @@ let () =
     | `String "US" -> true
     | _ -> false);
   let ua_aa =
-    Unspecced.parse_age_assurance_state (`Assoc [ ("status", `String "unknown") ])
+    Unspecced.parse_age_assurance_state
+      (`Assoc [ ("status", `String "unknown") ])
   in
   assert (String.length ua_aa.status >= 0);
   let contact_status = Contact.parse_sync_status_opt (`Assoc []) in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Compiled-only typechecks in `examples/offline.ml` for leftover public constructors that the last unique TestNetwork hops actually use:

- `Ageassurance.begin_body` (assert constructed JSON members)
- `Ageassurance.parse_config` on a small fixture (`get_config` is a live hop — not called)
- `Unspecced.init_age_assurance_body`
- `Unspecced.parse_age_assurance_state` on a tiny fixture JSON (status field only)

No live XRPC. No CHANGELOG (notes PR owns that). Hosted-only chat/video/Tap/phone/push/opam stay listed not faked.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (notes PR owns that)

Fixes # (issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff857c0f-11cd-4b75-8a07-dff14815b655?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff857c0f-11cd-4b75-8a07-dff14815b655&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

