### PR TITLE
Add downstream installed-package smoke test

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -67,6 +67,49 @@ jobs:
           path: dune_runtest.log
           if-no-files-found: warn
 
+      # Install from generated atproto.opam (not _build/default/src), then
+      # compile a separate Dune project that cannot see the source tree.
+      # Does not publish to opam-repository and does not create a release/tag.
+      - name: Install local atproto package
+        run: opam install . --yes
+
+      - name: Downstream installed-package smoke test
+        run: |
+          set -euo pipefail
+          prefix="$(opam var prefix)"
+          installed="${prefix}/lib/atproto"
+          if [ ! -d "${installed}" ]; then
+            echo "expected installed library at ${installed}" >&2
+            exit 1
+          fi
+          workspace="${GITHUB_WORKSPACE}"
+          case "${installed}" in
+            "${workspace}"*)
+              echo "atproto resolved inside the source tree: ${installed}" >&2
+              exit 1
+              ;;
+          esac
+          for m in tid syntax oauth; do
+            if [ ! -f "${installed}/${m}.cmi" ]; then
+              echo "missing ${m}.cmi under ${installed} (install/export incomplete)" >&2
+              ls -la "${installed}" >&2
+              exit 1
+            fi
+          done
+          smoke="${RUNNER_TEMP}/atproto-consumer-smoke"
+          rm -rf "${smoke}"
+          mkdir -p "${smoke}"
+          cp -R test/consumer-smoke/. "${smoke}/"
+          case "${smoke}" in
+            "${workspace}"*)
+              echo "smoke directory is inside the source tree: ${smoke}" >&2
+              exit 1
+              ;;
+          esac
+          cd "${smoke}"
+          opam exec -- dune build
+          opam exec -- dune exec -- ./main.exe
+
   lint-doc:
     strategy:
       fail-fast: false

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Downstream installed-package smoke test
         run: |
           set -euo pipefail
+          switch="$(opam var switch)"
           prefix="$(opam var prefix)"
           installed="${prefix}/lib/atproto"
           workspace="${GITHUB_WORKSPACE}"
@@ -116,8 +117,8 @@ jobs:
               ;;
           esac
           cd "${smoke}"
-          opam exec -- dune build
-          opam exec -- dune exec -- ./main.exe
+          opam exec --switch="${switch}" -- dune build
+          opam exec --switch="${switch}" -- dune exec -- ./main.exe
 
   lint-doc:
     strategy:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -92,9 +92,15 @@ jobs:
               exit 1
               ;;
           esac
-          for m in tid syntax oauth; do
-            if [ ! -f "${installed}/${m}.cmi" ]; then
-              echo "missing ${m}.cmi under ${installed} (install/export incomplete)" >&2
+          # Wrapped library: atproto.cmi plus atproto__Tid.cmi, not tid.cmi.
+          if [ ! -f "${installed}/atproto.cmi" ]; then
+            echo "missing wrapper atproto.cmi under ${installed}" >&2
+            ls -la "${installed}" >&2
+            exit 1
+          fi
+          for m in Tid Syntax Oauth; do
+            if [ ! -f "${installed}/atproto__${m}.cmi" ]; then
+              echo "missing atproto__${m}.cmi under ${installed} (wrap/export incomplete)" >&2
               ls -la "${installed}" >&2
               exit 1
             fi

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -78,14 +78,17 @@ jobs:
           set -euo pipefail
           prefix="$(opam var prefix)"
           installed="${prefix}/lib/atproto"
+          workspace="${GITHUB_WORKSPACE}"
+          echo "opam prefix: ${prefix}"
+          echo "installed atproto: ${installed}"
           if [ ! -d "${installed}" ]; then
             echo "expected installed library at ${installed}" >&2
             exit 1
           fi
-          workspace="${GITHUB_WORKSPACE}"
+          # setup-ocaml uses ${GITHUB_WORKSPACE}/_opam; reject dune _build only.
           case "${installed}" in
-            "${workspace}"*)
-              echo "atproto resolved inside the source tree: ${installed}" >&2
+            */_build/*|"${workspace}/_build"*)
+              echo "atproto resolved from dune _build, not opam install: ${installed}" >&2
               exit 1
               ;;
           esac

--- a/test/consumer-smoke/dune
+++ b/test/consumer-smoke/dune
@@ -1,0 +1,4 @@
+(executable
+ (name main)
+ (libraries atproto)
+ (modules main))

--- a/test/consumer-smoke/dune-project
+++ b/test/consumer-smoke/dune-project
@@ -1,5 +1,2 @@
-; Isolated downstream consumer used by TestSuite.
-; Copied out of the source tree before `dune build` so it can only
-; see the installed `atproto` package, not `src/`.
 (lang dune 2.9)
 (name atproto_consumer_smoke)

--- a/test/consumer-smoke/dune-project
+++ b/test/consumer-smoke/dune-project
@@ -1,0 +1,5 @@
+; Isolated downstream consumer used by TestSuite.
+; Copied out of the source tree before `dune build` so it can only
+; see the installed `atproto` package, not `src/`.
+(lang dune 2.9)
+(name atproto_consumer_smoke)

--- a/test/consumer-smoke/main.ml
+++ b/test/consumer-smoke/main.ml
@@ -1,0 +1,20 @@
+(* Isolated downstream consumer: links the installed [atproto] package.
+   No network, hosted services, or source-tree modules. *)
+
+open Atproto.Tid
+open Atproto.Syntax
+open Atproto.Oauth
+
+let () =
+  assert (Tid.is_valid "3jzfcijpj2z2a");
+  assert (Syntax.is_valid_nsid "app.bsky.feed.post");
+  assert (Syntax.is_valid_handle "alice.test");
+  assert (Syntax.is_valid_did "did:plc:abc123xyz0001112223333");
+  let meta =
+    Oauth.public_metadata
+      ~client_id:"https://client.example/client-metadata.json"
+      ~redirect_uris:[ "https://client.example/cb" ]
+      ()
+  in
+  Oauth.validate_metadata meta;
+  print_endline "consumer-smoke: installed atproto package links"

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 ; Copied to ${RUNNER_TEMP} by TestSuite; must not join this workspace.
+
 (data_only_dirs consumer-smoke)
 
 (tests

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,6 @@
+; Copied to ${RUNNER_TEMP} by TestSuite; must not join this workspace.
+(data_only_dirs consumer-smoke)
+
 (tests
  (flags
   (:standard -w +33 -warn-error +33))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the smallest CI coverage that a **clean downstream Dune project** can install and link the public `atproto` package through opam — not merely typecheck against `_build/default/src`.

After the existing `build` job’s `dune build -p atproto` / `dune runtest -p atproto` steps:

1. `opam install . --yes` installs the local checkout from generated `atproto.opam` into the existing 4.14.1 switch (no opam-repository publish, no release/tag).
2. The committed fixture `test/consumer-smoke/` (`dune-project`, `dune`, `main.ml`) is copied to `${RUNNER_TEMP}` so it is outside the repo workspace and cannot see source modules.
3. That isolated project depends on `(libraries atproto)` and compiles a no-network program using `Atproto.Tid`, `Atproto.Syntax`, and `Atproto.Oauth` helpers (TID/NSID/handle/DID checks + `Oauth.public_metadata` / `validate_metadata`).
4. The step asserts the library is under `$(opam var prefix)/lib/atproto` (setup-ocaml’s `${GITHUB_WORKSPACE}/_opam`, not `dune` `_build`) and that wrapped export files `atproto.cmi`, `atproto__Tid.cmi`, `atproto__Syntax.cmi`, and `atproto__Oauth.cmi` were installed.
5. Because the consumer build runs outside the repo (no local switch auto-detection), the workflow captures `opam var switch` before `cd` and runs consumer commands with `opam exec --switch="${switch}" -- ...`.
6. The fixture `dune-project` starts with `(lang dune 2.9)` on line 1 as required by Dune.

`test/dune` marks `consumer-smoke` as `data_only_dirs` so the fixture cannot join the main Dune workspace or `dune runtest -p atproto`. Action versions, OCaml 4.14.1, and ubuntu-22.04 are unchanged. No hosted calls, Docker, or public-API/protocol-test edits.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment — N/A (CI + fixture only)
- [x] User-facing change is noted in CHANGELOG.md — skipped; notes PR owns CHANGELOG/README; this is CI-only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab7b1cec-eed6-461f-b678-c67f5a36c28b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab7b1cec-eed6-461f-b678-c67f5a36c28b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

