### PR TITLE
Document libzstd system dependency for installs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,9 @@ pinning the GitHub repository.
 
 - OCaml **4.14.x only** (`>= 4.14.1` and `< 5.0`). CI tests **4.14.1**.
 - ocamlformat **0.25.1** (see `.ocamlformat`). `lint-fmt` must stay green.
+- System libzstd (Jane Street `zstandard` / Jetstream dict-zstd):
+  Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd` (headers ship
+  with the formula). Required, not optional.
 - Package-style build (what `opam install` / a dependent sees):
   `dune build -p atproto` and `dune runtest -p atproto`.
 
@@ -25,6 +28,8 @@ https://david-engelmann.github.io/atproto/. `dune-project`
 CI jobs: `build`, `lint-doc`, `lint-fmt`, `lint-opam`, `local-pds`.
 On push to `main`, `deploy-pages` publishes odoc HTML to
 https://david-engelmann.github.io/atproto/.
+CI installs Ubuntu `libzstd-dev` before every OCaml job; install
+that or Homebrew `zstd` before the commands below.
 
 ```shell
 opam install . --deps-only --with-test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ opam install . --deps-only --with-test
 dune build -p atproto
 ```
 
+Jetstream dict-zstd requires Jane Street `zstandard`, which needs system libzstd (Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd`) before `opam pin` / `opam install . --deps-only`.
+
 In a dependent `dune` stanza:
 
 ```lisp


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only. README install and CONTRIBUTING toolchain/checks now mention the system libzstd dependency that CI already installs before every OCaml job.

Jane Street `zstandard` (Jetstream dict-zstd) links against system libzstd. Without Ubuntu/Debian `libzstd-dev` or Homebrew `zstd`, `opam pin` / `opam install . --deps-only` fail. No workflow, source, test, or dune change.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (skipped: tiny install-docs hygiene)

Not an opam-repository publish. No tag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c1ff134-8c80-4ed1-8270-74b307c1a19a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c1ff134-8c80-4ed1-8270-74b307c1a19a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

