### PR TITLE
Add Error to odoc landing map and libzstd install notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-install.md
+++ b/.github/ISSUE_TEMPLATE/03-install.md
@@ -12,6 +12,7 @@ labels: ""
 - OCaml version (must be `>= 4.14.1` and `< 5.0`; CI is 4.14.1):
 - opam version / switch:
 - OS:
+- System libzstd (Jane Street `zstandard` / Jetstream dict-zstd; Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd`):
 
 **Command and output**
 Paste the command and the error.
@@ -21,3 +22,5 @@ This package is not on the public opam-repository. The supported install is:
 ```shell
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
 ```
+
+Jetstream dict-zstd needs Jane Street `zstandard` / system libzstd (Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd`) before `opam pin`.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -17,6 +17,9 @@ Not on the public opam-repository. Pin the GitHub repo (OCaml
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
 ]}
 
+Jetstream dict-zstd needs Jane Street [zstandard] / system
+libzstd (Ubuntu/Debian [libzstd-dev], macOS Homebrew [zstd]).
+
 Then [(libraries atproto)] in dune.
 
 {1 Documentation}

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -32,7 +32,7 @@ Auth / Session
 
 XRPC
 
-{!modules: Atproto.Xrpc}
+{!modules: Atproto.Xrpc Atproto.Error}
 
 Identity / PLC
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only. After #165/#170, `Atproto.Error` is a public XRPC type (README Errors row; function-level odoc already in `src/error.ml`) but was not listed in `{!modules:}`. #170 skipped codec/HTTP internals; Error is the protocol module that was an oversight.

#174 documented Jane Street `zstandard` / system libzstd on README + CONTRIBUTING; the odoc install page and install issue template still omitted it.

- XRPC `{!modules:}` now lists `Atproto.Xrpc` and `Atproto.Error`.
- `{1 Install}` in `doc/index.mld` notes Jetstream dict-zstd needs Jane Street `zstandard` / system libzstd (Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd`).
- `.github/ISSUE_TEMPLATE/03-install.md` asks for the same libzstd prerequisite.

No CHANGELOG/README (notes already through #174). lint-fmt + lint-doc are sufficient. No merge-when-green, tags, or opam publish.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment — existing `src/error.ml` odoc unchanged
- [x] User-facing change is noted in CHANGELOG.md — skipped; notes already through #174
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccdb7b4c-1cb5-47ed-a96f-2b586ce45628?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccdb7b4c-1cb5-47ed-a96f-2b586ce45628&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

