### PR TITLE
Odoc for Client HTTP/2 helpers

### DIFF
--- a/src/bsky/feed.ml
+++ b/src/bsky/feed.ml
@@ -8,11 +8,20 @@ open Embed
 
 (** [app.bsky.feed] — timeline, threads, author feed, search, and generators. *)
 module Feed = struct
-  (* Official app.bsky.feed.getAuthorFeed `filter` knownValues. *)
+  (** [app.bsky.feed.getAuthorFeed] [filter] knownValue [posts_with_replies]. *)
   let filter_posts_with_replies = "posts_with_replies"
+
+  (** [app.bsky.feed.getAuthorFeed] [filter] knownValue [posts_no_replies]. *)
   let filter_posts_no_replies = "posts_no_replies"
+
+  (** [app.bsky.feed.getAuthorFeed] [filter] knownValue [posts_with_media]. *)
   let filter_posts_with_media = "posts_with_media"
+
+  (** [app.bsky.feed.getAuthorFeed] [filter] knownValue
+      [posts_and_author_threads]. *)
   let filter_posts_and_author_threads = "posts_and_author_threads"
+
+  (** [app.bsky.feed.getAuthorFeed] [filter] knownValue [posts_with_video]. *)
   let filter_posts_with_video = "posts_with_video"
 
   (* Authors feed comes with either "post" "post"+"reply" or "post"+"reason"

--- a/src/client.ml
+++ b/src/client.ml
@@ -150,8 +150,10 @@ module Client = struct
         | None -> []))
     @ extra
 
-  (* HTTPS-only HTTP/2 GET that keeps status + response headers. Hosts with
-     an explicit port (local stacks) stay on Cohttp. *)
+  (** XRPC GET [nsid] with query [pairs] via [Http_client] HTTP/2 TLS.
+      For public HTTPS XRPC that needs status/response headers. Auth
+      from [session] or [bearer]; optional [host] and extra headers.
+      Hosts with an explicit port (local stacks) stay on Cohttp. *)
   let get_json_h2 ?session ?host ?bearer ?(extra = []) nsid pairs =
     let host = host_of ?session ?host () in
     if String.contains host ':' then
@@ -162,7 +164,10 @@ module Client = struct
       let resp = Http_client.run (Http_client.get url ~headers ()) in
       json_of_body (Response.body_string resp)
 
-  (* Symmetric HTTP/2 POST. Local :port hosts stay on Cohttp. *)
+  (** XRPC POST [nsid] with JSON [data] via [Http_client] HTTP/2 TLS.
+      For public HTTPS XRPC that needs status/response headers. Auth
+      from [session] or [bearer]; optional [host] and extra headers.
+      Hosts with an explicit port (local stacks) stay on Cohttp. *)
   let post_json_h2 ?session ?host ?bearer ?(extra = []) nsid data =
     let host = host_of ?session ?host () in
     if String.contains host ':' then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comment-only `(** ... *)` on public `Client.get_json_h2` / `Client.post_json_h2` (matching existing `get_json` / `post_json` tone). These use `Http_client` HTTP/2 TLS for public HTTPS XRPC that needs status/response headers; hosts with an explicit port stay on Cohttp. Same PR: one-line odoc on `Feed.filter_posts_*` `getAuthorFeed` knownValues.

No API changes. No tests. No CHANGELOG/README (a follow-up notes PR can cover it). No leftover `*_body` work, lexicon pin, tag, or opam publish.

Hosted-only chat / video / Tap / phone / push / opam stay listed, not faked. This PR is unrelated to those.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76b13d68-3dee-4672-8788-5873800e296e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76b13d68-3dee-4672-8788-5873800e296e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

