### PR TITLE
Add merge-when-green squash automation for main PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,6 +28,21 @@ https://david-engelmann.github.io/atproto/. `dune-project`
 CI jobs: `build`, `lint-doc`, `lint-fmt`, `lint-opam`, `local-pds`.
 On push to `main`, `deploy-pages` publishes odoc HTML to
 https://david-engelmann.github.io/atproto/.
+
+Open, non-draft pull requests that target `main` from this repository
+(or Dependabot) may be **squash-merged automatically** by
+`.github/workflows/merge-when-green.yml` once CI is green; the head
+branch is deleted. Docs-only diffs (`CHANGELOG` / `README` / `doc/**` /
+`.github/**` except workflows / `*.md`) merge after `lint-fmt` and
+`lint-doc` succeed. Other PRs wait for TestSuite `build`, `local-pds`,
+and `lint-*`. Forks, drafts, and failing checks are never merged.
+Stacked PRs that are only behind `main` get an update-branch after a
+merge. This does not publish to opam-repository or create a release
+tag. "Allow auto-merge" in repo settings is optional — the workflow
+merges on green itself. Branch protection that requires a human review
+will block the Actions token; merge those PRs manually or do not
+require a review for this automation.
+
 CI installs Ubuntu `libzstd-dev` before every OCaml job; install
 that or Homebrew `zstd` before the commands below.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,8 +33,10 @@ Open, non-draft pull requests that target `main` from this repository
 (or Dependabot) may be **squash-merged automatically** by
 `.github/workflows/merge-when-green.yml` once CI is green; the head
 branch is deleted. Docs-only diffs (`CHANGELOG` / `README` / `doc/**` /
-`.github/**` except workflows / `*.md`) merge after `lint-fmt` and
-`lint-doc` succeed. Other PRs wait for TestSuite `build`, `local-pds`,
+`*.md` / `.github` markdown, issue templates, `CODEOWNERS`,
+`dependabot.yml`) merge after `lint-fmt` and `lint-doc` succeed.
+`.github/scripts/**`, workflow YAML, and other `.github` files wait for
+full TestSuite. Other PRs wait for TestSuite `build`, `local-pds`,
 and `lint-*`. Forks, drafts, and failing checks are never merged.
 Stacked PRs that are only behind `main` get an update-branch after a
 merge. This does not publish to opam-repository or create a release

--- a/.github/scripts/merge-when-green.sh
+++ b/.github/scripts/merge-when-green.sh
@@ -22,16 +22,21 @@ is_dependabot_login() {
   esac
 }
 
-# Workflow YAML is code: a docs-only PR must not touch it.
+# Docs-only under .github/ is markdown / issue templates / PR template /
+# CODEOWNERS / SECURITY / dependabot.yml only. scripts/**, workflow YAML,
+# and other shell/config are code (full TestSuite).
 is_docs_only_file() {
   local f="${1:-}"
   [[ -z "$f" ]] && return 1
   case "$f" in
-    .github/workflows | .github/workflows/*) return 1 ;;
-  esac
-  case "$f" in
     CHANGELOG | CHANGELOG.md | README | README.md) return 0 ;;
-    doc | doc/* | .github | .github/* | *.md) return 0 ;;
+    doc | doc/*) return 0 ;;
+    *.md) return 0 ;;
+    .github/ISSUE_TEMPLATE | .github/ISSUE_TEMPLATE/*) return 0 ;;
+    .github/PULL_REQUEST_TEMPLATE.md) return 0 ;;
+    .github/CODEOWNERS) return 0 ;;
+    .github/SECURITY.md) return 0 ;;
+    .github/dependabot.yml) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -273,21 +278,32 @@ run_self_test() {
   expect_docs README.md yes
   expect_docs doc/index.mld yes
   expect_docs .github/CONTRIBUTING.md yes
+  expect_docs .github/SECURITY.md yes
+  expect_docs .github/PULL_REQUEST_TEMPLATE.md yes
+  expect_docs .github/ISSUE_TEMPLATE/bug_report.md yes
+  expect_docs .github/ISSUE_TEMPLATE/config.yml yes
+  expect_docs .github/CODEOWNERS yes
   expect_docs .github/dependabot.yml yes
   expect_docs doc/notes.md yes
   expect_docs leftover.md yes
+  expect_docs .github/scripts/foo.sh no
+  expect_docs .github/scripts/merge-when-green.sh no
+  expect_docs .github/workflows/x.yml no
   expect_docs .github/workflows/test_suite.yml no
   expect_docs .github/workflows/merge-when-green.yml no
+  expect_docs .github/FUNDING.yml no
   expect_docs src/lib/atproto.ml no
   expect_docs atproto.opam no
   expect_docs Makefile no
 
-  printf '%s\n' 'CHANGELOG.md' 'README.md' 'doc/index.mld' | is_docs_only_file_list \
+  printf '%s\n' 'CHANGELOG.md' 'README.md' 'doc/index.mld' '.github/CONTRIBUTING.md' | is_docs_only_file_list \
     || { log "FAIL: markdown+doc list should be docs-only"; fail=1; }
   printf '%s\n' 'CHANGELOG.md' 'src/x.ml' | is_docs_only_file_list \
     && { log "FAIL: mixed list should not be docs-only"; fail=1; }
-  printf '%s\n' '.github/workflows/test_suite.yml' | is_docs_only_file_list \
+  printf '%s\n' '.github/workflows/x.yml' | is_docs_only_file_list \
     && { log "FAIL: workflow YAML should not be docs-only"; fail=1; }
+  printf '%s\n' '.github/scripts/foo.sh' | is_docs_only_file_list \
+    && { log "FAIL: .github/scripts must not be docs-only"; fail=1; }
   : | is_docs_only_file_list \
     && { log "FAIL: empty list should not be docs-only"; fail=1; }
 

--- a/.github/scripts/merge-when-green.sh
+++ b/.github/scripts/merge-when-green.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# Squash-merge open, non-draft PRs targeting main once CI is green.
+# Intended to run from GitHub Actions on the default branch (trusted).
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-}"
+SELF_WORKFLOW_NAME="${SELF_WORKFLOW_NAME:-Merge when green}"
+EVENT_NAME="${EVENT_NAME:-}"
+WORKFLOW_HEAD_SHA="${WORKFLOW_HEAD_SHA:-}"
+WORKFLOW_CONCLUSION="${WORKFLOW_CONCLUSION:-}"
+DRY_RUN="${MERGE_WHEN_GREEN_DRY_RUN:-}"
+
+# TestSuite jobs that must be green for non-docs PRs.
+TESTSUITE_PREFIXES=(build lint-doc lint-fmt lint-opam local-pds)
+
+log() { printf '%s\n' "$*"; }
+
+is_dependabot_login() {
+  case "${1:-}" in
+    dependabot | dependabot\[bot\] | app/dependabot) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Workflow YAML is code: a docs-only PR must not touch it.
+is_docs_only_file() {
+  local f="${1:-}"
+  [[ -z "$f" ]] && return 1
+  case "$f" in
+    .github/workflows | .github/workflows/*) return 1 ;;
+  esac
+  case "$f" in
+    CHANGELOG | CHANGELOG.md | README | README.md) return 0 ;;
+    doc | doc/* | .github | .github/* | *.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_docs_only_file_list() {
+  local any=0
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    any=1
+    if ! is_docs_only_file "$f"; then
+      return 1
+    fi
+  done
+  [[ "$any" -eq 1 ]]
+}
+
+# Reads gh `pr checks --json name,state,bucket,workflow` from stdin.
+# $1 = docs|full|testsuite
+# docs: lint-fmt + lint-doc pass; any fail blocks; other pending is ok.
+# full / testsuite: every TestSuite job prefix has a pass; those jobs
+# are not pending/fail. Other workflows (lexicon-pin, this job) ignored
+# so we do not deadlock waiting for a check we do not wake on.
+checks_are_green() {
+  local mode="$1"
+  jq -e --arg mode "$mode" --arg self "$SELF_WORKFLOW_NAME" \
+    --argjson prefixes "$(printf '%s\n' "${TESTSUITE_PREFIXES[@]}" | jq -R . | jq -s .)" '
+    def ignored:
+      (.workflow // "") == $self or (.name // "") == $self;
+    def is_testsuite:
+      .name as $n | any($prefixes[]; $n == . or ($n | startswith(. + " ")));
+    def is_lint_min:
+      .name as $n | ($n | startswith("lint-fmt")) or ($n | startswith("lint-doc"));
+    def is_fail:
+      (.bucket == "fail")
+      or ((.state // "") | test("FAILURE|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED"));
+    def is_pending:
+      .bucket == "pending";
+    def is_pass:
+      .bucket == "pass";
+    map(select(ignored | not)) as $c |
+    if ($c | length) == 0 then
+      false
+    elif ($c | map(select(is_fail)) | length) > 0 then
+      false
+    elif $mode == "docs" then
+      ($c | any(is_lint_min and is_pass and (.name | startswith("lint-fmt"))))
+      and ($c | any(is_lint_min and is_pass and (.name | startswith("lint-doc"))))
+    else
+      ($c | map(select(is_testsuite and is_pending)) | length) == 0
+      and all($prefixes[]; . as $p |
+        $c | any(
+          (.name == $p or (.name | startswith($p + " "))) and is_pass
+        )
+      )
+    end
+  ' >/dev/null
+}
+
+eligible_source() {
+  local is_cross="$1"
+  local login="$2"
+  if [[ "$is_cross" == "false" ]]; then
+    return 0
+  fi
+  is_dependabot_login "$login"
+}
+
+pr_files() {
+  local n="$1"
+  gh pr view "$n" --repo "$REPO" --json files --jq '.files[].path'
+}
+
+pr_checks_json() {
+  local n="$1"
+  # `gh pr checks` exits non-zero when anything is pending/failing.
+  gh pr checks "$n" --repo "$REPO" --json name,state,bucket,workflow 2>/dev/null || true
+}
+
+should_merge_pr() {
+  local n="$1"
+  local head_oid="$2"
+  local files checks mode
+
+  files="$(pr_files "$n")"
+  if [[ -z "$files" ]]; then
+    log "PR #$n: no files listed; skip"
+    return 1
+  fi
+
+  mode="full"
+  if printf '%s\n' "$files" | is_docs_only_file_list; then
+    mode="docs"
+    log "PR #$n: docs-only heuristic (lint-fmt + lint-doc)"
+  else
+    log "PR #$n: require TestSuite jobs (build, local-pds, lint-*)"
+  fi
+
+  # Successful TestSuite workflow_run for this exact SHA is enough for
+  # a non-docs PR (and also fine for docs-only).
+  if [[ -n "$WORKFLOW_HEAD_SHA" && "$WORKFLOW_HEAD_SHA" == "$head_oid" && "$WORKFLOW_CONCLUSION" == "success" && "$EVENT_NAME" == "workflow_run" ]]; then
+    log "PR #$n: TestSuite succeeded for ${head_oid:0:7}"
+    return 0
+  fi
+
+  checks="$(pr_checks_json "$n")"
+  if [[ -z "$checks" || "$checks" == "[]" ]]; then
+    log "PR #$n: no checks yet"
+    return 1
+  fi
+  if printf '%s\n' "$checks" | checks_are_green "$mode"; then
+    return 0
+  fi
+  log "PR #$n: checks not green yet ($mode)"
+  return 1
+}
+
+enable_or_merge() {
+  local n="$1"
+  log "PR #$n: squash-merging and deleting the head branch"
+  if [[ -n "$DRY_RUN" ]]; then
+    log "PR #$n: dry-run; not merging"
+    return 0
+  fi
+  gh pr merge "$n" --repo "$REPO" --squash --delete-branch --yes
+}
+
+update_behind() {
+  local n="$1"
+  local oid="$2"
+  log "PR #$n: behind main; updating branch"
+  if [[ -n "$DRY_RUN" ]]; then
+    log "PR #$n: dry-run; not updating branch"
+    return 0
+  fi
+  gh api --method PUT "repos/${REPO}/pulls/${n}/update-branch" \
+    -H "Accept: application/vnd.github+json" \
+    -f expected_head_sha="$oid" >/dev/null
+}
+
+process_prs() {
+  local prs
+  prs="$(gh pr list --repo "$REPO" --base main --state open --limit 100 \
+    --json number,title,isDraft,isCrossRepository,author,mergeable,mergeStateStatus,headRefOid,url)"
+
+  if [[ -z "$prs" || "$prs" == "[]" ]]; then
+    log "No open PRs targeting main"
+    return 0
+  fi
+
+  local n title is_draft is_cross login mergeable status oid
+  while IFS=$'\t' read -r n title is_draft is_cross login mergeable status oid; do
+    [[ -z "$n" ]] && continue
+    log "Considering PR #$n ($title) draft=$is_draft cross=$is_cross author=$login mergeable=$mergeable status=$status"
+
+    if [[ "$is_draft" == "true" ]]; then
+      log "PR #$n: draft; skip"
+      continue
+    fi
+    if ! eligible_source "$is_cross" "$login"; then
+      log "PR #$n: fork (not Dependabot); skip"
+      continue
+    fi
+    if [[ "$status" == "DRAFT" ]]; then
+      log "PR #$n: draft status; skip"
+      continue
+    fi
+    if [[ "$status" == "DIRTY" || "$mergeable" == "false" || "$mergeable" == "CONFLICTING" ]]; then
+      log "PR #$n: merge conflict; skip"
+      continue
+    fi
+    if [[ "$status" == "BEHIND" ]]; then
+      if update_behind "$n" "$oid"; then
+        log "PR #$n: update-branch requested"
+      else
+        log "PR #$n: update-branch failed (leave for a human)"
+      fi
+      continue
+    fi
+    if [[ "$status" == "UNKNOWN" || "$mergeable" == "UNKNOWN" || -z "$mergeable" || "$mergeable" == "null" ]]; then
+      log "PR #$n: mergeability not computed yet; skip"
+      continue
+    fi
+
+    if ! should_merge_pr "$n" "$oid"; then
+      continue
+    fi
+
+    if [[ "$status" != "CLEAN" && "$status" != "HAS_HOOKS" && "$status" != "UNSTABLE" && "$status" != "BLOCKED" ]]; then
+      log "PR #$n: unexpected mergeStateStatus=$status; skip"
+      continue
+    fi
+
+    # UNSTABLE usually means failing/pending required checks. We already
+    # evaluated checks ourselves; still refuse UNSTABLE unless docs-only
+    # (pending build/local-pds is expected there).
+    if [[ "$status" == "UNSTABLE" ]]; then
+      local files
+      files="$(pr_files "$n")"
+      if ! printf '%s\n' "$files" | is_docs_only_file_list; then
+        log "PR #$n: UNSTABLE and not docs-only; skip"
+        continue
+      fi
+    fi
+
+    if enable_or_merge "$n"; then
+      log "PR #$n: merged"
+    else
+      log "PR #$n: merge failed (reviews / branch protection / Allow auto-merge not involved — this workflow merges itself). Leave for a human."
+    fi
+  done < <(printf '%s\n' "$prs" | jq -r '
+    .[] | [
+      .number,
+      (.title | gsub("\t"; " ")),
+      .isDraft,
+      .isCrossRepository,
+      (.author.login // ""),
+      (.mergeable | tostring),
+      (.mergeStateStatus // ""),
+      (.headRefOid // "")
+    ] | @tsv
+  ')
+  return 0
+}
+
+run_self_test() {
+  local fail=0
+  expect_docs() {
+    local path="$1"
+    local want="$2"
+    if is_docs_only_file "$path"; then
+      [[ "$want" == yes ]] || { log "FAIL: $path should not be docs-only"; fail=1; }
+    else
+      [[ "$want" == no ]] || { log "FAIL: $path should be docs-only"; fail=1; }
+    fi
+  }
+
+  expect_docs CHANGELOG.md yes
+  expect_docs README.md yes
+  expect_docs doc/index.mld yes
+  expect_docs .github/CONTRIBUTING.md yes
+  expect_docs .github/dependabot.yml yes
+  expect_docs doc/notes.md yes
+  expect_docs leftover.md yes
+  expect_docs .github/workflows/test_suite.yml no
+  expect_docs .github/workflows/merge-when-green.yml no
+  expect_docs src/lib/atproto.ml no
+  expect_docs atproto.opam no
+  expect_docs Makefile no
+
+  printf '%s\n' 'CHANGELOG.md' 'README.md' 'doc/index.mld' | is_docs_only_file_list \
+    || { log "FAIL: markdown+doc list should be docs-only"; fail=1; }
+  printf '%s\n' 'CHANGELOG.md' 'src/x.ml' | is_docs_only_file_list \
+    && { log "FAIL: mixed list should not be docs-only"; fail=1; }
+  printf '%s\n' '.github/workflows/test_suite.yml' | is_docs_only_file_list \
+    && { log "FAIL: workflow YAML should not be docs-only"; fail=1; }
+  : | is_docs_only_file_list \
+    && { log "FAIL: empty list should not be docs-only"; fail=1; }
+
+  eligible_source false someone || { log "FAIL: same-repo should be eligible"; fail=1; }
+  eligible_source true 'dependabot[bot]' || { log "FAIL: Dependabot fork should be eligible"; fail=1; }
+  eligible_source true outsider && { log "FAIL: other forks should not be eligible"; fail=1; }
+
+  local docs_pending_build full_green missing_build failing_fmt
+  docs_pending_build='[
+    {"name":"lint-fmt (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"lint-doc (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"build (ubuntu-22.04, 4.14.1)","state":"PENDING","bucket":"pending","workflow":"TestSuite"},
+    {"name":"Merge when green","state":"SUCCESS","bucket":"pass","workflow":"Merge when green"}
+  ]'
+  full_green='[
+    {"name":"lint-fmt (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"lint-doc (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"lint-opam (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"build (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"local-pds","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"deploy-pages","state":"SKIPPED","bucket":"skipping","workflow":"TestSuite"},
+    {"name":"lexicon-pin","state":"PENDING","bucket":"pending","workflow":"Lexicon pin drift"}
+  ]'
+  missing_build='[
+    {"name":"lint-fmt (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"lint-doc (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"lint-opam (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"},
+    {"name":"local-pds","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"}
+  ]'
+  failing_fmt='[
+    {"name":"lint-fmt (ubuntu-22.04, 4.14.1)","state":"FAILURE","bucket":"fail","workflow":"TestSuite"},
+    {"name":"lint-doc (ubuntu-22.04, 4.14.1)","state":"SUCCESS","bucket":"pass","workflow":"TestSuite"}
+  ]'
+
+  printf '%s\n' "$docs_pending_build" | checks_are_green docs \
+    || { log "FAIL: docs-only should pass with pending build"; fail=1; }
+  printf '%s\n' "$docs_pending_build" | checks_are_green full \
+    && { log "FAIL: full mode should wait for build/local-pds"; fail=1; }
+  printf '%s\n' "$full_green" | checks_are_green full \
+    || { log "FAIL: full TestSuite green should pass (lexicon-pin pending ok)"; fail=1; }
+  printf '%s\n' "$missing_build" | checks_are_green full \
+    && { log "FAIL: missing build should not pass full mode"; fail=1; }
+  printf '%s\n' "$failing_fmt" | checks_are_green docs \
+    && { log "FAIL: failing lint-fmt should block docs mode"; fail=1; }
+  printf '%s\n' '[]' | checks_are_green docs \
+    && { log "FAIL: empty checks should not pass"; fail=1; }
+
+  if [[ "$fail" -ne 0 ]]; then
+    log "self-test failed"
+    return 1
+  fi
+  log "self-test passed"
+}
+
+if [[ "${1:-}" == --self-test ]]; then
+  run_self_test
+  exit $?
+fi
+
+if [[ "${1:-}" == --classify-files ]]; then
+  if is_docs_only_file_list; then
+    log "docs-only"
+    exit 0
+  fi
+  log "code"
+  exit 1
+fi
+
+if [[ -z "$REPO" ]]; then
+  log "GITHUB_REPOSITORY is required"
+  exit 1
+fi
+
+process_prs

--- a/.github/workflows/merge-when-green.yml
+++ b/.github/workflows/merge-when-green.yml
@@ -1,0 +1,63 @@
+# Squash-merge green PRs targeting main (same-repo or Dependabot).
+# Does not use `gh pr merge --auto`: Allow auto-merge is off, and
+# --auto without required status checks would merge pending PRs.
+# This workflow merges only after it verifies checks itself.
+#
+# Wake-ups are chosen so we cannot loop and never run PR-head YAML:
+# - workflow_run of TestSuite (this workflow is not named TestSuite)
+# - check_run of lint-fmt / lint-doc only (this job is not those names)
+# - pull_request_target ready/opened/reopened (workflow file from main)
+name: Merge when green
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+    branches: [main]
+  workflow_run:
+    workflows: [TestSuite]
+    types: [completed]
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: merge-when-green
+  cancel-in-progress: false
+
+jobs:
+  merge-when-green:
+    name: Merge when green
+    runs-on: ubuntu-22.04
+    if: >
+      (github.event_name == 'pull_request_target'
+        && github.event.pull_request.draft == false)
+      || (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success')
+      || (github.event_name == 'check_run'
+        && github.event.check_run.conclusion == 'success'
+        && (startsWith(github.event.check_run.name, 'lint-fmt')
+            || startsWith(github.event.check_run.name, 'lint-doc')))
+    steps:
+      # Always the default-branch copy of the script, never PR head.
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Self-test merge script
+        run: bash .github/scripts/merge-when-green.sh --self-test
+
+      - name: Merge green PRs targeting main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion || '' }}
+        run: bash .github/scripts/merge-when-green.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Green, non-draft pull requests that target `main` from this repo (or Dependabot) are **squash-merged automatically** once CI is green, and the head branch is deleted. Aimed at Cursor/docs PRs and Dependabot so stacked greens do not need babysitting.

Implementation is a GitHub Action (no Mergify):

- `.github/workflows/merge-when-green.yml` + `.github/scripts/merge-when-green.sh`
- Permissions: `contents: write`, `pull-requests: write`
- Triggers (chosen so the job cannot loop and never runs PR-head YAML):
  - `workflow_run` of **TestSuite** `completed` + `success`
  - `check_run` `completed` + `success` for `lint-fmt*` / `lint-doc*` (docs-only fast path)
  - `pull_request_target` `opened` / `reopened` / `ready_for_review` (workflow file always from `main`; script is checked out from `main` only — `persist-credentials: false`)
- Eligibility: open, not draft, mergeable, base `main`, same-repo or Dependabot
- Docs-only heuristic: `CHANGELOG` / `README` / `doc/**` / `*.md` / `.github` markdown, issue templates, `PULL_REQUEST_TEMPLATE.md`, `CODEOWNERS`, `SECURITY.md`, `dependabot.yml`. Merge after `lint-fmt` + `lint-doc` succeed; any failing check still blocks.
- **Not** docs-only: `.github/scripts/**` (including this merge script), workflow YAML, `FUNDING.yml`, and any other `.github` path. Those wait for full TestSuite (`build`, `local-pds`, `lint-*`).
- Pending `lexicon-pin` does not block — we do not wake on that workflow
- Squash + `--delete-branch` to match existing practice
- Stacked PRs that are only **behind** `main` get `update-branch`
- Failing / pending / fork / draft PRs are never merged
- Does not publish to opam-repository, tag, or fake hosted services

`.github/CONTRIBUTING.md` notes that green PRs to `main` may auto-squash-merge.

`bash .github/scripts/merge-when-green.sh --self-test` covers the docs-only classifier and check evaluator (also run as a workflow step). Asserts `.github/scripts/foo.sh` and `.github/workflows/x.yml` are **not** docs-only, while `CHANGELOG.md` / `doc/index.mld` / `.github/CONTRIBUTING.md` are.

## Manual setting (David)

**This workflow does not require Settings → General → Pull Requests → "Allow auto-merge".** Repo `allow_auto_merge` is currently `false`. The job calls `gh pr merge --squash --delete-branch` only after it verifies checks itself.

`--auto` was **not** used on purpose: without required status checks, `gh pr merge --auto` would merge pending/failing PRs as soon as they are otherwise mergeable. Branch protection was not readable via the API (`403`); rulesets are empty.

Optional later (not needed to land this):

1. Enable **Allow auto-merge** if you want GitHub-native auto-merge as a backup.
2. Add **required status checks** (`lint-fmt`, `lint-doc`, `build`, `local-pds`, `lint-opam`) before relying on `--auto`.
3. If branch protection **requires a human / CODEOWNERS review**, the `GITHUB_TOKEN` cannot merge. Either do not require a review for this automation, or merge those PRs manually. This PR does not change branch protection.

This PR itself will not auto-merge (the workflow is not on `main` yet). After it is squash-merged, subsequent green PRs to `main` will.

## Checklist

- [x] Targets OCaml **4.14** only (`>= 4.14.1` and `< 5.0`; CI is 4.14.1)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `test_lexicon_coverage` (or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [ ] User-facing change is noted in CHANGELOG.md (skipped: contributor/CI automation only)

Not an opam-repository publish. No tag.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9db798-16a2-463d-b512-711c732f0c62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9db798-16a2-463d-b512-711c732f0c62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

