### PR TITLE
Rewrite public docs for third-party readers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Contributing
 
-Pull requests are welcome. This package is published on
-[opam-repository](https://github.com/ocaml/opam-repository)
-(`opam install atproto`; pending merge of the opam-repository PR).
-Pin the GitHub repository for development.
+Pull requests are welcome. **1.0.1** is tagged; the public opam
+package is [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
+(`opam install atproto` after that merges). Pin the GitHub
+repository for development. Product docs for third-party users
+are in [README.md](../README.md) and
+https://david-engelmann.github.io/atproto/.
 
 ## Toolchain
 
@@ -53,11 +55,21 @@ and `lint-*`. Forks, drafts, and failing checks are never merged.
 `lexicon-pin` drift does not block merge-when-green; pin bumps are
 separate PRs.
 Stacked PRs that are only behind `main` get an update-branch after a
-merge. This does not publish to opam-repository or create a release
-tag. "Allow auto-merge" in repo settings is optional — the workflow
+merge. "Allow auto-merge" in repo settings is optional — the workflow
 merges on green itself. Branch protection that requires a human review
 will block the Actions token; merge those PRs manually or do not
 require a review for this automation.
+
+## Local TestNetwork
+
+`make test-pds` starts official `@atproto/dev-env@0.6.4` (PLC, PDS,
+AppView, Ozone). Chat, video, Tap, SMS, and push are not in that
+stack — do not stub them. OAuth against the local AS (loopback
+metadata, PAR, DPoP, CSRF cookies, `getServiceAuth` for AppView /
+Ozone) lives in `test/test_local_oauth.ml`; do not invent a CSRF
+token. Authenticated AppView / Ozone reject a DPoP access token and
+a `createSession` `at+jwt` — mint service-auth instead. DPoP cannot
+be proxied.
 
 CI installs Ubuntu `libzstd-dev` before every OCaml job; install
 that or Homebrew `zstd` before the commands below.

--- a/.github/ISSUE_TEMPLATE/03-install.md
+++ b/.github/ISSUE_TEMPLATE/03-install.md
@@ -17,8 +17,9 @@ labels: ""
 **Command and output**
 Paste the command and the error.
 
-The published install is `opam install atproto` (pending merge of the
-opam-repository PR). A GitHub pin is for development:
+**1.0.1** is released. `opam install atproto` after
+[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
+merges. Until then, pin this repository:
 
 ```shell
 opam install atproto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agents
+
+This repository is an OCaml **client and protocol library** for the [AT Protocol](https://atproto.com). Read [README.md](README.md) first; module HTML is at https://david-engelmann.github.io/atproto/.
+
+## Install and call
+
+- Package: `atproto`. Dune: `(libraries atproto)`.
+- Released **1.0.1** ([tag](https://github.com/david-engelmann/atproto/releases/tag/1.0.1)). Public opam: [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703) (open). Until it merges, `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`.
+- OCaml `>= 4.14.1` and `< 5.4`. System **libzstd** is required (Jetstream dict-zstd).
+- Public, unauthenticated starting point:
+
+```ocaml
+let did = (Identity.resolve_handle "jay.bsky.team").did
+let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
+```
+
+## Honesty constraints
+
+Do not invent or stub hosted products. This package does **not** provide:
+
+- a PDS, OSS chat backend, video transcoder, Tap host, SMS gateway, or APNs/FCM
+- a Jetstream archive API key (operator supplies `JETSTREAM_API_KEY`)
+- a space host
+
+`Chat`, `Video`, `Contact`, `Notification.register_push`, and `Repo_sync` are **clients** (or an indexer toolkit). OAuth still requires the application to host `client-metadata.json`.
+
+`Lt_hash`, `At_uri.Space`, `Space_commit`, `Space_credential`, `Space_xrpc`, and `Space_sync` are **experimental** proposal [0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md) helpers — not a product API. Live space hops skip unless `ATP_SPACE=1` and `ATP_SPACE_HOST` names a real host.
+
+Official lexicons are pinned at `f0d4877a`. Do not bump that pin in a docs change.
+
+## Where to look
+
+| Question | Source |
+| --- | --- |
+| What to install / first call | [README.md](README.md) |
+| What each module is for | README library map + [odoc](https://david-engelmann.github.io/atproto/) |
+| What shipped when | [CHANGELOG.md](CHANGELOG.md) |
+| How to contribute / local TestNetwork | [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) |
+| Env names | `sample.env` |
+
+Prefer those documents over CI logs, helper-name dumps, or reconstructing the API from pull-request titles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,102 +3,80 @@
 All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Package version is **1.0.1** (`dune-project` / `atproto.opam`). This
-revision does **not** create a git tag or GitHub Release.
+Current package version is **1.0.1**, tagged at
+[`53ffbc2`](https://github.com/david-engelmann/atproto/releases/tag/1.0.1).
+The public opam package is
+[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703).
 
-This file is a human-readable release history for opam reviewers and
-third-party users. PR numbers are kept so the history can still be
-traced; they are not a substitute for `git log`.
+This file is the human-readable release history. PR numbers are
+included sparingly so a change can be traced; they are not a
+substitute for `git log`.
 
 ## [Unreleased]
 
 ### Added
 
-- Experimental `Lt_hash` (proposal
-  [0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md)
-  commit digest): 1024 little-endian uint16 lanes, unkeyed BLAKE3 XOF
-  expansion of `{collection}/{rkey}/{record_cid}`, lane-wise add/remove
-  mod 2^16, commit `hash` = `sha256(state)`. Official empty + `one`/`two`
-  snapshot vectors from bluesky-social/atproto#5187
-- Experimental space URI parse/serialize (`At_uri.Space`) and deniable
-  permissioned commits (`Space_commit`):
-  `at://{spaceDid}/space/{spaceType}/{skey}` and the 6-segment record
-  form; `ctx` = `atproto-space-v1` + TLS uint16be-prefixed
-  space/author/rev/ikm; `mac` =
-  `HMAC-SHA256(HKDF-Expand(ikm, ctx, 32), hash)` (expand-only);
-  `sig` = ES256 / ES256K over `sha256(ctx)` (low-S). `of_lt_hash`
-  wires `Lt_hash.hash`. Official `encodeCommitCtx` inputs from
-  bluesky-social/atproto#5187
-- Experimental space-credential materials (`Space_credential`):
-  delegation JWT (`typ` =
-  `atproto-space-delegation+jwt`, `iss`/`sub`/`aud`/`iat`/`exp`/`jti`,
-  `kid` `#atproto`), space credential (`typ` =
-  `atproto-space-credential+jwt`, no `aud`, `cnf.jkt` DPoP binding),
-  optional client-attestation JWT shape (`typ` =
-  `atproto-client-attestation+jwt`, `iss`=`sub`=`client_id`). Sign/verify
-  reuse service-auth ES256/ES256K. DPoP helpers reuse `Oauth` (RFC 9449
-  `dpop+jwt`, RFC 7638 `jkt`, `ath` = base64url(sha256(credential)); no
-  DPoP nonce). Offline fixtures from bluesky-social/atproto#5187.
-  **Not a stable spaces product API**. No space host is started or
-  stubbed. Still Unreleased relative to tags (not part of the 1.0.1
-  packaging cut)
-- Experimental `Space_xrpc` client (proposal 0016 § XRPC API /
-  bluesky-social/atproto#5187 draft lexicons): typed query / JSON
-  bodies and `Client.get_json` / `post_json` / `get_text` wrappers for
-  `getDelegationToken`, `getSpaceCredential` (reuses
-  `Space_credential` exchange DPoP), permissioned repo read/write
-  (`getRecord` / `listRecords` / `createRecord` / `putRecord` /
-  `deleteRecord` / `applyWrites` / `listSpaces`), sync queries
-  (`getLatestCommit` / `getRepo` / `listRepoOps` / `listRepos` /
-  `getBlob` / `listBlobs`), and notify (`registerNotify` /
-  `unregisterNotify` / `notifyWrite` / `notifySpaceDeleted`). Resource
-  reads accept optional space-credential DPoP. Live hops skip unless
-  `ATP_SPACE=1` and `ATP_SPACE_HOST`. Local oplog / two-root CAR apply
-  lives in `Space_sync`. No official lexicon pin bump
-- Experimental `Space_sync` (proposal 0016 incremental sync + two-root
-  CAR apply): `apply_op` / `apply_ops` / `apply_listed` replay
-  `listRepoOps` `{collection, rkey, cid, prev}` onto a running
-  `Lt_hash` (`cid` null = delete, `prev` null = create) and classify
-  `Caught_up` / `Diverged` / `Partial` against the optional trailing
-  signed commit. `encode` / `apply` consume the two-root CARv1 from
-  `getRepo` (signed commit, then DRISL `"{collection}/{rkey}"` → CID
-  in canonical DAG-CBOR key order, then record blocks in that order).
-  Apply verifies the commit MAC/signature, folds the index into
-  LtHash, and checks each record CID. Offline fixtures from
-  bluesky-social/atproto#5187 `packages/space/tests/sync.test.ts`.
-  Named `Space_sync` so it does not clash with `At_uri.Space`. **Not
-  a stable spaces product API**. No space host is started or stubbed.
-  Still Unreleased relative to tags (not part of the 1.0.1 packaging
-  cut). Deferred: `com.atproto.simplespace.*`, `space:` OAuth scopes,
-  proposal `registerNotify` `repo` (not in the #5187 lexicon)
+Experimental permissioned-data / spaces helpers from proposal
+[0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md).
+These modules landed on `main` before the 1.0.1 tag, so they are
+present in that tree, but they are **not a spaces product API**.
+The proposal is not final. This repo does not start or stub a
+space host. Live hops skip unless `ATP_SPACE=1` and
+`ATP_SPACE_HOST` names a real host.
+
+- `Lt_hash` — 0016 commit digest (1024-lane LtHash; official empty /
+  one / two snapshot vectors from bluesky-social/atproto#5187)
+- `At_uri.Space` — parse/serialize
+  `at://{spaceDid}/space/{type}/{skey}` and the six-segment record
+  form
+- `Space_commit` — deniable signed commits (`ctx`, HKDF-Expand MAC,
+  ES256 / ES256K `sig`); `of_lt_hash` wires `Lt_hash.hash`
+- `Space_credential` — delegation / space-credential /
+  client-attestation JWTs plus DPoP helpers (reuses `Oauth`; no
+  DPoP nonce)
+- `Space_xrpc` — draft `com.atproto.space.*` query/JSON builders
+  and `Client` wrappers (credential exchange, permissioned repo
+  read/write, sync queries, notify)
+- `Space_sync` — offline `listRepoOps` apply and two-root CAR
+  encode/apply (signed commit, then DRISL index, then records)
+
+Deferred: `com.atproto.simplespace.*`, `space:` OAuth scopes, and
+proposal `registerNotify` `repo` (not in the #5187 lexicon).
+
+### Changed
+
+- Public docs rewritten for third-party readers (README product
+  pitch and module map, 1.0.1 notes now that the tag exists, warmer
+  odoc landing). Addresses the readability concern on
+  ocaml/opam-repository#30695
 
 ### Notes
 
 - No lexicon pin bump. Official lexicons stay bluesky-social/atproto
   [`f0d4877a`](https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0).
 - Hosted-only products stay listed, not faked (see the 1.0.0 Notes
-  below). Experimental 0016 helpers now include URI + commit +
-  credential JWT / DPoP + draft `Space_xrpc` wrappers + local
-  `Space_sync` oplog / two-root CAR apply. `simplespace` management
-  and a space host stay deferred.
+  below).
 
 ## [1.0.1] - 2026-09-10
 
-Packaging / opam-health cut so
-[ocaml/opam-repository#30698](https://github.com/ocaml/opam-repository/pull/30698)
-can be fixed or superseded. `atproto.1.0.0` built on 4.14 / 5.2;
-opam-ci failed on the lexicon coverage drift gate, unbounded
-`digestif` / `mirage-crypto-ec` lower bounds, and a redundant
-`version:` field in the submitted opam file. 5.4+ SKIPs stay
-expected.
+Released as tag
+[`1.0.1`](https://github.com/david-engelmann/atproto/releases/tag/1.0.1)
+(`53ffbc2` / [#243](https://github.com/david-engelmann/atproto/pull/243)).
+Public opam publish:
+[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
+(open; supersedes #30698).
 
-This revision sets `dune-project` / `atproto.opam` to **1.0.1**. It
-does **not** create a git tag or GitHub Release and does **not**
-touch ocaml/opam-repository. Tagging and updating #30698 remain
-maintainer follow-ups.
+Packaging fix so opam-ci can install and test the package. The
+1.0.0 submission built on 4.14 / 5.2 but failed on the lexicon
+coverage gate under `with-test`, unbounded `digestif` /
+`mirage-crypto-ec` lower bounds, and a redundant `version:` field
+in the submitted opam file. OCaml 5.4+ remains out of range
+(Jane Street v0.17).
 
 No lexicon pin bump (official pin stays `f0d4877a`). Jane Street /
-OCaml bounds are unchanged.
+OCaml bounds are unchanged. Experimental 0016 helpers are
+documented under [Unreleased](#unreleased) — present on this tree,
+not a product API.
 
 ### Changed
 
@@ -130,12 +108,14 @@ OCaml bounds are unchanged.
 
 ## [1.0.0] - 2026-09-09
 
-First stable packaged surface. What is new since the tagged **0.1.0**
+First stable packaged surface, tagged at
+[`1.0.0`](https://github.com/david-engelmann/atproto/releases/tag/1.0.0)
+(`8a1b866` / [#237](https://github.com/david-engelmann/atproto/pull/237)).
+What is new since tagged **0.1.0**
 (`8f44fb9` / [#228](https://github.com/david-engelmann/atproto/pull/228)).
-
-This revision sets `dune-project` / `atproto.opam` to **1.0.0**. It
-does **not** create a git tag or GitHub Release. Tagging and the
-opam-repository 1.0.0 PR remain maintainer follow-ups. The 0.1.0
+The first 1.0.0 opam-repository submission was
+[#30698](https://github.com/ocaml/opam-repository/pull/30698)
+(superseded by [1.0.1](#101---2026-09-10) / #30703). The 0.1.0
 opam-repository PR
 [#30695](https://github.com/ocaml/opam-repository/pull/30695) is
 separate.
@@ -295,8 +275,6 @@ Honesty constraints for this 1.0.0 surface:
   the official app; the production client path is documented and
   library-ready; this package still does not fake APNs/FCM)
 - Permissioned data / spaces / LtHash (no stable public spec yet)
-- A git tag, GitHub Release, or opam-repository 1.0.0 PR — those
-  are maintainer follow-ups after this packaging PR merges
 
 ## [0.1.0] - 2026-09-09
 
@@ -304,8 +282,9 @@ First public opam release candidate, tagged at
 [#228](https://github.com/david-engelmann/atproto/pull/228)
 (`8f44fb9`). The packaged GitHub surface is now [1.0.0](#100---2026-09-09).
 
-`opam install atproto` after the [opam-repository PR](https://github.com/ocaml/opam-repository/pull/30695)
-merges installs this 0.1.0 cut. A GitHub pin still works for
+The 0.1.0 opam-repository PR
+[#30695](https://github.com/ocaml/opam-repository/pull/30695) was
+superseded by 1.0.0 / 1.0.1. A GitHub pin still works for
 development:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,18 +1,38 @@
 # atproto
 
-OCaml toolkit for the [AT Protocol](https://atproto.com) (XRPC, lexicons, repo sync, identity, AppView, Ozone, chat).
+**Typed OCaml toolkit for the [AT Protocol](https://atproto.com).**
 
-## Status
+Resolve identities, read and write repositories, follow the firehose, and call AppView, Ozone, and hosted Bluesky products (chat, video, Jetstream) from one library. Protocol pieces — XRPC, CID/CAR/MST, lexicons, OAuth/DPoP — are implemented here, not left as raw HTTP.
 
-**1.0.1** is the packaged surface (opam-health / lower bounds / coverage-gate split; see [CHANGELOG.md](CHANGELOG.md) `## [1.0.1]`). The client API since tagged **0.1.0** is documented under `## [1.0.0]` ([#229](https://github.com/david-engelmann/atproto/pull/229)–[#236](https://github.com/david-engelmann/atproto/pull/236)). See [Remaining gaps](#remaining-gaps) for hosted-only products this client does not fake. Tagging / GitHub Release and updating ocaml/opam-repository remain maintainer follow-ups.
+**[1.0.1](https://github.com/david-engelmann/atproto/releases/tag/1.0.1)** is released (`53ffbc2`). The public opam package is in [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703). Until that merges, pin this repository; after it merges, `opam install atproto`.
+
+This package is a **client**. It does not host a PDS, chat service, video transcoder, Tap, SMS gateway, or push backend. See [What this package does not host](#what-this-package-does-not-host).
+
+## Quick start
+
+Neither call needs `ATP_AUTH`:
+
+```shell
+opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+# after ocaml/opam-repository#30703 merges:
+# opam install atproto
+```
+
+```ocaml
+(* public AppView, no ATP_AUTH *)
+let did = (Identity.resolve_handle "jay.bsky.team").did
+let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
+```
+
+`examples/quickstart.ml` is that flow as a copy-paste executable (`dune exec -- examples/quickstart.exe`).
 
 ## Install
 
-This library is published to the public [opam-repository](https://github.com/ocaml/opam-repository) (`opam install atproto`). Pin this GitHub repo for the **1.0.1** surface (OCaml **>= 4.14.1 and < 5.4**, package version **1.0.1**). The 0.1.0 / 1.0.0 opam-repository PRs are separate; a 1.0.1 opam publish is a follow-up after the maintainer tags. CI `build` tests **4.14.1** and **5.3.0**. Jane Street `core` / `async` / `ppx_jane` / `zstandard` are pinned to **>= v0.16.0 and < v0.18~** (v0.16 on OCaml 4.14, v0.17 — the 5-ready line — on 5.1–5.3). Public Jane Street v0.17 does not support OCaml 5.4+; 5.0 is untested (v0.17 needs 5.1+). ocamlformat **0.25.1** stays the project format (`lint-fmt` on 4.14.1; that release needs OCaml `< 5.2`):
+Requires OCaml **>= 4.14.1 and < 5.4** (CI: **4.14.1** and **5.3.0**). Jane Street `core` / `async` / `ppx_jane` / `zstandard` are **>= v0.16.0 and < v0.18~** (v0.16 on 4.14, v0.17 on 5.1–5.3). Public Jane Street v0.17 does not support OCaml 5.4+; 5.0 is untested. Jetstream dict-zstd needs system **libzstd** (Debian/Ubuntu `libzstd-dev`, macOS Homebrew `zstd`) before `opam pin` / `opam install . --deps-only`. The Jane Street `zstandard` package is Linux-only (x86_64 / arm64).
 
 ```shell
 opam install atproto
-# development pin
+# development pin (use this until the opam-repository PR merges)
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
 ```
 
@@ -25,66 +45,147 @@ opam install . --deps-only --with-test
 dune build -p atproto
 ```
 
-Jetstream dict-zstd still requires Jane Street `zstandard` and system libzstd (Ubuntu/Debian `libzstd-dev`, macOS Homebrew `zstd`) before `opam pin` / `opam install . --deps-only`. The Jane Street `zstandard` opam package is Linux-only (x86_64 / arm64) in both v0.16 and v0.17.
-
 In a dependent `dune` stanza:
 
 ```lisp
 (libraries atproto)
 ```
 
-`opam pin` / `opam install .` invoke `dune build -p atproto` (the same build a dependent sees) and install the public `atproto` library. A GitHub pin is for development; the published package is `opam install atproto`.
+`opam pin` / `opam install .` run `dune build -p atproto` and install the public `atproto` library. Release notes: [CHANGELOG.md](CHANGELOG.md). Official lexicons stay pinned at bluesky-social/atproto [`f0d4877a`](https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0).
 
-Version notes for **1.0.1** are in [CHANGELOG.md](CHANGELOG.md) (`## [1.0.1] - 2026-09-10`); the client surface since tagged **0.1.0** is `## [1.0.0]`. Hosted-only products stay listed under [Remaining gaps](#remaining-gaps). No lexicon pin bump (official pin stays `f0d4877a`). Tagged **0.1.0** (`8f44fb9` / [#228](https://github.com/david-engelmann/atproto/pull/228)) remains the prior RC.
+## Documentation
 
-## Quick start
+| Resource | Where |
+| --- | --- |
+| API reference | https://david-engelmann.github.io/atproto/ (`dune build @doc` / `make doc`) |
+| Release notes | [CHANGELOG.md](CHANGELOG.md) |
+| Contributing | [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) |
+| For agents | [AGENTS.md](AGENTS.md) |
 
-Install the package, then resolve a handle and search posts. Neither call needs `ATP_AUTH`:
+Pushes to `main` deploy odoc with GitHub Actions Pages. Pull requests also upload the `odoc-html` artifact.
 
-```shell
-opam install atproto
-# or pin this repo for development
-opam pin add atproto git+https://github.com/david-engelmann/atproto.git
-```
+## Library map
 
-```ocaml
-(* public AppView, no ATP_AUTH *)
-let did = (Identity.resolve_handle "jay.bsky.team").did
-let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
-```
+Each row is a starting point. Function-level detail lives in [odoc](https://david-engelmann.github.io/atproto/); release-by-release depth is in the [CHANGELOG](CHANGELOG.md).
 
-`examples/quickstart.ml` is that flow as a copy-paste executable (`dune exec -- examples/quickstart.exe`).
-
-## Docs
-
-Module HTML is at https://david-engelmann.github.io/atproto/. Build it locally with `dune build @doc` or `make doc`. PRs upload the `odoc-html` TestSuite artifact; pushes to `main` deploy with GitHub Actions Pages (`actions/upload-pages-artifact` + `actions/deploy-pages`). GitHub Pages is enabled (Settings → Pages → Source: GitHub Actions). `dune-project` `documentation` points at that live URL.
+| Area | Modules | What it is for |
+| --- | --- | --- |
+| Session | `Auth`, `Session`, `Server` | App-password sessions, app passwords, invites, email, `getServiceAuth` |
+| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | Handle / DID resolve, PLC directory, `did:web` / `did:key` |
+| AppView | `Actor`, `Feed`, `Graph`, `Bookmark`, `Labeler`, `Unspecced` | Profiles, timelines, search, graphs, bookmarks, public labelers |
+| Records | `Repo`, `Records`, `Embed`, `Facet` | create/put/delete/applyWrites and typed post/like/follow/… builders |
+| Sync | `Sync`, `Repo_sync`, `Mst`, `Cid`, `Car`, `Dag_cbor` | Repo CAR, MST, CID; indexer / backfill toolkit (**not** a hosted Tap) |
+| Firehose | `Firehose`, `Websocket`, `Jetstream` | `subscribeRepos` and Jetstream live tail / archive HTTP |
+| OAuth | `Oauth`, `Oauth_scope` | PKCE, DPoP, public HTTPS client-metadata, browser login glue |
+| Chat | `Chat` | Hosted `chat.bsky.*` client (`api.bsky.chat`). No OSS chat backend |
+| Video | `Video` | Hosted `app.bsky.video.*` client (`video.bsky.app`). No transcoder |
+| Ozone | `Ozone` | `tools.ozone.*` moderation client (PDS `atproto-proxy` or service-auth) |
+| Notifications | `Notification` | List, prefs, activity subscriptions, `registerPush` (caller gateway) |
+| Contacts | `Contact` | Hosted phone-verified contacts. No SMS gateway |
+| Labels | `Label` | `queryLabels` / `subscribeLabels` and label-value definitions |
+| Lexicon | `Lexicon` | Parse lexicon-1 JSON, validate, `to_ocaml` codegen |
+| Syntax | `At_uri`, `Tid`, `Syntax`, `Error`, `Xrpc` | `at://`, TIDs, identifier validators, XRPC errors / headers |
+| Other clients | `Admin`, `Temp`, `Moderation`, `Draft`, `Ageassurance` | Admin, temp, user reports, drafts, age assurance |
+| Records (other) | `Site`, `Germnetwork` | `site.standard.*` and `com.germnetwork.declaration` builders |
+| HTTP | `Client`, `Http_client`, `App` | Shared XRPC GET/POST; HTTP/2 TLS for public HTTPS |
+| Experimental | `Lt_hash`, `At_uri.Space`, `Space_commit`, `Space_credential`, `Space_xrpc`, `Space_sync` | Proposal [0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md) only — **not a spaces product API** |
 
 ## Environment
 
-Create a `.env` (see `sample.env`) with at least:
+Create a `.env` (see `sample.env`) when you need a session or a non-default host.
 
-- `ATP_AUTH` : `EmailAddress:AppPassword`
-  - Use an [App Password](https://bsky.app/settings/app-passwords) (email as the username).
-- `ATP_HOST` : `bsky.social`
-  - PDS / entryway host **without** a scheme (`localhost:2583` for the official local network).
-- `ATP_SCHEME` : `https` (default) or `http` for a local stack without TLS.
+| Variable | Purpose |
+| --- | --- |
+| `ATP_AUTH` | `EmailAddress:AppPassword` — use an [App Password](https://bsky.app/settings/app-passwords) |
+| `ATP_HOST` | PDS / entryway host **without** a scheme (`bsky.social`; `localhost:2583` locally) |
+| `ATP_SCHEME` | `https` (default) or `http` for a local stack without TLS |
 
-Optional:
+Optional hosts (all without a scheme): `ATP_APPVIEW_HOST`, `ATP_OZONE_HOST` / `ATP_OZONE_DID`, `ATP_CHAT_HOST` / `ATP_CHAT_DID`, `ATP_VIDEO_HOST`. Local-network extras: `ATP_AUTH_BOB`, `ATP_AUTH_OZONE`, `BASE_ENDPOINT` (default `xrpc`).
 
-- `BASE_ENDPOINT` : `xrpc` (default)
-- `ATP_APPVIEW_HOST` : AppView host without a scheme (`localhost:2584` for `@atproto/dev-env`)
-- `ATP_OZONE_HOST` : Ozone host without a scheme (`localhost:2587`)
-- `ATP_OZONE_DID` : Ozone service DID (printed by `scripts/local-atproto.sh env`)
-- `ATP_AUTH_BOB` / `ATP_AUTH_OZONE` : second PDS account and ozone admin (local network only)
-- `ATP_CHAT_DID` : chat `atproto-proxy` DID (`did:web:api.bsky.chat#bsky_chat` by default; a bare DID gets `#bsky_chat`)
-- `ATP_CHAT_HOST` : hosted chat XRPC host without a scheme (`api.bsky.chat` by default)
-- `ATP_CHAT` : set to `1` / `true` / `yes` / `on` to run live DM tests even when the session JWT scope does not look like a chat grant
-- `ATP_VIDEO_HOST` : hosted video XRPC host without a scheme (`video.bsky.app` by default)
-- `ATP_SPACE` / `ATP_SPACE_HOST` : opt-in live draft `com.atproto.space.*` hops. There is no default host and no space product in this repo. Leave unset unless you have a real space host.
+Session creation, repo writes, graph mutes, bookmarks, chat, ozone, and most feed helpers need `ATP_AUTH`. Chat also needs a DM-capable session (`transition:chat.bsky`, `include:chat.bsky.authFullChatClient`, or `ATP_CHAT=1`). Public identity, DID PLC, firehose subscribe, AppView reads (`public.api.bsky.app`), and most `com.atproto.sync.*` reads do **not**.
 
-Session creation, repo writes, graph mutes, bookmarks, chat, ozone, and feed helpers need `ATP_AUTH`. Chat additionally needs a privileged / DM-capable session (`transition:chat.bsky`, `include:chat.bsky.authFullChatClient`, or `ATP_CHAT=1`). Live video-limit calls skip unless `ATP_AUTH` is a real credential (no invented video product). Public identity, DID PLC, firehose subscribe, AppView reads (`public.api.bsky.app`), and most `com.atproto.sync.*` reads do **not**.
+Live opt-ins (unset in CI): `ATP_CHAT`, `ATP_PHONE` / `ATP_PHONE_NUMBER`, `ATP_PUSH` / `ATP_PUSH_DID` / `ATP_PUSH_TOKEN`, `ATP_SPACE` / `ATP_SPACE_HOST` (no default space host), `JETSTREAM_API_KEY`.
 
-## Build and test
+## Hosted Bluesky products
+
+These paths are library-ready. None of them start a hosted service in this repo. Offline sketches live under `examples/`.
+
+### OAuth (HTTPS client-metadata)
+
+AT Protocol identifies a public client by an HTTPS `client_id` that **is** the URL of a JSON metadata document. This library builds, validates, and serializes that document and drives the browser login path. It does **not** host the file or a login UI.
+
+1. Build the document (`Oauth.public_https_metadata`). `client_id` must be `https://host/path` with no port; web `redirect_uris` must be HTTPS on the same origin. Native clients may use `http://127.0.0.1` / `http://[::1]` or a reverse-domain custom scheme.
+2. Publish it at that URL as HTTP 200 `application/json` (`Oauth.metadata_document`). The body's `client_id` must match the fetch URL. See `examples/client-metadata.json` and `examples/oauth_https_metadata.ml`.
+3. `Oauth.start_browser_login` discovers the PDS authorization server, runs PAR, and returns the authorize URL (PKCE S256 + DPoP + `state`).
+4. On the redirect (`?code=&state=&iss=`), `Oauth.complete_browser_login` exchanges the code for a DPoP token. Authed AppView / Ozone / chat still use `Oauth.get_service_auth`, not the DPoP access token. **DPoP cannot be proxied.**
+
+Loopback `http://localhost?redirect_uri=…` and local TestNetwork stay the development path. `Auth.createSession` stays a Cohttp password session.
+
+### Chat (`chat.bsky.*`)
+
+Client for the hosted Bluesky chat service (`did:web:api.bsky.chat#bsky_chat`, host `api.bsky.chat` / `ATP_CHAT_HOST`). Official TestNetwork does not start a DM service. This repo does not fake one.
+
+- **Scopes.** `Oauth.default_scope` (`atproto transition:generic`) is not enough. Declare `Oauth.default_chat_scope` (adds `transition:chat.bsky`) or `Oauth_scope.full_chat_client_scope` (`include:chat.bsky.authFullChatClient`). Privileged app-passwords carry a chat grant; regular ones do not. `Chat.scope_has_chat` detects a DM grant.
+- **Password session.** Privileged `createSession` + `Chat.list_convos` / `get_messages` / `send_message` through the PDS with `atproto-proxy` (`Chat.effective_proxy`).
+- **OAuth.** Mint `getServiceAuth` (`aud` = `Chat.service_aud`, `lxm` = the `chat.bsky.*` NSID) and call `Chat.list_convos_service` / `get_messages_service` / `send_message_service` on `api.bsky.chat`. Those helpers do not send `atproto-proxy`.
+
+`examples/chat_production.ml` is offline wiring.
+
+### Video (`app.bsky.video.*`)
+
+Client for the hosted Bluesky video service (`video.bsky.app` / `ATP_VIDEO_HOST`). Official TestNetwork does not start a transcoder. This repo does not fake one.
+
+- **Service-auth.** Audience is `did:web:<pds-host>` from the session `#atproto_pds` (`Video.pds_audience`), not `did:web:video.bsky.app`. `lxm` is `com.atproto.repo.uploadBlob`. Password: `Video.mint_upload_token`. OAuth: `Oauth.get_service_auth` with the same aud / lxm.
+- **Upload.** Small clips: `Video.upload_video`. Larger files: multipart `start_upload` / `upload_part` / `finish_upload`. Poll with `Video.poll_job_status` / `ensure_blob`.
+- **Embed.** Put the job **blob ref** on the post (`Video.video_embed_json` / `embed_of_job` + `Records.post`). Do not write the HLS playlist into the create embed.
+
+`examples/video_production.ml` is offline wiring.
+
+### Indexer (`Repo_sync`)
+
+A backfill / firehose-apply toolkit for building an indexer. It is **not** a hosted Tap. Official TestNetwork is a local PDS + AppView + Ozone stack, not a Tap host.
+
+- **Backfill.** `Repo_sync.fetch_repo` / `backfill` pull `com.atproto.sync.getRepo`. Offline: `open_car` / `resync_from_car`.
+- **Walk / proof.** `walk_json` decodes records as IPLD JSON. `export_record_proof` / `verify_record_proof` are getRecord inclusion proofs.
+- **Firehose.** `process_commit` applies `#commit` ops while `Synchronized`. A `#sync` with a different rev marks `Desynchronized` until `resync_from_car`.
+- **Export.** Sync 1.1 `export_car` / `export_subset`. Offline fixture: `write_signed_repo` (production signers use `Mst.sign_p256` / `sign_k256`).
+
+`examples/repo_sync_indexer.ml` is an offline sketch.
+
+### Jetstream
+
+Client for Jetstream live tail and Network Replay HTTP. Live `subscribe` / `subscribe_one` stay unauthenticated (v2 offers `Sec-WebSocket-Protocol: xrpc.v1.json`; dict-zstd is `~compress:true`).
+
+Bluesky-hosted archive HTTP (`planSnapshot` / `planBackfill` / `listSegments` / …) needs an operator API key from [bsky.network/account](https://bsky.network/account) — not a PDS JWT. Pass `JETSTREAM_API_KEY` (or `JETSTREAM_ARCHIVE_TOKEN` / `~token`) as the raw key. This library does not invent one. `require_archive_token` fails closed before HTTP. Self-hosted Jetstream needs no key.
+
+`examples/jetstream_archive.ml` is offline wiring.
+
+### Phone, contacts, and push
+
+Client for hosted Bluesky phone verification, contact import, and push registration. It does not send SMS and does not start an APNs/FCM gateway.
+
+- **Contacts.** Password sessions use `Contact.get_matches` / `import_contacts` through the PDS. OAuth mints AppView service-auth and calls `*_service` on `public.api.bsky.app`.
+- **SMS.** `Contact.start_phone_verification` → `verify_phone` → `import_contacts` is Bluesky-hosted SMS. Live hops skip unless `ATP_PHONE=1` and `ATP_PHONE_NUMBER` is an E.164 number you own. `Temp.request_phone_verification` is a different privileged signup-SMS client and is also not faked.
+- **Push.** `Notification.register_push` takes a caller `serviceDid`, device token, platform (`ios` / `android` / `web`), and `appId`. Official Bluesky push is closed to the official app.
+
+`examples/contacts_production.ml` is offline wiring.
+
+## What this package does not host
+
+These are hosted products this client talks to, not missing protocol cores. The client paths above are implemented; the **servers** are not.
+
+- **HTTPS `client-metadata.json` and the browser redirect** — your application hosts them. The library builds the document and drives authorize → code → token.
+- **Tap** — `Repo_sync` is the indexer library. This repo does not fake a Tap host.
+- **Video transcoder** — talk to `video.bsky.app`. No local transcoder.
+- **OSS chat** — `@atproto/dev-env` 0.6.4 does not start one (`ozone.chatUrl` = `localhost:2590`, “must run separate chat service”). Talk to `api.bsky.chat`.
+- **Jetstream archive key** — the operator supplies `JETSTREAM_API_KEY`. Live subscribe stays unauthenticated.
+- **SMS / phone-verification gateway** — hosted Bluesky SMS only. `requestPhoneVerification` is not faked.
+- **APNs/FCM** — official Bluesky push is closed to the official app; third-party clients host their own gateway.
+- **Spaces** — `Lt_hash`, `At_uri.Space`, `Space_commit`, `Space_credential`, `Space_xrpc`, and `Space_sync` implement draft proposal [0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md). They are **experimental**, not a stable product API. Deferred: `com.atproto.simplespace.*`, `space:` OAuth scopes, proposal `registerNotify` `repo`. Live hops skip unless `ATP_SPACE=1` and `ATP_SPACE_HOST` names a real host. This repo does not fake a space host.
+
+Official lexicons are pinned at [`f0d4877a`](https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0). CI `@lexicon-coverage` fails if that pin grows and a public client NSID lacks a helper (or an explicit skip). That gate is not `dune runtest` / opam `with-test`. Hosted-only *servers* are not skip reasons.
+
+## Development
 
 ```shell
 opam install . --deps-only --with-test
@@ -92,16 +193,13 @@ dune build
 dune runtest
 ```
 
-`dune build` also typechecks `examples/offline.ml` against the current public API (no network, no credentials). `dune runtest` executes that example plus `examples/oauth_https_metadata.ml`, `examples/chat_production.ml`, and `examples/video_production.ml`. A release-style build (what `opam install` / a dependent sees) is `dune build -p atproto` and `dune runtest -p atproto`. opam `with-test` runs those unit tests; official NSID coverage is CI-only (`dune build @lexicon-coverage`, not `@runtest`).
+`dune build` typechecks `examples/offline.ml` against the public API (no network). `dune runtest` also runs the offline production sketches. A release-style build is `dune build -p atproto` and `dune runtest -p atproto`. Live Bluesky tests that need credentials skip unless `ATP_AUTH` is a real `email:app-password` pair (placeholders in `sample.env` do not count). Public-network tests (handle resolve, PLC, `getLatestCommit`, `subscribeRepos`, AppView reads) run without auth.
 
-Live Bluesky tests that need credentials are skipped unless `ATP_AUTH` is set to a real `email:app-password` pair (placeholder values in `sample.env` do not count). Public-network tests (handle resolve, PLC directory, `getLatestCommit`, `subscribeRepos`, AppView feed/search/labeler reads) run without auth and skip only if the request itself fails.
+### Local AT Protocol network
 
-## Local AT Protocol network (PDS + AppView + Ozone)
-
-CI and `make test-pds` start Bluesky's official OSS local network — published [`@atproto/dev-env@0.6.4`](https://www.npmjs.com/package/@atproto/dev-env) (`TestNetwork.create()`, the same stack as `make run-dev-env` in [bluesky-social/atproto](https://github.com/bluesky-social/atproto)). This is a **separate** GitHub Actions job on the runner VM (Docker and Node >= 22 are available there). The existing `build` job stays inside `ocaml/opam:ubuntu-22.04` and does not start Docker.
+`make test-pds` starts Bluesky’s official [`@atproto/dev-env@0.6.4`](https://www.npmjs.com/package/@atproto/dev-env) — PLC (`:2582`), PDS (`:2583`), AppView (`:2584`), Ozone (`:2587`). Chat, video, Tap, SMS, and push are **not** in that stack.
 
 ```shell
-# start Postgres+Redis + official dev-env, then run PDS / AppView / Ozone tests
 make test-pds
 
 # or step by step
@@ -110,338 +208,45 @@ make test-pds
 eval "$(./scripts/local-atproto.sh env)"
 export ATP_REQUIRE_LOCAL_PDS=1
 dune exec -- test/test_local_pds.exe
-dune exec -- test/test_local_appview.exe
-dune exec -- test/test_local_ozone.exe
-dune exec -- test/test_local_oauth.exe
-
 ./scripts/local-atproto.sh down
 ```
 
-`scripts/local-pds.sh` is a back-compat wrapper around `scripts/local-atproto.sh`.
+Point the client at the stack with `ATP_SCHEME=http`, `ATP_HOST=localhost:2583`, `ATP_APPVIEW_HOST=localhost:2584`, `ATP_OZONE_HOST=localhost:2587`, `ATP_AUTH=alice.test:hunter2`. Mock accounts come from official `generateMockSetup` (`alice.test` / `bob.test` / ozone admin `admin-mod.test`). If the network is up, a failed protocol call **fails the test**; the suite skips only when it is not aimed at a local host.
 
-Compose file for Postgres/Redis: `docker/dev-env/compose.yaml` (official `postgres:14.4-alpine` on `5433` and `redis:7.0-alpine` on `6380`, matching atproto `packages/dev-infra`). The Node process then starts:
+OAuth against this TestNetwork (loopback metadata, PAR, DPoP, service-auth) is covered by `test/test_local_oauth.ml`. See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
-| Service | Port | Package |
-| --- | --- | --- |
-| PLC | `http://localhost:2582` | `@did-plc/server` |
-| PDS | `http://localhost:2583` | `@atproto/pds` |
-| AppView | `http://localhost:2584` | `@atproto/bsky` (`app.bsky.*`) |
-| Ozone | `http://localhost:2587` | `@atproto/ozone` (`tools.ozone.*`) |
-| bsync | (internal) | `@atproto/bsync` |
-| introspect | `http://localhost:2581` | dev-env |
-
-Mock accounts from official `generateMockSetup` (not production Bluesky credentials):
-
-- `alice.test` / `hunter2` and `bob.test` / `hunter2` (the suite waits until AppView has indexed both)
-- Ozone admin: `admin-mod.test` / `admin-mod-pass` plus the ozone service DID (`ATP_OZONE_DID`)
-- Ozone `ADMIN_PASSWORD` in this stack is `admin-pass`; tests use the PDS session + `atproto-proxy` (the library's existing path)
-
-Point the client at the local stack with:
-
-- `ATP_SCHEME=http`
-- `ATP_HOST=localhost:2583`
-- `ATP_APPVIEW_HOST=localhost:2584`
-- `ATP_OZONE_HOST=localhost:2587`
-- `ATP_AUTH=alice.test:hunter2`
-
-`test/test_local_oauth.ml` serves a loopback `client-metadata.json`, discovers the PDS authorization server (`.well-known/oauth-protected-resource` + `oauth-authorization-server`), and runs PAR + DPoP against this `@atproto/dev-env` 0.6.4 oauth-provider. Official `http://localhost?redirect_uri=…` is used when the AS rejects a hosted `http://127.0.0.1` client_id (HTTPS is required by the spec except that loopback exception). `Oauth.form_encode` uses URI generic percent-encoding so a loopback `client_id` (`…&scope=atproto%20transition%3Ageneric`) is one form field; path-safe encoding would split on `&` and the AS would derive metadata with only the default `atproto` scope. Hosted `client-metadata.json` and the official loopback `client_id` query both declare `Oauth.default_scope` (`atproto transition:generic`); PAR requests that same string so `transition:generic` is not an undeclared scope. `GET /oauth/authorize` is a browser document navigation (`sec-fetch-mode: navigate`, `sec-fetch-dest: document`, `sec-fetch-site: none`); a bare GET is HTTP 400 HTML (`Missing sec-fetch-mode header`). With those headers the local AS returns HTTP 200 `__authorizeData` and sets `csrf-token`, `dev-id`, and `ses-id` (it does **not** mint a `code` on that GET — the login/consent SPA is still HTML). The library replays those **real** cookies on `/@atproto/oauth-provider/~api/sign-in` + `/consent` (`sec-fetch-mode: same-origin`, `Origin` / `Referer` = issuer, `x-csrf-token` matching the authorize cookie). Inventing a CSRF token is not a substitute. `alice.test` / `hunter2` complete sign-in and consent; consent returns `/oauth/authorize/redirect?code=…`. Token exchange, DPoP `getSession`, DPoP `getServiceAuth` (`aud` = `ATP_APPVIEW_DID`, `lxm` = `getTimeline` / `listNotifications`), refresh (when the AS issues a refresh token), and RFC 7009 revoke are then required (`ATP_REQUIRE_LOCAL_PDS=1`). Authed AppView still does not accept the DPoP access token or a `createSession` `at+jwt`; the client mints a service-auth JWT from the OAuth session and sends that Bearer to `:2584`. `test_live_oauth_ozone` repeats that login as `admin-mod.test` / `admin-mod-pass`, asserts DPoP + `atproto-proxy` `emitEvent` is rejected (`DPoP requests cannot be proxied`), then mints `getServiceAuth` (`aud` = `ATP_OZONE_DID`, `lxm` = `tools.ozone.moderation.emitEvent`) and POSTs `emitEvent` to `:2587` with that Bearer (`Ozone.emit_event_service_typed`). If AppView or Ozone rejects that hop (or the NSID is not served), only that hop is skipped — token assertions stay required. A public HTTPS client-metadata host is still application-level: `Oauth.public_https_metadata` / `start_browser_login` / `complete_browser_login` build and drive the authorize → code → token path; the app publishes the HTTPS document and receives the browser redirect.
-
-`test/test_local_pds.ml` hits PDS `com.atproto` identity / session / repo / blob / sync / moderation, plus `refreshSession` (refreshJwt Bearer) / `deleteSession` / `getAccountInviteCodes` and a local PLC directory create/update. `Identity.resolve_did` / `resolve_identity` call the XRPC first, then fall back to local PLC (`PLC_ORIGIN`, default `http://localhost:2582` on a local host) because `@atproto/pds` 0.5.x returns `MethodNotImplemented` for those two queries. `test/test_local_appview.ml` hits AppView `app.bsky.actor` / `feed` / `graph` / `notification` / `labeler` / `unspecced` (public reads on `:2584` with no session). Authenticated AppView APIs (`getTimeline`, `getMutes`, `listNotifications`) mint `com.atproto.server.getServiceAuth` (`aud` = AppView DID, `lxm` = the XRPC) and send that JWT to AppView — never the PDS `at+jwt` access token (`InvalidToken: Malformed token`). Extra AppView NSIDs (`getPosts`, `searchActors`, `searchPostsV2`, `getQuotes`, `getRelationships`, `getLists`, `getActorStarterPacks`, `getPreferences`, …) are called only when this AppView implements them. `test/test_local_ozone.ml` hits `tools.ozone.moderation.emitEvent` / `queryEvents` / `queryStatuses` / `getRepo` / `getRecord` / `searchRepos` / `getEvent` / `getReporterStats`, `tools.ozone.server.getConfig`, `tools.ozone.team.listMembers`, `tools.ozone.communication.listTemplates`, `tools.ozone.set.querySets` / `getValues`, `tools.ozone.queue.listQueues`, `tools.ozone.report.queryReports`, and `com.atproto.label.queryLabels` via the PDS + `atproto-proxy` (direct Ozone rejects `at+jwt`). OAuth clients cannot send DPoP through that proxy; `test_live_oauth_ozone` uses `getServiceAuth` + `Ozone.emit_event_service_typed` on `:2587` instead. If the local network is up, a failed protocol call **fails the test**. The suite skips only when it is not aimed at a local host (typical laptop `dune runtest` without Docker/Node). In CI, `ATP_REQUIRE_LOCAL_PDS=1` is set and the stack is required.
-
-`com.atproto.server.createAppPassword` is sent as the official POST `{ "name" }` (optional `privileged`) with `Authorization: Bearer`. This `@atproto/pds` 0.5.x TestNetwork build still 500s (`InternalServerError`) on that valid call; the local PDS suite asserts that isolated 500 so the rest of the file still runs.
-
-### Chat (`chat.bsky.*`)
-
-Pinned `@atproto/dev-env@0.6.4` `TestNetwork.create()` does **not** start a `chat.bsky.app` DM service. `packages/dev-env/src/bin.ts` sets `ozone.chatUrl` to `http://localhost:2590` with the comment `must run separate chat service`. There is no official OSS chat backend in that revision, so this repo does not fake one.
-
-The **production path** is the hosted Bluesky chat service (`did:web:api.bsky.chat#bsky_chat`, host `api.bsky.chat` / `ATP_CHAT_HOST`). See [Production chat](#production-chat-hosted-chatbsky) below. Live DM calls skip unless `ATP_AUTH` has a chat/DM OAuth scope (or `ATP_CHAT=1`).
-
-### Video (`app.bsky.video.*`)
-
-Pinned `@atproto/dev-env@0.6.4` `TestNetwork.create()` does **not** start a `video.bsky.app` transcoder. This repo does not fake one.
-
-The **production path** is the hosted Bluesky video service (host `video.bsky.app` / `ATP_VIDEO_HOST`). See [Production video](#production-video-hosted-appbskyvideo) below. Live `getUploadLimits` skips unless `ATP_AUTH` is a real credential.
-
-## What this library covers
-
-| Area | Module | Notes |
-| --- | --- | --- |
-| Session / JWT | `Auth`, `Session` | `createSession` URL uses `ATP_HOST` + `BASE_ENDPOINT`; optional `authFactorToken` / `allowTakendown`; typed `getSession` (`emailConfirmed`, `active`, `status`) via `Client.get_text`; `refreshSession` / `deleteSession` via `Client.post_json` with Bearer `refreshJwt` (empty delete output stays `""`) |
-| AppView actor | `Actor` | Profiles, search, suggestions via `Client.get_json` (`get_profile` / `get_profiles` / `get_suggestions` / `search_actors` / `search_actors_typeahead` share `get_profile_body` / `get_profiles_body` / `get_suggestions_body` / `search_actors_body`), get/put preferences (all current `app.bsky.actor.defs#preferences` kinds). Profile views parse pronouns/website, `associated` (chat / germ / activitySubscription), verification, status, `joinedViaStarterPack`, and viewer scoped mutes / knownFollowers |
-| AppView feed | `Feed` | Timeline, `getPostThread` (`threadViewPost` / `notFoundPost` / `blockedPost`, optional parent, top-level embed + quote/bookmark counts, `viewer.knownLikers`), `getAuthorFeed` (`filter` knownValues `posts_with_replies` / `posts_no_replies` / `posts_with_media` / `posts_and_author_threads` / `posts_with_video` + `includePins` + public `get_author_feed_page`), session `get_author_feed` / `get_likes` / `get_post_thread` / `get_posts` / `get_reposted_by` / `get_timeline` / `get_feed_skeleton` via `Client.get_json` / `Client.get_text` sharing query-pair helpers, leftover `get_author_feed` / `get_author_feed_page` sharing `get_author_feed_body` and `get_feed_skeleton` / `get_feed_skeleton_parsed` sharing `get_feed_skeleton_body`, leftover AppView `get_feed` / `get_list_feed` / `get_actor_feeds` / `search_posts` sharing `get_feed_body` / `get_list_feed_body` / `get_actor_feeds_body` / `search_posts_body`, leftover `search_posts_v2` / `get_quotes` / `get_actor_likes` sharing `search_posts_v2_body` / `get_quotes_body` / `get_actor_likes_body`, reply `grandparentAuthor`, generators, `searchPosts` + `searchPostsV2` (array filters, `detectedQueryLanguages`), quotes, list feed, interactions |
-| AppView graph | `Graph` | Follows/blocks/mutes (including `muteActor` `onlyReposts` / `onlyQuoteposts` scoped mutes; `mute_actor_body` / `unmute_actor_body`; `mute_actor` / `unmute_actor` via `Client.post_json` keep `string`; `mute_actor_list_body` / `unmute_actor_list_body` / `mute_thread_body` / `unmute_thread_body`; `mute_actor_list` / `unmute_actor_list` / `mute_thread` / `unmute_thread` share those bodies via `Client.post_json`), leftover AppView `get_list` / `get_lists` / `get_actor_starter_packs` / `search_starter_packs` / `search_starter_packs_v2` / `get_relationships` / `get_known_followers` sharing `get_list_body` / `get_lists_body` / `get_actor_starter_packs_body` / `search_starter_packs_body` / `get_relationships_body` / `get_known_followers_body`, lists, starter packs (`listItemsSample` / official `feeds` / `labels`), `searchStarterPacks` + `searchStarterPacksV2`, `getListsWithMembership` / `getStarterPacksWithMembership`, relationships (`blockedByList` / `blockingByList`), known followers |
-| Bookmarks | `Bookmark` | `createBookmark` / `deleteBookmark` / `getBookmarks`; bookmark `item` is the feed `#postView` / `#notFoundPost` / `#blockedPost` union |
-| Jetstream | `Jetstream` | v2 live tail, collection/DID/kind filters, seq + unix-µs cursors, reconnect/dedupe, v1 `/subscribe` compat; v2 `subscribe` / `subscribe_one` offer **`Sec-WebSocket-Protocol: xrpc.v1.json`** (RFC 6455 §4.1 echo required; unoffered connections unchanged); **live dict-zstd** `subscribeEvents` (`~compress:true`: v2 `zstdDictionary=<id>`, v1 `compress=true` / `Socket-Encoding: zstd`; `getZstdDictionary` over HTTPS with a checked-in production-dict fallback); v2 is server-push only (no client data frames); Network Replay planner + archive HTTP (`JETSTREAM_API_KEY` / `JETSTREAM_ARCHIVE_TOKEN` or `~token` → `Authorization: Bearer`; skippable unauthenticated path for public/self-hosted; `require_archive_token` / `~require_token` if the operator needs a key and has not supplied one; no invented key); `.jss` v1 header / block-index / columnar decode (`~decompress` injection plus built-in `decompress_zstd`) |
-| Video | `Video` | `getJobStatus`, `getUploadLimits` / `get_upload_limits_service`, byte upload (`uploadVideo` URL + POST), multipart `startUpload` / `uploadPart` / `finishUpload` / `abortUpload` / `getUploadStatus`, service-auth audience (`pds_audience` from session `#atproto_pds` else `atp_host`; `uploadBlob` lxm; `upload_service_auth_body` / `mint_upload_token`), query-pair helpers (`get_job_status_body` / `get_upload_status_body` / `upload_video_body`), injectable job poll, `video_embed_json` / `embed_of_blob` / `embed_of_job` for `Records.post`, `part_slice` for multipart. Client only — no hosted transcoder |
-| Unspecced | `Unspecced` | Popular generators, leftover search skeletons sharing `search_posts_skeleton_body` / `search_actors_skeleton_body` / `search_starter_packs_skeleton_body`, leftover `get_suggestions_skeleton` / `get_post_thread_v2` / suggested-users sharing `get_suggestions_skeleton_body` / `get_post_thread_v2_body` / `get_suggested_users_body` / `get_suggested_users_skeleton_body`, trending topics + `getTrends` / `getTrendsSkeleton`, tagged suggestions, unspecced age-assurance state, suggestion / feed / starter-pack / onboarding / discover / explore / seeMore skeletons, `getPostThreadV2` / `getPostThreadOtherV2`, config |
-| Labeler | `Labeler` | `app.bsky.labeler.getServices`; `policies_to_json` (`labelValues` / optional `labelValueDefinitions`) for `Records.labeler_service ~policies` |
-| Chat / DMs | `Chat` | `chat.bsky.convo.*` including typed message facets/reactions/embeds, **system message data** (`addedBy` / `removedBy` / `approvedBy` / `unlockedBy` / `lockedBy`), `getConvoMembers` (`role` / `addedBy` / `chatDisabled` / `kind` / leftover `profileViewBasic` avatar / associated / viewer / labels / createdAt / verification), `getMessages.relatedProfiles`, `replyTo` union (`messageView` / `deletedMessageView` / `messageBeforeUserJoinedGroupView`), group convo leftover fields (`createdAt` / `joinLink` / `joinRequestCount` / `memberLimit`), `listConvoRequests` `convoView` / `joinRequestConvoView` union, `getLog` message / relatedProfiles / member; `chat.bsky.group` create/add/remove/edit + join links / join requests / mutual groups; notification prefs; actor status / declaration / `chat.bsky.actor.exportAccountData` / delete; moderation views + `subscribeModEvents`; production hosted path: `atproto-proxy` from default `did:web:api.bsky.chat#bsky_chat`, session `#bsky_chat`, or `ATP_CHAT_DID`; query-pair helpers (`list_convos_body` / `get_convo_body` / `get_messages_body`) shared with service-auth `list_convos_service` / `get_convo_service` / `get_messages_service` / `send_message_service` on `api.bsky.chat` (`Chat.service_aud` / `ATP_CHAT_HOST`; DPoP cannot be proxied); `Oauth.default_chat_scope` / `Chat.scope_has_chat` |
-| Ozone | `Ozone` | `tools.ozone.moderation.*` including typed event/subject unions (`modEventMuteReporter` / `ageAssurance*` / `accountEvent` / `scheduleTakedownEvent` / leftover `modEventView` `creatorHandle` / `subjectHandle` / `modTool`, leftover `subjectStatusView` mute/takedown/appeal/age-assurance fields) plus typed `emit_event` encode (`event_to_json` / `subject_to_json` / `mod_tool_to_json` / `emit_event_typed` / `emit_event_service_typed`; raw Yojson `emit_event` unchanged), typed `create_activity` encode (`report_activity_to_json` / `create_activity_typed` / `create_activity_typed_body`; raw Yojson `create_activity` unchanged), subjects/repos/records, timeline, typed `get_account_preferences` (`Actor.preference` list / `app.bsky.actor.defs#preferences`, including `interestsPref.updatedAt`), reporter stats, typed `schedule_action` encode (`schedule_action_typed` / `schedule_action_typed_body`; optional typed `mod_tool`; raw Yojson `schedule_action` unchanged), `list_scheduled_actions` Yojson body (`list_scheduled_actions_body`; `list_scheduled_actions` shares that body), `cancel_scheduled_actions` Yojson body (`cancel_scheduled_actions_body`; `cancel_scheduled_actions` shares that body), query_events / query_statuses query-pair helpers (`query_events_body` / `query_statuses_body`; `query_events` / `query_events_service` / `query_statuses` share those pairs), leftover query_reports / search_repos query-pair helpers (`query_reports_body` / `search_repos_body`; `query_reports` / `search_repos` share those pairs); plus communication templates (`create_template_body`; `update_template_body` shared with `update_template`; `delete_template_body` `{ "id" }`), sets (`upsert_set_body` / `add_set_values_body` / `delete_set_values_body`; callers share those bodies), settings (`upsert_option_body`; no invented `managerRole`), team (`update_member_body`; `update_member` shares that body), safelink (`query_safelink_rules_body`; `query_safelink_rules` shares that body), signature, verification, hosting history + `getConfig` (`appview` / `pds` / `blobDivert` / `chat` / `viewer.role` / `verifierDid`); `tools.ozone.queue.*` (list/create/update/delete, moderator assign + `assignmentView.moderator` + `assign_queue_moderator_body` / `unassign_queue_moderator_body`, `routeReports` + `route_reports_body`) and `tools.ozone.report.*` (query/get, activities, assignments, stats, close/reassign); password sessions send `atproto-proxy` through the PDS; OAuth uses `getServiceAuth` + `emit_event_service` / `emit_event_service_typed` / `query_events_service` / `get_config_service` on the Ozone host |
-| Admin | `Admin` | `com.atproto.admin` subject status, account info (`inviteNote` / `invitedBy` / `threatSignatures`), invites, email |
-| Repo writes | `Repo`, `Records` | `createRecord` / `putRecord` / `deleteRecord` / `applyWrites` bodies via `Client.post_json` (`post_repo_write` keeps `string`); Yojson `create_record_json` / `put_record_json` (`create_record_body` / `put_record_body`; string `create_record` / `put_record` unchanged); `delete_record_body` + `apply_writes_parsed` (string `delete_record` / `apply_writes` unchanged); `blob_ref_to_json` (`parse_blob_ref` / `upload_blob` unchanged); string `describe_repo` / `get_record` / `list_records` via `Client.get_text` sharing `describe_repo_body` / `get_record_body` / `list_records_body` with typed parsers; `list_missing_blobs` via `Client.get_json` (`list_missing_blobs_body`); binary `upload_blob` / `import_repo` stay Cohttp; builders for post/like/repost/follow/block/listblock/list/listitem/starterpack/`referencelistoptout`/profile/status/contentVisibility/verification/threadgate/postgate/generator/labeler/notification declaration / `com.atproto.lexicon.schema` |
-| Server | `Server` | session `describe_server` / `list_app_passwords` / `get_account_invite_codes` via `Client.get_text` (`get_account_invite_codes_body`; empty query shared with `describe_server_parsed`); `create_account` via `Client.post_json` sharing `create_account_body`; `create_invite_codes` shares `create_invite_codes_body`; describe server (typed), app passwords (`privileged` + typed `#appPassword` parse), invites (`createInviteCode` `forAccount`, `createInviteCodes` `forAccounts`), `reserveSigningKey`, account activate/status (`activateAccount` / `deactivateAccount` / typed `checkAccountStatus` including `repoCommit` / `repoRev` / `repoBlocks`), `createAccount` extras (`did`, `verificationCode` / `verificationPhone`, `plcOp`), `getServiceAuth` via `Client.get_json` (`get_service_auth_body`; aud may be `did#service`), email confirm/update (`confirmEmail`, `requestEmailConfirmation`, `requestEmailUpdate`, `updateEmail`). Procedures (`createInviteCode(s)`, `revokeAppPassword`, `resetPassword`, `deleteAccount`, `requestPasswordReset`, `requestAccountDelete`) POST JSON bodies per lexicon (they previously used GET) |
-| Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | resolve + typed `resolveDid` / `resolveIdentity` (`#identityInfo`) via `Client.get_json` (`resolve_handle` / `resolve_did` / `resolve_identity` share `resolve_handle_body` / `resolve_did_body` / `resolve_identity_query`). When the host returns `MethodNotImplemented` (PDS 0.5.x and current entryway), the client falls back to PLC (`PLC_ORIGIN` or `http://localhost:2582` on a local PDS) / `did:web` and wraps `{ didDoc }` |
-| PLC chain | `Did_plc` | Genesis DID, prev CID links, p256 **and k256** ECDSA (low-S, IEEE P1363). Directory URLs accept a host or a full origin (`http://localhost:2582`); `PLC_ORIGIN` overrides the default `https://plc.directory`. Create/update/tombstone operation builders, directory `POST /{did}`, `GET /{did}/data`, and `GET /{did}/log/audit` |
-| Sync | `Sync` | `getLatestCommit`, `getRepo` (CAR), public `getBlocks` (bytes/CAR), `listBlobs`, `listRepos`, host/repo status |
-| CID / CAR | `Cid`, `Car`, `Dag_cbor` | CIDv1 (including SHA-256 `Cid.create`) + CARv1, blessed CID check, Sync 1.1 streamable pre-order, IPLD JSON ↔ DAG-CBOR (`of_yojson` / `to_yojson`; `$link` / `$bytes`) |
-| MST | `Mst` | Layer/prefix rules, node parse, CID verify, lookup, insert/delete/walk, firehose-diff inversion **and** forward apply, `diff_ops` (prev tree → next tree), p256/k256 commit sign+verify, pre-order blocks, collection-range proofs |
-| Repo sync (TAP-like) | `Repo_sync` | Library-ready indexer / backfill (not a hosted Tap): open/verify repo CAR, walk records as IPLD JSON (`walk` / `walk_json` / `record_json`), `getRecord` inclusion proof (`export_record_proof` / `verify_record_proof` / partial CAR), record-table apply of firehose ops, `#sync` desync, MST-level `apply_commit_tree`, Sync 1.1 pre-order export + collection-subset CAR, offline `write_signed_repo` (JSON → DAG-CBOR → MST → signed commit → CAR). `examples/repo_sync_indexer.ml` |
-| TID | `Tid` | Record-key / commit-rev identifiers (base32-sortable, official syntax) |
-| AT URI | `At_uri` | public `at://` parse / serialize; experimental proposal-0016 space / permissioned-record URIs (`At_uri.Space`, first path segment literal `space`) |
-| Lexicon | `Lexicon` | Parse lexicon-1 JSON (parameters + procedure input/output schemas + `permission-set`), `to_ocaml` codegen (unions emit polymorphic variants), JSON validate, `resolveLexicon` client, small bundled official lexicon documents including `app.bsky.graph.referencelistoptout` and official OAuth permission-sets |
-| Temp | `Temp` | `com.atproto.temp.checkHandleAvailability` (available / suggestions union), `checkSignupQueue`, `dereferenceScope`, plus privileged `addReservedHandle` / `requestPhoneVerification` / `revokeAccountCredentials` clients (no invented operator session). Deprecated `fetchLabels` remains `Label.query_labels` |
-| Firehose | `Firehose`, `Websocket` | RFC 6455 client (`wss://` and local `ws://`) + `subscribeRepos` frame decode (`#commit`/`#sync`/`#identity`/`#account`/`#info`) |
-| OAuth / DPoP | `Oauth`, `Oauth_scope` | PKCE S256, DPoP ES256 + nonce (RFC 9449 `htu` without query/fragment, random `jti`, RFC 7638 `dpop_jkt`), client metadata (`logo_uri` / `tos_uri` / `policy_uri`), **public HTTPS client-metadata** (`https_client_id` / `public_https_metadata` / `validate_https_metadata` / `metadata_document` / `metadata_http_response` / `fetch_client_metadata`; HTTP 200 + `application/json`; `client_id` in the document must match the fetch URL), production browser login glue (`start_browser_login` / `complete_browser_login`: discover → PAR → authorize URL → parse redirect → token exchange; no hosted login UI), PAR (`prompt=create` signup) / token / refresh / RFC 7009 revoke, `require_request_uri_registration`, resource-server `use_dpop_nonce` retry, `expect_sub` / `expires_at`; origin-aware URLs + loopback HTTP issuer; live Cohttp GET/POST (DPoP-Nonce + cookies); oauth-provider `~api` sign-in/consent helpers (real authorize CSRF/device cookies, no invented CSRF); DPoP XRPC (`xrpc_url` / `get_json_dpop` / `xrpc_post_dpop` / `get_service_auth`) so a client mints AppView, Ozone, or hosted-chat service-auth from the OAuth token and sends it with `Client.get_json ~bearer` / `Ozone.emit_event_service_typed` / `Chat.list_convos_service`; DPoP cannot be proxied; `default_chat_scope` / `Oauth_scope.has_chat` / `full_chat_client_scope` for DM grants (`transition:chat.bsky` or `include:chat.bsky.authFullChatClient`; `default_scope` is not enough); local TestNetwork discovery / hosted loopback metadata / PAR / token / getSession / getServiceAuth / AppView getTimeline / Ozone emitEvent / refresh / revoke; granular scope grammar (`repo:`/`rpc:`/`blob:`/`include:`/`transition:`) + official `app.bsky.auth*` / `chat.bsky.authFullChatClient` permission-set parse/expand |
-| Labels | `Label` | `queryLabels` via `Client.get_json` (`query_labels` / `query_labels_parsed` share `query_labels_body`) + label / query parse (`ver`, `exp`) + `#selfLabels` + typed `#labelValueDefinition` parse/encode (`label_value_definition_strings_to_json` / `label_value_definition_to_json`; `severity` / `blurs` / `locales`; optional `defaultSetting` / `adultOnly`); `subscribeLabels` unchanged |
-| XRPC headers | `Xrpc` | `atproto-proxy`, accept-labelers, rate-limit, `x-atproto-bsky-topics` (deprecated `x-bsky-topics`); service-auth JWT mint/verify (ES256/ES256K, `kid`/`jti`/`iat`/`lxm`, `did#service` aud, replay cache) |
-| Errors | `Error` | XRPC `{error, message}` including rate limits |
-| Syntax | `Syntax` | Handle, DID, NSID, record-key, datetime, language validators |
-| Drafts | `Draft` | `app.bsky.draft` create/get/update/delete + typed draft / embed / threadgate / postgate builders plus typed create/update encode (`draft_to_json` / `create_draft_typed` / `update_draft_typed` / `*_typed_body`; raw Yojson `create_draft` / `update_draft` unchanged) |
-| Contacts | `Contact` | `app.bsky.contact` phone verify, import, matches, dismiss, sync status, remove data; leftover `get_matches_body` (`limit` / `cursor`; `get_matches` / `get_matches_appview` / `get_matches_service` share those pairs); AppView service-auth `get_matches_appview` / `get_sync_status_appview`; OAuth `*_service` on AppView host (`import_contacts_service` / `start_phone_verification_service` / `verify_phone_service` / …); `ATP_PHONE` / `ATP_PHONE_NUMBER` skip gates. Client only — no SMS gateway |
-| Age assurance | `Ageassurance` | `app.bsky.ageassurance` begin / getConfig / getState + region-rule union; stash `#event` parses `initIp` / `initUa` / `completeIp` / `completeUa` |
-| Embeds / facets | `Embed`, `Facet` | Images, external (`readingTime`, `associatedProfiles`, source theme RGB, `associatedRefs`), record, recordWithMedia, video (`presentation` `default`/`gif`), **gallery**, record `#view` union; `getEmbedExternalView`; mention / link / tag parse **and serialize** |
-| Notifications | `Notification` | All `listNotifications` known reasons; `listNotifications` query-pair helper (`list_notifications_body`; `list_notifications` / `list_notifications_page` share those pairs; currently sent fields only: optional `reasons` / `priority` / `cursor` / `seenAt` / `limit`); leftover `list_activity_subscriptions_body` (`limit` / `cursor`); `getUnreadCount` via `Client.get_json`; `updateSeen` Yojson `update_seen_body` via `Client.post_json` (empty output stays `""`); `putPreferences` v1 `put_preferences_body` (`priority`) and `putActivitySubscription` `put_activity_subscription_body` (`subject` / `activitySubscription`) via `Client.post_json`; prefs-v2; `register_push_body` / `unregister_push_body` (`serviceDid` / `token` / `platform` knownValues `ios` / `android` / `web` / `appId`; optional `ageRestricted`); optional `atproto-proxy` (`effective_push_proxy` / `ATP_PUSH_DID` / `Xrpc.notif_proxy`); `ATP_PUSH` skip gate. Client only — no APNs/FCM |
-| User reports | `Moderation` | `com.atproto.moderation.createReport` (strongRef / repoRef, optional `modTool`, reason-type constants; Yojson `create_report_body_from_strong_ref` / `create_report_body_from_repo_ref`; string `create_report_data_from_*` unchanged) |
-| Crypto / codecs | `K256`, `Base32`, `Base58`, `Base64url`, `Hash`, `Varint`, `Lt_hash`, `Space_commit`, `Space_credential` | secp256k1, multibase, CID/CAR varints; experimental proposal-0016 LtHash, deniable signed commits, and space-credential JWT / DPoP helpers (not a spaces product API) |
-| Spaces XRPC (experimental) | `Space_xrpc` | draft `com.atproto.space.*` query/JSON builders + `Client.get`/`post` wrappers (credential exchange, permissioned repo read/write, sync queries, notify). Reuses `Space_credential` DPoP. Live hops skip unless `ATP_SPACE=1` and `ATP_SPACE_HOST`. Named `Space_xrpc` so it does not collide with `At_uri.Space`. Not a spaces product; no host is faked |
-| Spaces sync apply (experimental) | `Space_sync` | offline `listRepoOps` apply (`apply_op` / `apply_listed`) + two-root permissioned CAR `encode` / `apply` (commit then DRISL index, then records). Named `Space_sync` so it does not collide with `At_uri.Space`. Not a spaces product; no host is faked |
-| HTTP helpers | `App`, `Client`, `Cohttp_client`, `Http_client`, `Http_method`, `Request`, `Response`, `User` | Endpoint URLs, shared XRPC GET/POST (Cohttp) + AppView `post_json_appview` service-auth (password `at+jwt`, or OAuth DPoP `Oauth.get_service_auth` + `get_json ~bearer`) + Ozone host/DID env (`ozone_host_from_env` / `ozone_did_from_env`), **HTTP/2 TLS** GET/POST/PUT/DELETE/PATCH via `Http_client` (IPv6 + `Client.get_json_h2` / `Client.post_json_h2` for public HTTPS). Requires HTTPS + ALPN `h2` |
-| Sites | `Site` | Official `site.standard` records: document, publication, theme.basic/color, graph recommend + subscription plus typed record encodes (`document_to_json` / `publication_to_json` / `recommend_to_json` / `subscription_to_json`; siblings of `theme_to_json` / `contributor_to_json` / `parse_*`; lexicon fields only) |
-| Germ Network | `Germnetwork` | `com.germnetwork.declaration` record (`$bytes` keys, `messageMe` policy) |
-
-## Production OAuth (HTTPS client-metadata)
-
-AT Protocol identifies a public client by an HTTPS `client_id` that **is** the URL of a JSON metadata document. This library builds, validates, and serializes that document and drives the browser login path. It does **not** host the file or a login UI.
-
-1. Build the document (`Oauth.public_https_metadata` / `Oauth.validate_https_metadata`). `client_id` must be `https://host/path` with no port; web `redirect_uris` must be HTTPS on the same origin. Native clients may also use `http://127.0.0.1` / `http://[::1]` or a reverse-domain custom scheme (`com.example.app:/callback`).
-2. Publish it at that URL over HTTPS as HTTP 200 with `Content-Type: application/json` (`Oauth.metadata_document` / `Oauth.metadata_http_response`). The body's `client_id` must exactly match the fetch URL. See `examples/client-metadata.json` and the tiny server sketch in `examples/oauth_https_metadata.ml`.
-3. Discover the PDS authorization server, PAR, and redirect the browser to the authorize URL: `Oauth.start_browser_login` (PKCE S256 + DPoP + `state`).
-4. On the redirect (`?code=&state=&iss=`), `Oauth.complete_browser_login` checks `state` / `iss` and exchanges the code for a DPoP token. Authed AppView / Ozone still use `Oauth.get_service_auth`, not the DPoP access token.
-
-Loopback `http://localhost?redirect_uri=…` and local TestNetwork stay the development path. `Auth.createSession` / `make_auth_token_request` stay Cohttp password sessions.
-
-## Production chat (hosted `chat.bsky.*`)
-
-This library is a **client** for Bluesky hosted chat. It does not start or stub a chat service. Official TestNetwork still has no OSS chat backend.
-
-**Scopes.** `Oauth.default_scope` (`atproto transition:generic`) is not enough for DMs. A chat-capable public client should declare `Oauth.default_chat_scope` (`atproto transition:generic transition:chat.bsky`) on the HTTPS metadata document and the PAR request. The granular alternative is `Oauth_scope.full_chat_client_scope` (`atproto include:chat.bsky.authFullChatClient`). The bundled permission-set in this pin expands to `listConvos` / `sendMessage` plus `chat.bsky.actor.declaration` — not every leftover `chat.bsky.*` NSID. Privileged app-passwords carry a chat/DM grant on the `createSession` JWT; regular app-passwords do not. `Chat.scope_has_chat` / `Oauth_scope.has_chat` detect `chat.bsky`, `bsky_chat`, or `authFullChatClient`. Live tests skip unless that predicate is true or `ATP_CHAT=1`.
-
-**Proxy precedence** (`Chat.effective_proxy`): explicit `~proxy`, else the session DID-document `#bsky_chat` service (`did:web:<host>#bsky_chat`), else `ATP_CHAT_DID`, else `did:web:api.bsky.chat#bsky_chat`.
-
-**Password session.** Privileged `createSession` + `Chat.list_convos` / `get_messages` / `send_message` through the PDS with `atproto-proxy`.
-
-**OAuth / DPoP.** DPoP cannot be proxied (same rule as Ozone). After `Oauth.complete_browser_login`:
-
-1. Mint `com.atproto.server.getServiceAuth` with DPoP (`Oauth.get_service_auth`; `aud` = `Chat.service_aud` / `did:web:api.bsky.chat`, `lxm` = the `chat.bsky.*` NSID). Password sessions can mint the same JWT with `Client.get_service_auth`.
-2. Call `Chat.list_convos_service` / `get_convo_service` / `get_messages_service` / `send_message_service` on `Chat.default_host` (`api.bsky.chat` / `ATP_CHAT_HOST`) with that Bearer. Those helpers do **not** send `atproto-proxy`.
-
-`examples/chat_production.ml` is that wiring as an offline sketch (scopes, proxy, query/POST bodies, `getServiceAuth` aud/lxm). It does not hit the network and is not a hosted chat product.
-
-## Production video (hosted `app.bsky.video.*`)
-
-This library is a **client** for Bluesky hosted video. It does not start or stub a transcoder. Official TestNetwork still has no video service.
-
-**Service-auth.** `getServiceAuth` audience is `did:web:<pds-host>`, not `did:web:video.bsky.app`. Prefer the session DID document `#atproto_pds` endpoint (`Video.pds_audience`); entryway `ATP_HOST` is often `bsky.social`. `lxm` is `Video.upload_blob_lxm` (`com.atproto.repo.uploadBlob`), not `app.bsky.video.uploadVideo`. Recommended lifetime is `Video.recommended_exp` (1800s). Password sessions: `Video.mint_upload_token`. OAuth DPoP: `Oauth.get_service_auth` with the same aud / lxm / exp (DPoP cannot be sent as the video Bearer).
-
-**Limits.** `Video.get_upload_limits_service` (and session `get_upload_limits`, which mints that JWT) call `app.bsky.video.getUploadLimits` on `Video.default_host` (`video.bsky.app` / `ATP_VIDEO_HOST`). Bluesky-hosted accounts typically need a verified email; daily remaining videos/bytes come back on that response. This is not a local quota server.
-
-**Upload.** Small/typical clips: `Video.upload_video` (raw bytes, `Content-Type: video/mp4`) to `upload_video_url`. Larger files: multipart `start_upload` / `upload_part` / `finish_upload` (optional `abort_upload` / `get_upload_status`); `part_slice` gives offset/length when `total_bytes` is known. Both paths return a job id.
-
-**Poll.** `Video.poll_job_status` / `ensure_blob` until a blob ref is present (`JOB_STATE_COMPLETED`, or `already_exists` with a blob — not a hard failure). Inject `get_status` / `sleep` in tests. Client poll only.
-
-**Embed.** Put the job **blob ref** on `app.bsky.feed.post` via `Video.video_embed_json` / `embed_of_job` + `Records.post`. Optional `alt` / `aspect_ratio` / `presentation` (`default` / `gif`). The HLS **playlist** is `app.bsky.embed.video#view` after AppView hydrates the post — do not write the playlist into the create embed. This pin's `app.bsky.embed.video` create object has no captions field.
-
-`examples/video_production.ml` is that wiring as an offline sketch (audience, upload URL, job/multipart helpers, embed → post). It does not hit the network and is not a hosted video product.
-
-## Production indexer (TAP-like repo sync)
-
-This library is a **client / backfill toolkit** for building an indexer. It does not start or stub a hosted Tap. Official TestNetwork is a local PDS + AppView + Ozone stack, not a Tap host.
-
-**Backfill.** `Repo_sync.fetch_repo` / `backfill` pull `com.atproto.sync.getRepo`. Offline / tests use `open_car` / `open_car_bytes` / `resync_from_car` on a CAR you already have. `verify_snapshot` re-checks the MST; pass PLC / did:key `~keys` to check the commit signature.
-
-**Walk.** `walk` is path + CID. `record_block` returns DAG-CBOR bytes. `record_json` / `walk_json` decode those bytes as IPLD JSON (`Dag_cbor.to_yojson`; `$link` / `$bytes`).
-
-**getRecord proof.** `export_record_proof` builds a partial CAR (commit + MST covering path + record). `verify_record_proof` accepts that shape or a PDS `getRecord` CAR. Live: `fetch_record_proof`.
-
-**Firehose.** While `Synchronized`, `process_commit` / `process_message` apply `#commit` ops to the in-memory record table (`live=true` for the tail). `apply_commit_tree` applies the same ops to the MST and checks `commit.data`. `#sync` with a different rev marks `Desynchronized` (`process_sync`); ignore further commits until `resync_from_car` / `backfill`.
-
-**Sync 1.1 export.** `export_car` is a full pre-order repo CAR. `export_subset` / `verify_subset` are collection-range proofs.
-
-**Offline fixture.** `write_signed_repo` is JSON → DAG-CBOR → MST → signed commit → CAR. The example signs with `Mst.encode_repo_commit` (unsigned). Production signers use `Mst.sign_p256` / `sign_k256`.
-
-`examples/repo_sync_indexer.ml` is that wiring as an offline sketch (in-memory fixture CAR, walk, proof, firehose apply, `#sync` desync, Sync 1.1 export). It does not hit the network and is not a hosted Tap.
-
-## Production Jetstream archive (operator API key)
-
-This library is a **client** for Jetstream live tail and Network Replay HTTP. It does not invent an archive API key and does not pretend unauthenticated download works on Bluesky-hosted instances that require one.
-
-**Live tail.** `subscribe` / `subscribe_one` stay unauthenticated and are not metered. v2 offers `Sec-WebSocket-Protocol: xrpc.v1.json`. Dict-zstd is `~compress:true`.
-
-**Archive HTTP.** Bluesky-hosted `planSnapshot` / `planBackfill` / `listSegments` / `getSegment` / `getBlock` need an operator API key from [bsky.network/account](https://bsky.network/account). That is not a PDS session JWT and not `getServiceAuth`. Official TypeScript / Go SDKs read `JETSTREAM_API_KEY` and send `Authorization: Bearer`. This client does the same: explicit `~token`, else `JETSTREAM_API_KEY`, else `JETSTREAM_ARCHIVE_TOKEN` (alias). Pass the raw key — do not include a `Bearer ` prefix. Self-hosted Jetstream needs no key.
-
-**Failing closed.** `require_archive_token` / `try_* ~require_token:true` raise `Archive_token_required` before HTTP when no key is available. Default `try_*` stay unauthenticated so public / self-hosted probes and CI remain skippable (`Snapshot_gated` 401/403). A missing, malformed, or revoked key returns 401 `{"error":"invalid bearer credential"}`. This library never fabricates a key.
-
-**Resume.** `range_header` is the HTTP `Range` for `getSegment` after a mid-download 429 (`{"error":"byte limit exceeded"}`). Usage is metered in response bytes, not requests.
-
-`examples/jetstream_archive.ml` is that wiring as an offline sketch (env names, Bearer header, official-over-alias precedence, `require_archive_token`). It injects a fixture string — not a real credential — and does not hit the network.
-
-## Production phone / contacts / push (hosted AppView + caller gateway)
-
-This library is a **client** for hosted Bluesky phone verification, contact import, and push registration. It does not send SMS and does not start an APNs/FCM gateway. Official TestNetwork still has no phone or push service.
-
-**Contacts.** `app.bsky.contact.*` is AppView. Password sessions: `Contact.get_matches` / `get_sync_status` / `import_contacts` through the PDS / entryway. OAuth DPoP cannot be the AppView Bearer — mint `com.atproto.server.getServiceAuth` (`aud` = AppView DID, `lxm` = the `app.bsky.contact.*` NSID) and call `get_matches_service` / `get_sync_status_service` / `import_contacts_service` / `start_phone_verification_service` / `verify_phone_service` on `Client.appview_host_from_env` (`public.api.bsky.app` / `ATP_APPVIEW_HOST`). Query pairs are `get_matches_body` (`limit` / `cursor`).
-
-**Hosted SMS.** `Contact.start_phone_verification` → `verify_phone` (returns `token`) → `import_contacts`. That is Bluesky-hosted SMS, not a local gateway. Live hops stay skippable unless `ATP_PHONE=1` and `ATP_PHONE_NUMBER` is a real E.164 number you own. `com.atproto.temp.requestPhoneVerification` is a different privileged signup-SMS client (`Temp.request_phone_verification`) and is also not faked. `Server.describe_server` reports `phoneVerificationRequired`; `createAccount` accepts `verificationPhone` / `verificationCode`.
-
-**Push.** `Notification.register_push` / `unregister_push` take a caller-supplied `serviceDid` + device token + `platform` (`ios` / `android` / `web`) + `appId`. Official Bluesky push is closed to the official app. `Xrpc.notif_proxy` (`did:web:api.bsky.app#bsky_notif`) is the public service fragment, not a default credential. Optional `atproto-proxy` comes from `~proxy` or `ATP_PUSH_DID` (`effective_push_proxy`) — some PDS builds do not route `unregisterPush` to `#bsky_notif` themselves. Live hops stay skippable unless `ATP_PUSH=1` plus `ATP_PUSH_DID` / `ATP_PUSH_TOKEN` / `ATP_PUSH_APP_ID`.
-
-`examples/contacts_production.ml` is that wiring as an offline sketch (query/POST bodies, AppView `*_service` helpers, push platforms, `notif_proxy`). It does not hit the network and is not an SMS or push product.
-
-## Remaining gaps
-
-These are product-level, not missing protocol cores.
-
-**What 1.0.0 covers.** See [CHANGELOG.md](CHANGELOG.md) (`## [1.0.0]`) for the packaged client since tagged 0.1.0: OCaml 5 / packaging ([#229](https://github.com/david-engelmann/atproto/pull/229)), public HTTPS OAuth ([#230](https://github.com/david-engelmann/atproto/pull/230)), hosted chat ([#231](https://github.com/david-engelmann/atproto/pull/231)), hosted video ([#232](https://github.com/david-engelmann/atproto/pull/232)), TAP-like `Repo_sync` indexer ([#233](https://github.com/david-engelmann/atproto/pull/233)), Jetstream archive token env ([#234](https://github.com/david-engelmann/atproto/pull/234)), phone/contacts/push clients ([#235](https://github.com/david-engelmann/atproto/pull/235)), and the human-readable CHANGELOG ([#236](https://github.com/david-engelmann/atproto/pull/236)). Hosted-only SMS / APNs-FCM / unhosted feed generator stay listed not faked (`requestPhoneVerification` is not faked). Pin this GitHub repo for the 1.0.0 surface; tagging and the opam-repository 1.0.0 PR remain follow-ups.
-
-- Official lexicons are pinned at bluesky-social/atproto [`f0d4877a03`](https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0) (`app.bsky.actor.defs#interestsPref` `updatedAt`). `lexicons/official-nsids.json` is the compact NSID snapshot (`query` / `procedure` / `subscription` / `record` / `permission-set`); `scripts/gen-official-nsids.py` rebuilds it against a SHA. TestSuite `@lexicon-coverage` (`test_lexicon_coverage`) fails if that pin grows and a public client NSID is missing a helper, record builder, bundled permission-set, or an explicit one-line skip. That gate is CI-only — not `@runtest` / opam `with-test`. Hosted-only *servers* (no OSS chat backend, no video transcoder, no Tap host, no SMS gateway, no APNs/FCM push backend) are not skip reasons. Five deprecated/internal NSIDs are skipped in `lexicons/coverage-skips.json`: `com.atproto.temp.fetchLabels`, `com.atproto.sync.getCheckout`, `com.atproto.sync.getHead`, `com.atproto.sync.notifyOfUpdate`, and `internal.bsky.actor.getProfiles`.
-- An application still has to **host** the HTTPS `client-metadata.json` (that URL is `client_id`) and receive the browser redirect against a remote PDS. The library now builds/validates the public HTTPS document and drives authorize → code → token (`start_browser_login` / `complete_browser_login`). It does not host the document or a login UI. Local TestNetwork already runs loopback metadata + PAR + DPoP through token, AppView service-auth, and Ozone privileged writes as `admin-mod.test`.
-- A hosted **Tap** service. The indexer / backfill library path is documented and library-ready (`Repo_sync.open_car` / `verify_snapshot` / `walk_json` / `export_record_proof` / `verify_record_proof` / `process_commit` / `process_sync` / `apply_commit_tree` / Sync 1.1 `export_car` / `export_subset` / offline `write_signed_repo`; `examples/repo_sync_indexer.ml`). TestNetwork is a local PDS + AppView + Ozone stack, not a Tap host. This repo does not fake a hosted Tap.
-- No hosted **video transcoder**. The production hosted client path is documented and library-ready (`Video.pds_audience` from `#atproto_pds`, `upload_blob_lxm` / `mint_upload_token` / `get_upload_limits_service` on `video.bsky.app`, injectable `poll_job_status`, multipart `part_slice`, `video_embed_json` / `embed_of_job`; `examples/video_production.ml`). Live video tests stay skippable unless `ATP_AUTH` is a real credential. This repo does not fake a local transcoder.
-- No official **OSS chat** backend in `@atproto/dev-env` 0.6.4 TestNetwork (`ozone.chatUrl` = `localhost:2590`, “must run separate chat service”). The production hosted path is documented and library-ready (`Oauth.default_chat_scope` / `include:chat.bsky.authFullChatClient`, `Chat.effective_proxy` / `ATP_CHAT_DID`, service-auth `*_service` helpers on `api.bsky.chat` because DPoP cannot be proxied; `examples/chat_production.ml`). Live DM tests stay skippable unless `ATP_AUTH` has a chat/DM scope or `ATP_CHAT=1`. This repo does not fake a local chat service.
-- Jetstream archive HTTP **download** on Bluesky-hosted instances still requires the **operator to supply** an API key (`JETSTREAM_API_KEY` / `JETSTREAM_ARCHIVE_TOKEN`, or `~token`). The library reads that env and sends `Authorization: Bearer`. It does not invent a key. Live `subscribeEvents` stays unauthenticated. Self-hosted archives may omit the key.
-- No hosted **SMS / phone-verification** gateway. The production hosted client path is documented and library-ready (`Contact.get_matches_body` / `get_matches_appview` / `*_service`, `start_phone_verification` / `verify_phone` / `import_contacts`; `Temp.request_phone_verification`; `Server.describe_server` `phoneVerificationRequired`; `examples/contacts_production.ml`). Live SMS hops stay skippable unless `ATP_PHONE=1` and `ATP_PHONE_NUMBER` is a real number. Official TestNetwork does not start SMS. This repo does not fake `requestPhoneVerification`.
-- No official **OSS push** gateway (official Bluesky push is closed to the official app; third-party clients host their own). The production hosted client path is documented and library-ready (`Notification.register_push_body` / `unregister_push_body` / `platform_ios` / `effective_push_proxy` / `Xrpc.notif_proxy`; `examples/contacts_production.ml`). Live register hops stay skippable unless `ATP_PUSH=1` plus a caller `serviceDid` / device token. This repo does not fake APNs/FCM.
-- Permissioned data / spaces: experimental `Lt_hash`, `At_uri.Space`,
-  `Space_commit`, `Space_credential`, `Space_xrpc`, and `Space_sync`
-  helpers landed (proposal
-  [0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md)
-  — LtHash digest, space / permissioned-record URI parse/serialize, deniable
-  signed commits with `ctx` / HKDF-Expand MAC / ES256+ES256K `sig`,
-  delegation / space-credential / client-attestation JWTs, DPoP via
-  `Oauth`, draft `com.atproto.space.*` request/response builders plus
-  `Client.get_json` / `post_json` / `get_text` wrappers, and offline
-  oplog / two-root CAR apply). The proposal is not final; this is not a
-  stable spaces product API. Deferred: `com.atproto.simplespace.*`
-  management, `space:` OAuth scope grammar, and `registerNotify` `repo`
-  (proposal prose; not in #5187). Live hops skip unless `ATP_SPACE=1`
-  and `ATP_SPACE_HOST` names a real host. This repo does not fake a
-  space host.
-
-## Sample usage
+## Examples
 
 ```ocaml
 (* public AppView, no auth *)
 let did = (Identity.resolve_handle "jay.bsky.team").did
 let commit = Sync.get_latest_commit did
-let discover =
-  Feed.get_feed_generator
-    ~feed:"at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot"
-    ()
+let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 let author =
   Feed.get_author_feed_page ~actor:"jay.bsky.team" ~limit:5
     ~filter:Feed.filter_posts_no_replies ~include_pins:true ()
-let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
-let posts_v2 = Feed.search_posts_v2 ~query:"atproto" ~hashtags:[ "atproto" ] ~limit:5 ()
-let packs = Graph.search_starter_packs_v2 ~q:"bluesky" ~limit:5 ()
-let popular = Unspecced.get_popular_feed_generators ~limit:5 ()
-let trends = Unspecced.get_trends ~limit:5 ()
-let services =
-  Labeler.get_services ~dids:[ "did:plc:ar7c4by46qjdydhdevvrndac" ] ()
-let _ =
-  Records.labeler_service
-    ~policies:
-      (Labeler.policies_to_json
-         { label_values = [ "!hide" ]; label_value_definitions = [] })
-    ~created_at:"2024-01-01T00:00:00.000Z" ()
 
-(* MST layer for a repo key — official vector *)
-let () = assert (Mst.layer_for_key "blue" = 1)
-
-(* experimental proposal-0016 LtHash / space URI — not a spaces product *)
-let () =
-  assert (Lt_hash.is_empty (Lt_hash.empty ()));
-  assert (
-    Hash.hex_encode (Lt_hash.hash (Lt_hash.empty ()))
-    = "e5a00aa9991ac8a5ee3109844d84a55583bd20572ad3ffcd42792f3c36b183ad");
-  let space =
-    At_uri.Space.of_string
-      "at://did:example:space/space/app.bsky.group/test"
-  in
-  assert (not (At_uri.Space.is_record space));
-  assert (
-    Space_credential.space_host_aud "did:example:space"
-    = "did:example:space#atproto_space_host");
-  assert (
-    Space_credential.delegation_typ = "atproto-space-delegation+jwt");
-  assert (
-    Space_xrpc.get_record_body
-      ~space:"at://did:example:space/space/app.bsky.group/test"
-      ~repo:"did:example:alice" ~collection:"app.bsky.feed.post"
-      ~rkey:"3jzfcijpj2z2a"
-    |> List.assoc "space"
-    = "at://did:example:space/space/app.bsky.group/test");
-  let empty_ops =
-    Space_sync.apply_ops (Lt_hash.empty ())
-      [
-        Space_sync.op ~collection:"app.bsky.feed.post" ~rkey:"3kbcq3p7ad401"
-          ~cid:"bafyreia" ();
-        Space_sync.op ~collection:"app.bsky.feed.post" ~rkey:"3kbcq3p7ad401"
-          ~prev:"bafyreia" ();
-      ]
-  in
-  assert (Lt_hash.is_empty empty_ops)
-
-(* TID used as record keys and commit revs *)
-let () = assert (Tid.is_valid "3jzfcijpj2z2a")
-
-(* typed Bluesky record builders + facet serialize *)
+(* typed record + facet *)
 let post =
   Records.post ~text:"hello #atproto" ~created_at:"2024-01-01T00:00:00.000Z"
     ~facets:[ Facet.tag ~byte_start:6 ~byte_end:14 "atproto" ]
     ()
 
-(* OAuth: publish HTTPS client-metadata, then drive authorize → code → token.
-   The app still hosts the JSON at client_id and receives /cb. *)
+(* password session *)
+let username, password = Auth.username_and_password_from_env
+let session = Session.create_session username password
+let profile = Actor.get_profile session "jay.bsky.team"
+
+(* OAuth: you still host client-metadata.json at client_id and receive /cb *)
 let client_id = Oauth.https_client_id ~host:"client.example" ()
 let meta =
   Oauth.public_https_metadata ~client_id
     ~redirect_uris:[ "https://client.example/cb" ] ()
 let _ = Oauth.metadata_http_response meta
-(* Official loopback client_id for local / TestNetwork development *)
-let loopback =
-  Oauth.loopback_client_id ~redirect_uri:"http://127.0.0.1:8080/cb" ()
-let _ = Oauth.localhost_metadata loopback
-(* Production browser path (inject live Cohttp, or a test double):
-   let login = Oauth.start_browser_login ~http_get ~http_post ~priv ~pub
-     ~pds_origin ~client_id ~redirect_uri () in
-   (* redirect the user-agent to login.authorize_url *)
-   let token, _ = Oauth.complete_browser_login ~http:http_post ~priv ~pub
-     ~login ~redirect:callback_uri () *)
+(* Oauth.start_browser_login / complete_browser_login drive authorize → token *)
 
-(* video: service-auth aud = did:web:<pds> from #atproto_pds, lxm = uploadBlob *)
-let upload =
-  Video.upload_video_url ~did:"did:plc:abc123xyz0001112223333" ~name:"clip.mp4" ()
-let embed =
-  Video.video_embed_json
-    ~video:(`Assoc [ ("$type", `String "blob"); ("mimeType", `String "video/mp4") ])
-    ~alt:"demo" ~presentation:"gif" ()
-let _ = Video.get_job_status_body ~job_id:"job-1" ()
-let _ = Video.upload_video_body ~did:"did:plc:abc123xyz0001112223333" ~name:"clip.mp4" ()
-(* after mint_upload_token / Oauth.get_service_auth and poll_job_status:
-   Records.post ~text ~created_at ~embed:(Video.embed_of_blob blob) () *)
-let schema =
-  Records.lexicon_schema ~id:"com.example.ping"
-    ~defs:(`Assoc [ ("main", `Assoc [ ("type", `String "query") ]) ])
-    ()
-let start =
-  Video.start_upload_body ~size_bytes:1_048_576 ~mime_type:"video/mp4"
-    ~name:"clip.mp4" ()
-
-(* firehose: one subscribeRepos frame from the public relay *)
+(* firehose + Jetstream URL (subscribe_one talks to the public WS) *)
 let _header, msg = Firehose.subscribe_one ()
-
-(* Jetstream v2 JSON tail — URL only here; subscribe_one talks to the public WS
-   and offers Sec-WebSocket-Protocol: xrpc.v1.json (RFC 6455 §4.1 echo) *)
 let _js =
   Jetstream.subscribe_url
     ~filter:
@@ -451,75 +256,11 @@ let _js =
         kinds = [ Jetstream.Commit ];
       }
     ()
-let _headers = Jetstream.subscribe_extra_headers ()
-(* v2 dict-zstd: query zstdDictionary=<id>; header stays xrpc.v1.json *)
-let _js_zstd =
-  Jetstream.subscribe_url ~compress:true ~zstd_dictionary_id:20260811 ()
-let _headers_zstd = Jetstream.subscribe_extra_headers ~compress:true ()
-(* archive HTTP: operator key from JETSTREAM_API_KEY (or ~token).
-   Live subscribe stays unauthenticated. See examples/jetstream_archive.ml *)
-let _auth = Jetstream.archive_authorization ~token:"operator-supplied-key" ()
-let _ = Jetstream.require_archive_token ~token:"operator-supplied-key" ()
 
-(* TAP-like local indexer: backfill a CAR, then apply firehose ops *)
-let acct =
-  Repo_sync.create_account ~did:"did:plc:abc123xyz0001112223333"
-    ~collections:[ "app.bsky.feed.post" ] ()
-let _ = Repo_sync.status_to_string acct.Repo_sync.status
-(* after Sync.get_repo / open_car: walk_json, export_record_proof,
-   process_commit, process_sync → resync_from_car. See
-   examples/repo_sync_indexer.ml (offline, no hosted Tap). *)
-
-(* granular OAuth scopes (atproto remains mandatory) *)
-let scopes = Oauth_scope.parse "atproto repo:app.bsky.feed.post"
-
-(* authenticated writes / private surfaces *)
-let username, password = Auth.username_and_password_from_env
-let session = Session.create_session username password
-let profile = Actor.get_profile session "jay.bsky.team"
-let _ = profile.pronouns
-let _ = profile.viewer.muted_only_reposts
-let prefs = Actor.get_preferences session
-let _ = Actor.preferences_to_json prefs
-let _ = Graph.mute_actor_body ~actor:"alice.test" ~only_reposts:true ()
-let _ = Graph.unmute_actor_body ~actor:"alice.test"
-let _ =
-  Graph.mute_actor_list_body
-    ~list:"at://did:plc:abc123xyz0001112223333/app.bsky.graph.list/3k2a"
-let _ =
-  Graph.mute_thread_body
-    ~root:"at://did:plc:abc123xyz0001112223333/app.bsky.feed.post/3k2b"
-let _ =
-  Graph.get_list_body
-    ~list:"at://did:plc:abc123xyz0001112223333/app.bsky.graph.list/3k2a"
-    ~limit:10 ()
-let _ = Graph.search_starter_packs_body ~q:"bluesky" ~limit:5 ()
-let _ =
-  Auth.create_session_body ~identifier:"alice.test" ~password:"x"
-    ~allow_takendown:true ()
-let bookmarks = Bookmark.get_bookmarks session ~limit:10 ()
-(* chat: password + atproto-proxy, or OAuth service-auth on api.bsky.chat *)
-let _ = Oauth.default_chat_scope
-let convos = Chat.list_convos session ~limit:10 ()
-let chat_status = Chat.get_actor_status session ()
-let _ = Chat.effective_proxy ~did_doc:(Option.value ~default:`Null session.did_doc) ()
-let _ = Chat.list_convos_body ~limit:10 ()
-let _ = Chat.service_aud ()
-(* after Oauth.get_service_auth ~aud:(Chat.service_aud ()) ~lxm:"chat.bsky.convo.listConvos":
-   Chat.list_convos_service ~bearer ~host:Chat.default_host ~limit:10 () *)
-
-(* site.standard + germnetwork records — local builders, no network *)
-let article =
-  Site.document ~site:"https://standard.site" ~title:"hello"
-    ~published_at:"2026-01-01T00:00:00.000Z" ()
-let _ = Site.document_to_json (Site.parse_document article)
-let germ = Germnetwork.declaration ~version:"1.0.0" ~current_key:"key" ()
-
-(* topics header for Client.get_json ~extra — current x-atproto-bsky-topics *)
-let _topics = Xrpc.topics_headers [ "news"; "sports" ]
-
-(* HTTP/2 XRPC GET that keeps status + rate-limit headers (skips if ALPN h2 fails) *)
-let _h2 =
-  Http_client.xrpc_url ~host:"public.api.bsky.app"
-    "com.atproto.identity.resolveHandle" ~query:[ ("handle", "bsky.app") ] ()
+(* experimental proposal 0016 — not a spaces product *)
+let space =
+  At_uri.Space.of_string "at://did:example:space/space/app.bsky.group/test"
+let () = assert (not (At_uri.Space.is_record space))
 ```
+
+More copy-paste sketches: `examples/quickstart.ml`, `examples/oauth_https_metadata.ml`, `examples/chat_production.ml`, `examples/video_production.ml`, `examples/repo_sync_indexer.ml`, `examples/jetstream_archive.ml`, `examples/contacts_production.ml`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Pushes to `main` deploy odoc with GitHub Actions Pages. Pull requests also uploa
 
 Each row is a starting point. Function-level detail lives in [odoc](https://david-engelmann.github.io/atproto/); release-by-release depth is in the [CHANGELOG](CHANGELOG.md).
 
-| Area | Modules | What it is for |
+| Area | Modules | Purpose |
 | --- | --- | --- |
 | Session | `Auth`, `Session`, `Server` | App-password sessions, app passwords, invites, email, `getServiceAuth` |
 | Identity | `Identity`, `Did_plc`, `Did_web`, `Did_key` | Handle / DID resolve, PLC directory, `did:web` / `did:key` |

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,59 +1,64 @@
 {0 AT Protocol for OCaml}
 
-{!Atproto} is a typed client and protocol library for the
-{{:https://atproto.com}AT Protocol}: XRPC, identity, repo sync,
-AppView, Ozone, and a chat client. Official lexicons are pinned at
-bluesky-social/atproto
-{{:https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0}[f0d4877a03]}.
-Leftovers are hosted-only (no PDS, OSS chat backend, video transcoder,
-or Tap in this package). {!Atproto.Oauth} builds and validates a public
-HTTPS client-metadata document and the authorize → code → token
-browser path; the application still hosts that document.
-{!Atproto.Chat} is a client for hosted [chat.bsky.*]
-([atproto-proxy] or service-auth on [api.bsky.chat]; DPoP cannot be
-proxied). Official TestNetwork does not start chat.
-{!Atproto.Video} is a client for hosted [app.bsky.video.*] on
-[video.bsky.app] (service-auth [did:web:<pds>] + [uploadBlob];
-job poll; multipart; embed the blob, not the playlist). It does
-not run a transcoder. Official TestNetwork does not start one.
-{!Atproto.Repo_sync} is the TAP-like indexer / backfill library
-path (open/verify repo CAR, walk records as IPLD JSON, getRecord
-inclusion proof, firehose [#commit] / [#sync], Sync 1.1 export,
-offline [write_signed_repo]). It is not a hosted Tap service.
-{!Atproto.Jetstream} archive HTTP reads an operator API key from
-[JETSTREAM_API_KEY] / [JETSTREAM_ARCHIVE_TOKEN] (or [~token]) and
-sends [Authorization: Bearer]. It does not invent a key. Live
-[subscribe] stays unauthenticated.
-{!Atproto.Contact} is a client for hosted [app.bsky.contact.*]
-(password session or AppView service-auth [*_service]; SMS via
-[startPhoneVerification] is hosted-only and not faked).
-{!Atproto.Notification} [registerPush] / [unregisterPush] take a
-caller [serviceDid] plus device token; official Bluesky push is
-closed to the official app. This package does not send APNs/FCM.
+{!Atproto} is a typed OCaml client for the
+{{:https://atproto.com}AT Protocol}. Use it to resolve identities,
+read and write repositories, follow the firehose, and call AppView,
+Ozone, and hosted Bluesky products (chat, video, Jetstream).
 
-{1 Install}
+{b 1.0.1} is released. Until
+{{:https://github.com/ocaml/opam-repository/pull/30703}ocaml/opam-repository\#30703}
+merges, pin the GitHub repository. The narrative guide — install,
+quick start, hosted-product paths, and honest gaps — is the
+{{:https://github.com/david-engelmann/atproto#atproto}GitHub README}.
+Release notes are in
+{{:https://github.com/david-engelmann/atproto/blob/main/CHANGELOG.md}CHANGELOG.md}.
 
-Published on the public opam-repository (`opam install atproto`;
-pending merge of the opam-repository PR). Pin the GitHub repo for
-development (OCaml [>= 4.14.1] and [< 5.4]; CI tests 4.14.1 and
-5.3.0). Jane Street [core] / [async] / [ppx_jane] / [zstandard] are
-[>= v0.16.0] and [< v0.18~] (v0.16 on 4.14, v0.17 on 5.1-5.3):
+{1 Start here}
+
+Neither call needs credentials:
 
 {[
-opam install atproto
-(* development pin *)
-opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+let did = (Identity.resolve_handle "jay.bsky.team").did
+let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 ]}
 
-Jetstream dict-zstd needs Jane Street [zstandard] / system
-libzstd (Ubuntu/Debian [libzstd-dev], macOS Homebrew [zstd]).
+{v
+opam pin add atproto git+https://github.com/david-engelmann/atproto.git
+(* after the opam-repository PR merges: opam install atproto *)
+v}
 
-Then [(libraries atproto)] in dune.
+Then [(libraries atproto)] in dune. Requires OCaml [>= 4.14.1] and
+[< 5.4] (CI: 4.14.1 and 5.3.0). Jetstream dict-zstd needs system
+libzstd ([libzstd-dev] / Homebrew [zstd]).
 
-{1 Documentation}
+{1 What this library is}
 
-{{:https://david-engelmann.github.io/atproto/}https://david-engelmann.github.io/atproto/}
-([dune build @doc] on [main]; PRs also upload the [odoc-html] artifact).
+A client and protocol library: XRPC, lexicons (pinned at
+{{:https://github.com/bluesky-social/atproto/commit/f0d4877a03dc8ede0d3e9a36d5b72ada63b5d2e0}[f0d4877a03]}),
+CID / CAR / MST, OAuth / DPoP, and typed helpers for AppView, Ozone,
+chat, and video.
+
+It does {e not} host a PDS, chat backend, video transcoder, Tap, SMS
+gateway, or APNs/FCM:
+
+- {!Atproto.Oauth} builds a public HTTPS client-metadata document
+  and drives authorize → code → token. Your application still hosts
+  that URL and the redirect.
+- {!Atproto.Chat} talks to hosted [chat.bsky.*] on [api.bsky.chat]
+  ([atproto-proxy] or service-auth; DPoP cannot be proxied).
+- {!Atproto.Video} talks to hosted [app.bsky.video.*] on
+  [video.bsky.app] (service-auth [did:web:<pds>] + [uploadBlob]).
+- {!Atproto.Repo_sync} is an indexer / backfill toolkit, not a Tap
+  host.
+- {!Atproto.Jetstream} archive HTTP needs an operator-supplied
+  [JETSTREAM_API_KEY]. Live [subscribe] stays unauthenticated.
+- {!Atproto.Contact} and {!Atproto.Notification} [registerPush] are
+  clients for hosted SMS / a caller push gateway.
+
+Experimental proposal-0016 modules ({!Atproto.Lt_hash},
+{!Atproto.Space_commit}, {!Atproto.Space_credential},
+{!Atproto.Space_xrpc}, {!Atproto.Space_sync}) are {b not} a spaces
+product API. There is no space host in this package.
 
 {1 Public modules}
 
@@ -69,11 +74,11 @@ Identity / PLC
 
 {!modules: Atproto.Identity Atproto.Did_plc Atproto.Did_web Atproto.Did_key}
 
-MST / CID / CAR
+MST / CID / CAR / indexer
 
 {!modules: Atproto.Mst Atproto.Cid Atproto.Car Atproto.Dag_cbor Atproto.Repo_sync}
 
-Experimental permissioned-data digest / commits / credentials / XRPC / sync apply (proposal 0016; not a spaces product)
+Experimental permissioned-data (proposal 0016; not a spaces product)
 
 {!modules: Atproto.Lt_hash Atproto.Space_commit Atproto.Space_credential Atproto.Space_xrpc Atproto.Space_sync}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [avsm’s readability / third-party-suitability concern](https://github.com/ocaml/opam-repository/pull/30695#issuecomment-3693706095) on the 0.1.0 opam submission: public docs should read like a finished library, not a maintainer or CI log.

**1.0.1** is tagged at `53ffbc2`. The opam PR is [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703). This PR is docs-only (no version bump, no lexicon pin bump, no dune-project / opam description change, no fake hosts).

### README
- Leads with a product pitch and accurate status (released; opam PR in flight).
- Quick start stays two copy-paste blocks.
- Install is short (bounds, libzstd, pin vs `opam install`).
- Replaces the per-helper tables (Ozone/Server walls) with a scannable **library map**.
- Production paths stay accurate but tighter.
- Remaining gaps stay honest and short. Process leftover voice (“follow-ups remain”, “does not create a tag”) is gone.

### CHANGELOG
- Header and **1.0.1** now say the tag/release exist and point at #30703.
- Unreleased 0016 notes are readable bullets (still experimental, still no space host).
- 1.0.0 / 0.1.0 present-tense “does not create a tag” / pending-opam wording updated.

### odoc landing (`doc/index.mld`)
- Warm start: what the library is, one public call, where gaps are, link to the GitHub README.

### Also
- Short [`AGENTS.md`](AGENTS.md) so LLM consumers get install / first call / honesty constraints without cluttering the README.
- CONTRIBUTING + install issue template: 1.0.1 / #30703, TestNetwork pointer (CSRF essay left in the test file).

## Checklist

- [x] Targets supported OCaml (`>= 4.14.1` and `< 5.4`; CI is 4.14.1 + 5.3.0)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `@lexicon-coverage` (`test_lexicon_coverage`, or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host / SMS gateway / APNs-FCM push backend
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md

Docs-only: ready for review once `lint-fmt` and `lint-doc` are green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-092a3e06-6cc5-476f-a21f-44dcf006e018?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-092a3e06-6cc5-476f-a21f-44dcf006e018&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

