### PR TITLE
Polish 1.0.2 public docs for the opam tag

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,10 @@
 # Contributing
 
-Pull requests are welcome. **1.0.1** is tagged; package version on
-this tree is **1.0.2**. The public opam package is
-[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
-(`opam install atproto` after that merges; a 1.0.2 publish
-supersedes it). Pin the GitHub repository for development. Product
-docs for third-party users are in [README.md](../README.md) and
+Pull requests are welcome. Package version on this tree is **1.0.2**.
+The next opam submit is **atproto.1.0.2** (new PR after tag; it
+supersedes ocaml/opam-repository#30703). Pin the GitHub repository
+for development. Product docs for third-party users are in
+[README.md](../README.md) and
 https://david-engelmann.github.io/atproto/.
 
 ## Toolchain

--- a/.github/ISSUE_TEMPLATE/03-install.md
+++ b/.github/ISSUE_TEMPLATE/03-install.md
@@ -17,9 +17,9 @@ labels: ""
 **Command and output**
 Paste the command and the error.
 
-**1.0.1** is released. `opam install atproto` after
-[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
-merges. Until then, pin this repository:
+**1.0.2** is the packaged surface. `opam install atproto` after
+**atproto.1.0.2** lands on opam-repository. Until then, pin this
+repository:
 
 ```shell
 opam install atproto

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-**1.0.2** is the current release (OCaml **>= 4.14.1** and **< 5.4**;
-CI tests **4.14.1** and **5.3.0**). Jane Street packages resolve to
-v0.16 on 4.14 and v0.17 on 5.1–5.3. Tagged **0.1.0** remains the
-prior release candidate.
+**1.0.2** is the current packaged surface (OCaml **>= 4.14.1** and
+**< 5.4**; CI tests **4.14.1** and **5.3.0**). Jane Street packages
+resolve to v0.16 on 4.14 and v0.17 on 5.1–5.3. Tagged **1.0.1**
+remains the prior release.
 
 ## Reporting a Vulnerability
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ This repository is an OCaml **client and protocol library** for the [AT Protocol
 ## Install and call
 
 - Package: `atproto`. Dune: `(libraries atproto)`.
-- Released **1.0.1** ([tag](https://github.com/david-engelmann/atproto/releases/tag/1.0.1)). Public opam: [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703) (open). Until it merges, `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`.
+- Packaged **1.0.2**. Until **atproto.1.0.2** is on opam-repository, `opam pin add atproto git+https://github.com/david-engelmann/atproto.git`. Then `opam install atproto`.
 - OCaml `>= 4.14.1` and `< 5.4`. System **libzstd** is required (Jetstream dict-zstd).
+- Public live tests skip unless `ATP_PUBLIC=1`. Default `opam install -t` / `@runtest` is offline. Credential hops stay on `ATP_AUTH`; local TestNetwork stays on `ATP_LOCAL_PDS`.
 - Public, unauthenticated starting point:
 
 ```ocaml
@@ -16,7 +17,9 @@ let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 
 ## Honesty constraints
 
-Do not invent or stub hosted products. This package does **not** provide:
+Do not invent or stub hosted products. Do not claim public-network
+tests run in default `with-test` (they need `ATP_PUBLIC=1`). This
+package does **not** provide:
 
 - a PDS, OSS chat backend, video transcoder, Tap host, SMS gateway, or APNs/FCM
 - a Jetstream archive API key (operator supplies `JETSTREAM_API_KEY`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Current package version is **1.0.2** (`dune-project` / `atproto.opam`).
-This revision does **not** create a git tag or GitHub Release.
 Tagged **1.0.1** is at
 [`53ffbc2`](https://github.com/david-engelmann/atproto/releases/tag/1.0.1).
-The public opam package is
-[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
-(to be superseded after this cut).
+The next opam submit is **atproto.1.0.2** (new PR after tag;
+supersedes
+[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)).
 
 This file is the human-readable release history. PR numbers are
 included sparingly so a change can be traced; they are not a
@@ -46,13 +45,6 @@ space host. Live hops skip unless `ATP_SPACE=1` and
 Deferred: `com.atproto.simplespace.*`, `space:` OAuth scopes, and
 proposal `registerNotify` `repo` (not in the #5187 lexicon).
 
-### Changed
-
-- Public docs rewritten for third-party readers (README product
-  pitch and module map, 1.0.1 notes now that the tag exists, warmer
-  odoc landing). Addresses the readability concern on
-  ocaml/opam-repository#30695
-
 ### Notes
 
 - No lexicon pin bump. Official lexicons stay bluesky-social/atproto
@@ -62,25 +54,16 @@ proposal `registerNotify` `repo` (not in the #5187 lexicon).
 
 ## [1.0.2] - 2026-09-10
 
-Packaging / opam-health cut so
-[ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703)
-can be superseded. `atproto.1.0.1` built, linted, and passed
-lower-bounds; almost every opam-ci `tests` job failed on
-public-network live hops (`identity:test_resolve_actor_live`,
-`did_plc:test_resolve_live` / `test_live_chain_structure`,
-`sync:test_list_blobs_public` / `test_get_record_proof_public`,
-`temp:test_check_handle_live`, `suite:test_search_starter_packs_*_live`,
-`unspecced:test_popular_live`, and the same class of AppView /
-firehose / Jetstream / did:web / HTTP/2 smokes). Those tests hit
-plc.directory / AppView / a public PDS and only `skip_if` on a
-caught exception. Partial success + assert, or a non-skip path,
-still failed the suite. Opam `with-test` must not depend on those
-hosts.
+Opam-health follow-up to tagged
+[1.0.1](#101---2026-09-10). The 1.0.1 package built, linted, and
+passed lower-bounds; opam-ci `tests` failed because unauthenticated
+live hops (PLC directory, AppView, public PDS, firehose / Jetstream)
+ran by default and only skipped on a caught exception.
 
-This revision sets `dune-project` / `atproto.opam` to **1.0.2**. It
-does **not** create a git tag or GitHub Release and does **not**
-touch ocaml/opam-repository. Tagging and superseding #30703 remain
-maintainer follow-ups.
+**1.0.2** makes `opam install -t` / `dune build -p atproto @runtest`
+offline-safe. The opam submit is **atproto.1.0.2** (new
+ocaml/opam-repository PR after tag). It supersedes #30703. This
+repository does not edit ocaml/opam-repository.
 
 No lexicon pin bump (official pin stays `f0d4877a`). Jane Street /
 OCaml bounds are unchanged. No fake hosts.
@@ -101,15 +84,15 @@ OCaml bounds are unchanged. No fake hosts.
 - `dune build -p atproto @runtest` / opam `with-test` is offline-safe
   when `ATP_PUBLIC` is unset
 - GitHub Actions default TestSuite `build` does **not** set
-  `ATP_PUBLIC` (deterministic; no public hops). The previous default
-  suite ran those hops and skipped only on request failure. Re-run
-  them with `ATP_PUBLIC=1` locally (`make test-public`) or the
-  optional **PublicLive** workflow (`workflow_dispatch` only; not a
-  merge-when-green required check)
+  `ATP_PUBLIC`. Re-run public hops with `make test-public` or the
+  optional **PublicLive** workflow (`workflow_dispatch` only)
+- Public docs rewritten for third-party readers
+  ([#244](https://github.com/david-engelmann/atproto/pull/244)):
+  README product pitch and module map, warmer odoc landing,
+  `AGENTS.md`
 
 ### Notes
 
-- This does not touch ocaml/opam-repository
 - Experimental 0016 helpers stay under [Unreleased](#unreleased)
 
 ## [1.0.1] - 2026-09-10

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Resolve identities, read and write repositories, follow the firehose, and call AppView, Ozone, and hosted Bluesky products (chat, video, Jetstream) from one library. Protocol pieces — XRPC, CID/CAR/MST, lexicons, OAuth/DPoP — are implemented here, not left as raw HTTP.
 
-**1.0.2** is the packaged surface (`ATP_PUBLIC` gate; see [CHANGELOG.md](CHANGELOG.md)). Tagged **[1.0.1](https://github.com/david-engelmann/atproto/releases/tag/1.0.1)** is at `53ffbc2`. The public opam package is in [ocaml/opam-repository#30703](https://github.com/ocaml/opam-repository/pull/30703) (to be superseded after this cut). Until a 1.0.2 opam publish, pin this repository.
+**1.0.2** is the packaged surface. Pin this repository until
+**atproto.1.0.2** lands on opam-repository; then `opam install atproto`.
+See [CHANGELOG.md](CHANGELOG.md).
 
 This package is a **client**. It does not host a PDS, chat service, video transcoder, Tap, SMS gateway, or push backend. See [What this package does not host](#what-this-package-does-not-host).
 
@@ -14,7 +16,7 @@ Neither call needs `ATP_AUTH`:
 
 ```shell
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
-# after ocaml/opam-repository#30703 merges:
+# after atproto.1.0.2 is on opam-repository:
 # opam install atproto
 ```
 
@@ -32,7 +34,7 @@ Requires OCaml **>= 4.14.1 and < 5.4** (CI: **4.14.1** and **5.3.0**). Jane Stre
 
 ```shell
 opam install atproto
-# development pin (use this until the opam-repository PR merges)
+# development pin (use this until atproto.1.0.2 is on opam-repository)
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
 ```
 
@@ -218,6 +220,20 @@ OAuth against this TestNetwork (loopback metadata, PAR, DPoP, service-auth) is c
 
 ## Examples
 
+Copy-paste sketches under `examples/`. `dune build` typechecks them;
+none invent a hosted service.
+
+| File | Demo |
+| --- | --- |
+| [`examples/quickstart.ml`](examples/quickstart.ml) | Public AppView: resolve a handle and search posts (no `ATP_AUTH`) |
+| [`examples/offline.ml`](examples/offline.ml) | Typechecks the public API with no network |
+| [`examples/oauth_https_metadata.ml`](examples/oauth_https_metadata.ml) | HTTPS `client-metadata.json` + browser login (you still host the document) |
+| [`examples/chat_production.ml`](examples/chat_production.ml) | Hosted `chat.bsky.*` on `api.bsky.chat` (no OSS chat backend) |
+| [`examples/video_production.ml`](examples/video_production.ml) | Hosted `app.bsky.video.*` on `video.bsky.app` (no transcoder) |
+| [`examples/repo_sync_indexer.ml`](examples/repo_sync_indexer.ml) | Indexer / backfill via `Repo_sync` (not a Tap host) |
+| [`examples/jetstream_archive.ml`](examples/jetstream_archive.ml) | Jetstream archive HTTP with an operator-supplied key |
+| [`examples/contacts_production.ml`](examples/contacts_production.ml) | Hosted phone / contacts / push clients (no SMS or APNs/FCM) |
+
 ```ocaml
 (* public AppView, no auth *)
 let did = (Identity.resolve_handle "jay.bsky.team").did
@@ -263,5 +279,3 @@ let space =
   At_uri.Space.of_string "at://did:example:space/space/app.bsky.group/test"
 let () = assert (not (At_uri.Space.is_record space))
 ```
-
-More copy-paste sketches: `examples/quickstart.ml`, `examples/oauth_https_metadata.ml`, `examples/chat_production.ml`, `examples/video_production.ml`, `examples/repo_sync_indexer.ml`, `examples/jetstream_archive.ml`, `examples/contacts_production.ml`.

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -5,13 +5,15 @@
 read and write repositories, follow the firehose, and call AppView,
 Ozone, and hosted Bluesky products (chat, video, Jetstream).
 
-{b 1.0.1} is released. Until
-{{:https://github.com/ocaml/opam-repository/pull/30703}ocaml/opam-repository\#30703}
-merges, pin the GitHub repository. The narrative guide — install,
-quick start, hosted-product paths, and honest gaps — is the
+{b 1.0.2} is the packaged surface. Until {b atproto.1.0.2} lands on
+opam-repository, pin the GitHub repository; then [opam install
+atproto]. The narrative guide — install, quick start, hosted-product
+paths, and honest gaps — is the
 {{:https://github.com/david-engelmann/atproto#atproto}GitHub README}.
 Release notes are in
 {{:https://github.com/david-engelmann/atproto/blob/main/CHANGELOG.md}CHANGELOG.md}.
+Public-internet live tests skip unless [ATP_PUBLIC=1]. Default
+[opam install -t] / [@runtest] stay offline.
 
 {1 Start here}
 
@@ -24,7 +26,7 @@ let posts = Feed.search_posts ~q:"atproto" ~limit:5 ()
 
 {v
 opam pin add atproto git+https://github.com/david-engelmann/atproto.git
-(* after the opam-repository PR merges: opam install atproto *)
+(* after atproto.1.0.2 is on opam-repository: opam install atproto *)
 v}
 
 Then [(libraries atproto)] in dune. Requires OCaml [>= 4.14.1] and

--- a/sample.env
+++ b/sample.env
@@ -13,12 +13,12 @@ ATP_HOST=bsky.social
 # ATP_AUTH_BOB=bob.test:hunter2
 # ATP_AUTH_OZONE=admin-mod.test:admin-mod-pass
 # ATP_LOCAL_PDS=1
-# Public internet live hops (plc.directory, AppView, public PDS,
-# firehose / Jetstream / did:web). Default unset so opam with-test
-# and the GitHub TestSuite build job stay offline-safe. ATP_PUBLIC=1
-# (or true / yes / on) opts in. Local TestNetwork stays on
-# ATP_LOCAL_PDS; credential hops stay on ATP_AUTH. Hosted-only
-# products stay on ATP_SPACE / ATP_PHONE / ATP_PUSH / ATP_CHAT.
+# Public-internet live hops (plc.directory, AppView, public PDS,
+# firehose / Jetstream / did:web). Unset by default: opam with-test
+# and GitHub TestSuite stay offline. ATP_PUBLIC=1 (or true / yes /
+# on) opts in. Local TestNetwork stays on ATP_LOCAL_PDS; credential
+# hops stay on ATP_AUTH. Hosted-only products stay on ATP_SPACE /
+# ATP_PHONE / ATP_PUSH / ATP_CHAT.
 # ATP_PUBLIC=1
 # Chat (not in the local TestNetwork). Hosted production path:
 #   proxy did:web:api.bsky.chat#bsky_chat, host api.bsky.chat


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#245 squash-merged before the author-agent 1.0.2 docs/examples polish (`6b7b241`) landed on the old branch. This follow-up cherry-picks that commit onto `main` so the packaged surface is the intended opam candidate:

- Name **atproto.1.0.2** as the next opam submit (supersedes ocaml/opam-repository#30703 after tag)
- README examples index
- Cleaner CHANGELOG 1.0.2 notes
- Align AGENTS.md / odoc landing / sample.env / SECURITY / install template on `ATP_PUBLIC` and hosted-only honesty

Docs-only. No lexicon pin bump. No ocaml/opam-repository edit.

## Checklist

- [x] Targets supported OCaml (`>= 4.14.1` and `< 5.4`; CI is 4.14.1 + 5.3.0)
- [x] Not an opam-repository publish
- [x] No lexicon pin bump unless `scripts/gen-official-nsids.py` was re-run and `@lexicon-coverage` (`test_lexicon_coverage`, or an explicit skip) still passes
- [x] No fake OSS chat / video transcoder / Tap host / SMS gateway / APNs-FCM push backend
- [x] No invented Jetstream archive token
- [x] New public module has a module-level `(** ... *)` odoc comment
- [x] User-facing change is noted in CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c4e75c-260c-4b34-8f8f-4da5117c9c9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c4e75c-260c-4b34-8f8f-4da5117c9c9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

